### PR TITLE
fix(ci): add security-events permission to security-scan job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -461,6 +461,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-containers
     if: github.event_name != 'pull_request'
+    permissions:
+      contents: read
+      security-events: write
 
     steps:
     - name: Checkout code


### PR DESCRIPTION
## Summary
- Fixes security-scan job failing with "Resource not accessible by integration" error
- Adds required `security-events: write` permission for SARIF upload to GitHub Code Scanning

## Root Cause
The `security-scan` job was attempting to upload Trivy vulnerability scan results using `github/codeql-action/upload-sarif@v3`, which requires explicit `security-events: write` permission. Without this permission, the action fails with an integration access error.

## Changes
Added explicit permissions block to `security-scan` job in `.github/workflows/ci.yml`:
```yaml
permissions:
  contents: read        # Required for checkout
  security-events: write  # Required for SARIF upload
```

## Test Plan
- [x] All pre-commit checks passed (format, clippy, tests, audit, deny)
- [ ] Verify security-scan job succeeds on main branch after merge
- [ ] Confirm SARIF results are uploaded to Code Scanning

## References
- Fixes: https://github.com/DominicBurkart/nanna-coder/actions/runs/18260970074/job/51989367203
- GitHub Docs: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token