### PR TITLE
fix(ci): remove invalid rust-bin reference from cache-warming workflow

### DIFF
--- a/.github/workflows/cache-warming.yml
+++ b/.github/workflows/cache-warming.yml
@@ -57,12 +57,8 @@ jobs:
         echo "🔥 Warming cache: Building Rust toolchain and dependencies..."
         START_TIME=$(date +%s)
 
-        # Build Rust toolchain
-        echo "🦀 Building Rust toolchain (1.84.0)..."
-        nix build nixpkgs#rust-bin.stable."1.84.0".default --print-build-logs --no-link
-
-        # Build cargo dependencies (the expensive part)
-        echo "📦 Building Cargo dependencies..."
+        # Build cargo dependencies (this also builds the Rust toolchain)
+        echo "📦 Building Cargo dependencies and toolchain..."
         nix develop --command cargo fetch --locked
         nix develop --command cargo build --workspace --all-features --release
 


### PR DESCRIPTION
## Summary
- Fixes CI failure in Cache Warming workflow on main branch
- Removes invalid `nixpkgs#rust-bin.stable."1.84.0".default` build step

## Problem
The Cache Warming workflow was failing with:
```
error: flake 'flake:nixpkgs' does not provide attribute 'packages.x86_64-linux.rust-bin.stable.1.84.0.default'
```

This is because `rust-bin` is provided by the rust-overlay flake, not nixpkgs directly.

## Solution
Removed the explicit Rust toolchain build step since:
1. The Rust toolchain is already included in the `nix develop` environment
2. Running `cargo build` within `nix develop` automatically builds the toolchain
3. The explicit build was unnecessary and incorrect

## Testing
- [x] Pre-commit checks pass (clippy, fmt, audit, deny, security review)
- [ ] CI will verify the fix when PR is merged

## Fixes
- https://github.com/DominicBurkart/nanna-coder/actions/runs/18272050735