### PR TITLE
docs: update test/eval documentation in ARCHITECTURE.md

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -46,3 +46,54 @@ flowchart TD
     C -- Can compile binary for --> n2(["Sandbox"])
     n2 -- Can be promoted to --> n3(["Release"])
 ```
+
+# Tests and Evals
+
+```mermaid
+---
+config:
+  theme: redux-dark
+---
+flowchart TD
+    subgraph UT["Unit Tests"]
+        u1["Data types & serialization"]
+        u2["Config parsing"]
+        u3["Entity CRUD"]
+        u4["Tool execution"]
+        u5["Prompt construction"]
+    end
+
+    subgraph IT["Integration Tests"]
+        i1["Container lifecycle"]
+        i2["Agent loop (mock model)"]
+        i3["MCP protocol"]
+        i4["Security & provenance (shell)"]
+        i5["Onboarding E2E"]
+    end
+
+    subgraph EV["Evals"]
+        e1["Happy-path task cases"]
+        e2["Decision-making quality"]
+        e3["RAG accuracy"]
+        e4["Model judge scoring"]
+    end
+
+    subgraph UT_IT["Unit ∩ Integration"]
+        ui1["Agent state transitions"]
+        ui2["Entity store operations"]
+    end
+
+    subgraph UT_EV["Unit ∩ Evals"]
+        ue1["Eval case deserialization"]
+        ue2["Eval report generation"]
+    end
+
+    subgraph IT_EV["Integration ∩ Evals"]
+        ie1["End-to-end task completion"]
+        ie2["Containerised agent runs"]
+    end
+
+    subgraph ALL["Unit ∩ Integration ∩ Evals"]
+        a1["Agent decision loop"]
+    end
+```

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,3 +1,79 @@
+# Primary Use-Case (Background Agents Delegate Tasks to Nanna)
+
+```mermaid
+---
+config:
+  theme: redux-dark
+  layout: elk
+---
+flowchart TD
+    %% Provider side
+    subgraph ProviderHosted["Provider-Hosted"]
+        subgraph ProviderAgent["Primary Agent"]
+            OrchestratorHarness["Orchestrator Harness"]
+            OrchestratorModel["Provider's Frontier Model"]
+            OrchestratorSecondaryModel["Provider's Specialized Secondary Models"]
+            OrchestratorHarness --> OrchestratorModel
+            OrchestratorHarness --> OrchestratorSecondaryModel
+            ProviderDevEnv["Agent Dev Env"]
+        end
+        OrchestratorHarness --> ProviderDevEnv
+    end
+
+    %% Nanna side (Self-hosted or in Provider)
+    subgraph Nanna["Nanna"]
+        subgraph NannaDev["Containers (Self-hosted or in Provider)"]
+            NannaHarness["Nanna Harness"]
+            NannaDevEnv["Agent Dev Container(s)"]
+            NannaHarness --> NannaDevEnv
+        end
+        subgraph GatewayHosted["Local or Secondary Provider"]
+            NannaModel["Nanna Model"]
+        end
+    end
+
+    %% Connections between orchestration layers
+    OrchestratorHarness --> NannaHarness
+
+    %% Optional external model provider for Nanna
+    NannaHarness --> NannaModel
+
+    %% Classes
+    classDef area fill:#202020,stroke:#555,stroke-width:1px,color:#DDD
+    classDef orchestrator stroke:#9D4EDD,fill:#E0AAFF,color:#5A189A
+    classDef subagent stroke:#46EDC8,fill:#DEFFF8,color:#378E7A
+    classDef nanna stroke:#FFB703,fill:#FFE8B6,color:#8B4513
+    classDef model stroke:#B5179E,fill:#FFD6F0,color:#7209B7
+
+    class ProviderHosted,NannaDev,GatewayHosted area
+    class ProviderAgent orchestrator
+    class Nanna nanna
+    class NannaModel,OrchestratorModel,OrchestratorSecondaryModel model
+```
+
+# Delegation Sequence
+
+```mermaid
+---
+config:
+  theme: redux-dark
+  layout: dagre
+---
+sequenceDiagram
+    participant O as Orchestrator
+    participant N as Nanna
+    O->>N: assign_task(description, repo_path)
+    N-->>O: task_id
+    Note over O: continues other tasks
+    Note over N: agent loop in worktree
+    O->>N: poll_task(task_id)
+    N-->>O: running
+    O->>N: poll_task(task_id)
+    N-->>O: completed
+    O->>N: get_result(task_id)
+    N-->>O: result
+```
+
 # Harness Control Flow
 
 ```mermaid
@@ -53,9 +129,10 @@ flowchart TD
 ---
 config:
   theme: redux-dark
+  layout: dagre
 ---
 flowchart TD
-    subgraph UT["Unit Tests"]
+    subgraph UT["Unit Tests (~30 inline modules)"]
         u1["Data types & serialization"]
         u2["Config parsing"]
         u3["Entity CRUD"]
@@ -67,15 +144,21 @@ flowchart TD
         i1["Container lifecycle"]
         i2["Agent loop (mock model)"]
         i3["MCP protocol"]
-        i4["Security & provenance (shell)"]
-        i5["Onboarding E2E"]
+        i4["Security (6 shell scripts in tests/security/)"]
+        i5["Provenance (test-provenance.sh in tests/integration/)"]
+        i6["Onboarding E2E"]
     end
 
-    subgraph EV["Evals"]
-        e1["Happy-path task cases"]
-        e2["Decision-making quality"]
-        e3["RAG accuracy"]
-        e4["Model judge scoring"]
+    subgraph EC["Eval Cases (evals/cases/)"]
+        ec1["happy-path-001"]
+        ec2["happy-path-002"]
+        ec3["happy-path-003"]
+    end
+
+    subgraph ED["Eval Dimensions / Scoring (harness/src/agent/eval.rs)"]
+        ed1["Decision-making quality"]
+        ed2["RAG accuracy"]
+        ed3["Model judge scoring"]
     end
 
     subgraph UT_IT["Unit ∩ Integration"]
@@ -96,4 +179,15 @@ flowchart TD
     subgraph ALL["Unit ∩ Integration ∩ Evals"]
         a1["Agent decision loop"]
     end
+
+    UT_IT --> UT
+    UT_IT --> IT
+    UT_EV --> UT
+    UT_EV --> EC
+    UT_EV --> ED
+    IT_EV --> IT
+    IT_EV --> EC
+    ALL --> UT
+    ALL --> IT
+    ALL --> EC
 ```


### PR DESCRIPTION
## Summary

- Adds a "Tests and Evals" mermaid diagram to ARCHITECTURE.md showing scope overlap between unit tests, integration tests, and evals (closes #101)
- Diagram uses subgraphs to represent each category and their intersections, matching the existing mermaid-heavy tone
- Content reflects the actual codebase: ~30 inline unit test modules, 6 integration test files + shell-based security/provenance tests, and 3 eval cases with a multi-level evaluation framework

## Test plan

- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --all-features --all-targets -- -D warnings` passes
- [x] `cargo test --all-features` passes
- [ ] Verify mermaid diagram renders correctly on GitHub

https://claude.ai/code/session_016LGnihh2HtPWjxCwUsU9Mz