### PR TITLE
feat: add OpenAI-compatible gateway provider

### DIFF
--- a/harness/Cargo.toml
+++ b/harness/Cargo.toml
@@ -29,7 +29,7 @@ eval-runner = ["tempfile"]
 
 [dependencies]
 async-trait = "0.1"
-clap = { version = "4.0", features = ["derive"] }
+clap = { version = "4.0", features = ["derive", "env"] }
 image-builder = { path = "../image-builder" }
 model = { path = "../model", features = ["openai-compat"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/harness/Cargo.toml
+++ b/harness/Cargo.toml
@@ -31,7 +31,7 @@ eval-runner = ["tempfile"]
 async-trait = "0.1"
 clap = { version = "4.0", features = ["derive"] }
 image-builder = { path = "../image-builder" }
-model = { path = "../model" }
+model = { path = "../model", features = ["openai-compat"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0"

--- a/harness/src/main.rs
+++ b/harness/src/main.rs
@@ -240,7 +240,11 @@ fn generate_swebench_report(
 fn build_provider_from_cli(
     cli: &Cli,
 ) -> Result<Arc<dyn ModelProvider>, Box<dyn std::error::Error>> {
-    build_provider_arc(cli.provider.as_str(), cli.api_base.as_deref(), cli.api_key.as_deref())
+    build_provider_arc(
+        cli.provider.as_str(),
+        cli.api_base.as_deref(),
+        cli.api_key.as_deref(),
+    )
 }
 
 fn build_provider_arc(
@@ -270,40 +274,6 @@ fn build_provider_arc(
         }
     };
     Ok(gateway.build_provider()?)
-}
-
-fn generate_swebench_report(
-    input: &std::path::Path,
-    output_dir: Option<&std::path::Path>,
-    compare: Option<&std::path::Path>,
-) -> Result<(std::path::PathBuf, Option<std::path::PathBuf>), Box<dyn std::error::Error>> {
-    use harness::eval::swebench_report::SweBenchReport;
-    use harness::eval::swebench_results::SweBenchRunResult;
-
-    let json = std::fs::read_to_string(input)?;
-    let run_result: SweBenchRunResult = serde_json::from_str(&json)?;
-
-    let owned_default;
-    let base_dir: &std::path::Path = match output_dir {
-        Some(p) => p,
-        None => {
-            owned_default = std::env::current_dir()?.join("results");
-            owned_default.as_path()
-        }
-    };
-
-    let report = SweBenchReport::new("SWE-bench Report", run_result);
-    let report_path = report.write_to_directory(base_dir)?;
-
-    let comparison_path = if let Some(compare_path) = compare {
-        let compare_json = std::fs::read_to_string(compare_path)?;
-        let compare_result: SweBenchRunResult = serde_json::from_str(&compare_json)?;
-        Some(report.write_comparison_to_directory(&compare_result, base_dir)?)
-    } else {
-        None
-    };
-
-    Ok((report_path, comparison_path))
 }
 
 fn create_tool_registry(workspace_root: &std::path::Path) -> ToolRegistry {
@@ -597,7 +567,10 @@ async fn health_check(provider: &dyn ModelProvider) -> Result<(), Box<dyn std::e
 
     match provider.health_check().await {
         Ok(()) => {
-            println!("\u{2713} Health check passed. {} is running and accessible.", name);
+            println!(
+                "\u{2713} Health check passed. {} is running and accessible.",
+                name
+            );
             info!("Health check successful");
         }
         Err(e) => {

--- a/harness/src/main.rs
+++ b/harness/src/main.rs
@@ -5,6 +5,7 @@ use harness::entities::{EntityStore, InMemoryEntityStore};
 use harness::tools::ToolRegistry;
 use model::prelude::*;
 use std::io::{self, Write};
+use std::sync::Arc;
 use tracing::{error, info};
 
 // NOTE: `main.rs` binds the workspace entity store to `InMemoryEntityStore`
@@ -16,6 +17,18 @@ use tracing::{error, info};
 #[command(name = "harness")]
 #[command(about = "A CLI tool for interacting with language models")]
 struct Cli {
+    /// Provider backend: "ollama" or "openai-compat"
+    #[arg(long, default_value = "ollama")]
+    provider: String,
+
+    /// Base URL for the API (overrides provider default)
+    #[arg(long)]
+    api_base: Option<String>,
+
+    /// API key for authentication (openai-compat only)
+    #[arg(long)]
+    api_key: Option<String>,
+
     #[command(subcommand)]
     command: Commands,
 }
@@ -94,8 +107,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let cli = Cli::parse();
 
-    let config = OllamaConfig::default();
-    let provider = OllamaProvider::new(config)?;
+    let provider = build_provider_from_cli(&cli)?;
 
     let workspace_root = std::env::current_dir()?;
     let tool_registry = create_tool_registry(&workspace_root);
@@ -111,7 +123,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
             if let Some(initial_prompt) = prompt {
                 single_chat(
-                    &provider,
+                    provider.as_ref(),
                     &tool_registry,
                     &model,
                     &initial_prompt,
@@ -121,7 +133,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .await?;
             } else {
                 interactive_chat(
-                    &provider,
+                    provider.as_ref(),
                     &tool_registry,
                     &model,
                     tools,
@@ -132,13 +144,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
         }
         Commands::Models => {
-            list_models(&provider).await?;
+            list_models(provider.as_ref()).await?;
         }
         Commands::Tools => {
             list_tools(&tool_registry);
         }
         Commands::Health => {
-            health_check(&provider).await?;
+            health_check(provider.as_ref()).await?;
         }
         Commands::Agent {
             prompt,
@@ -148,6 +160,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             tools,
         } => {
             run_agent(
+                &cli.provider,
+                cli.api_base.as_deref(),
+                cli.api_key.as_deref(),
                 &prompt,
                 &model,
                 max_iterations,
@@ -161,7 +176,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             model,
             max_iterations,
         } => {
-            run_mcp_server(&model, max_iterations).await?;
+            run_mcp_server(
+                &cli.provider,
+                cli.api_base.as_deref(),
+                cli.api_key.as_deref(),
+                &model,
+                max_iterations,
+            )
+            .await?;
         }
         Commands::SweBenchReport {
             input,
@@ -212,6 +234,69 @@ fn generate_swebench_report(
     };
 
     Ok((report_path, comparison_path))
+}
+
+fn build_provider_from_cli(
+    cli: &Cli,
+) -> Result<Arc<dyn ModelProvider>, Box<dyn std::error::Error>> {
+    let gateway = match cli.provider.as_str() {
+        "ollama" => {
+            let mut cfg = OllamaConfig::default();
+            if let Some(base) = &cli.api_base {
+                cfg = cfg.with_base_url(base);
+            }
+            GatewayConfig::Ollama(cfg)
+        }
+        "openai-compat" => {
+            let base_url = cli
+                .api_base
+                .clone()
+                .unwrap_or_else(|| "http://localhost:8080".to_string());
+            GatewayConfig::OpenaiCompat(OpenAICompatConfig {
+                base_url,
+                api_key: cli.api_key.clone(),
+                default_model: "default".to_string(),
+                timeout: std::time::Duration::from_secs(30),
+            })
+        }
+        other => {
+            return Err(format!(
+                "Unknown provider: {}. Use 'ollama' or 'openai-compat'.",
+                other
+            )
+            .into());
+        }
+    };
+    Ok(gateway.build_provider()?)
+}
+
+fn build_provider_arc(
+    provider_name: &str,
+    api_base: Option<&str>,
+    api_key: Option<&str>,
+) -> Result<Arc<dyn ModelProvider>, Box<dyn std::error::Error>> {
+    let gateway = match provider_name {
+        "ollama" => {
+            let mut cfg = OllamaConfig::default();
+            if let Some(base) = api_base {
+                cfg = cfg.with_base_url(base);
+            }
+            GatewayConfig::Ollama(cfg)
+        }
+        "openai-compat" => {
+            let base_url = api_base.unwrap_or("http://localhost:8080").to_string();
+            GatewayConfig::OpenaiCompat(OpenAICompatConfig {
+                base_url,
+                api_key: api_key.map(|s| s.to_string()),
+                default_model: "default".to_string(),
+                timeout: std::time::Duration::from_secs(30),
+            })
+        }
+        other => {
+            return Err(format!("Unknown provider: {}", other).into());
+        }
+    };
+    Ok(gateway.build_provider()?)
 }
 
 fn create_tool_registry(workspace_root: &std::path::Path) -> ToolRegistry {
@@ -294,7 +379,7 @@ async fn store_repo_guidance_entity(
 }
 
 async fn single_chat(
-    provider: &OllamaProvider,
+    provider: &dyn ModelProvider,
     tool_registry: &ToolRegistry,
     model: &str,
     prompt: &str,
@@ -362,7 +447,7 @@ async fn single_chat(
 }
 
 async fn interactive_chat<S: EntityStore + Send>(
-    provider: &OllamaProvider,
+    provider: &dyn ModelProvider,
     tool_registry: &ToolRegistry,
     model: &str,
     enable_tools: bool,
@@ -461,7 +546,7 @@ async fn interactive_chat<S: EntityStore + Send>(
     Ok(())
 }
 
-async fn list_models(provider: &OllamaProvider) -> Result<(), Box<dyn std::error::Error>> {
+async fn list_models(provider: &dyn ModelProvider) -> Result<(), Box<dyn std::error::Error>> {
     println!("Available models:");
     let models = provider.list_models().await?;
 
@@ -499,12 +584,13 @@ fn list_tools(tool_registry: &ToolRegistry) {
     }
 }
 
-async fn health_check(provider: &OllamaProvider) -> Result<(), Box<dyn std::error::Error>> {
-    println!("Performing health check...");
+async fn health_check(provider: &dyn ModelProvider) -> Result<(), Box<dyn std::error::Error>> {
+    let name = provider.provider_name();
+    println!("Performing health check ({})...", name);
 
     match provider.health_check().await {
         Ok(()) => {
-            println!("✓ Health check passed. Ollama is running and accessible.");
+            println!("✓ Health check passed. {} is running and accessible.", name);
             info!("Health check successful");
         }
         Err(e) => {
@@ -555,7 +641,11 @@ fn build_session_system_prompt(workspace_root: &std::path::Path) -> String {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn run_agent(
+    provider_name: &str,
+    api_base: Option<&str>,
+    api_key: Option<&str>,
     prompt: &str,
     model: &str,
     max_iterations: usize,
@@ -564,10 +654,8 @@ async fn run_agent(
     workspace_root: &std::path::Path,
 ) -> Result<(), Box<dyn std::error::Error>> {
     use harness::agent::{AgentConfig, AgentContext, AgentLoop};
-    use std::sync::Arc;
 
-    let config = OllamaConfig::default();
-    let provider = Arc::new(OllamaProvider::new(config)?);
+    let provider = build_provider_arc(provider_name, api_base, api_key)?;
     let entity_store = initialize_workspace(workspace_root).await;
 
     let agent_config = AgentConfig {
@@ -627,15 +715,16 @@ async fn run_agent(
 }
 
 async fn run_mcp_server(
+    provider_name: &str,
+    api_base: Option<&str>,
+    api_key: Option<&str>,
     model: &str,
     max_iterations: usize,
 ) -> Result<(), Box<dyn std::error::Error>> {
     use harness::mcp::NannaMcpServer;
     use harness::task::TaskManager;
-    use std::sync::Arc;
 
-    let config = OllamaConfig::default();
-    let provider = Arc::new(OllamaProvider::new(config)?);
+    let provider = build_provider_arc(provider_name, api_base, api_key)?;
     let task_manager = Arc::new(TaskManager::default());
 
     info!(

--- a/harness/src/main.rs
+++ b/harness/src/main.rs
@@ -25,8 +25,9 @@ struct Cli {
     #[arg(long)]
     api_base: Option<String>,
 
-    /// API key for authentication (openai-compat only)
-    #[arg(long)]
+    /// API key for authentication (openai-compat only).
+    /// Prefer setting NANNA_API_KEY in the environment to avoid shell history exposure.
+    #[arg(long, env = "NANNA_API_KEY")]
     api_key: Option<String>,
 
     #[command(subcommand)]
@@ -239,35 +240,7 @@ fn generate_swebench_report(
 fn build_provider_from_cli(
     cli: &Cli,
 ) -> Result<Arc<dyn ModelProvider>, Box<dyn std::error::Error>> {
-    let gateway = match cli.provider.as_str() {
-        "ollama" => {
-            let mut cfg = OllamaConfig::default();
-            if let Some(base) = &cli.api_base {
-                cfg = cfg.with_base_url(base);
-            }
-            GatewayConfig::Ollama(cfg)
-        }
-        "openai-compat" => {
-            let base_url = cli
-                .api_base
-                .clone()
-                .unwrap_or_else(|| "http://localhost:8080".to_string());
-            GatewayConfig::OpenaiCompat(OpenAICompatConfig {
-                base_url,
-                api_key: cli.api_key.clone(),
-                default_model: "default".to_string(),
-                timeout: std::time::Duration::from_secs(30),
-            })
-        }
-        other => {
-            return Err(format!(
-                "Unknown provider: {}. Use 'ollama' or 'openai-compat'.",
-                other
-            )
-            .into());
-        }
-    };
-    Ok(gateway.build_provider()?)
+    build_provider_arc(cli.provider.as_str(), cli.api_base.as_deref(), cli.api_key.as_deref())
 }
 
 fn build_provider_arc(

--- a/harness/src/main.rs
+++ b/harness/src/main.rs
@@ -299,6 +299,40 @@ fn build_provider_arc(
     Ok(gateway.build_provider()?)
 }
 
+fn generate_swebench_report(
+    input: &std::path::Path,
+    output_dir: Option<&std::path::Path>,
+    compare: Option<&std::path::Path>,
+) -> Result<(std::path::PathBuf, Option<std::path::PathBuf>), Box<dyn std::error::Error>> {
+    use harness::eval::swebench_report::SweBenchReport;
+    use harness::eval::swebench_results::SweBenchRunResult;
+
+    let json = std::fs::read_to_string(input)?;
+    let run_result: SweBenchRunResult = serde_json::from_str(&json)?;
+
+    let owned_default;
+    let base_dir: &std::path::Path = match output_dir {
+        Some(p) => p,
+        None => {
+            owned_default = std::env::current_dir()?.join("results");
+            owned_default.as_path()
+        }
+    };
+
+    let report = SweBenchReport::new("SWE-bench Report", run_result);
+    let report_path = report.write_to_directory(base_dir)?;
+
+    let comparison_path = if let Some(compare_path) = compare {
+        let compare_json = std::fs::read_to_string(compare_path)?;
+        let compare_result: SweBenchRunResult = serde_json::from_str(&compare_json)?;
+        Some(report.write_comparison_to_directory(&compare_result, base_dir)?)
+    } else {
+        None
+    };
+
+    Ok((report_path, comparison_path))
+}
+
 fn create_tool_registry(workspace_root: &std::path::Path) -> ToolRegistry {
     harness::tools::create_tool_registry(workspace_root)
 }
@@ -590,11 +624,11 @@ async fn health_check(provider: &dyn ModelProvider) -> Result<(), Box<dyn std::e
 
     match provider.health_check().await {
         Ok(()) => {
-            println!("✓ Health check passed. {} is running and accessible.", name);
+            println!("\u{2713} Health check passed. {} is running and accessible.", name);
             info!("Health check successful");
         }
         Err(e) => {
-            println!("✗ Health check failed: {}", e);
+            println!("\u{2717} Health check failed: {}", e);
             error!("Health check failed: {}", e);
             return Err(e.into());
         }

--- a/model/Cargo.toml
+++ b/model/Cargo.toml
@@ -12,6 +12,7 @@ repository.workspace = true
 [features]
 default = ["ollama"]
 ollama = ["dep:ollama-rs"]
+openai-compat = []
 
 [dependencies]
 async-trait = "0.1"

--- a/model/src/config.rs
+++ b/model/src/config.rs
@@ -169,12 +169,31 @@ mod kani_proofs {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+/// Configuration for an OpenAI-compatible provider endpoint.
+///
+/// **Security note:** `api_key` is intentionally excluded from `Serialize` so
+/// it is never written to config files, audit logs, or other serialised
+/// representations. Supply the key at runtime via the `NANNA_API_KEY`
+/// environment variable.
+#[derive(Clone, Serialize, Deserialize)]
 pub struct OpenAICompatConfig {
     pub base_url: String,
+    /// API key for bearer-auth. Not serialised; supply at runtime.
+    #[serde(skip_serializing, default)]
     pub api_key: Option<String>,
     pub default_model: String,
     pub timeout: Duration,
+}
+
+impl std::fmt::Debug for OpenAICompatConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OpenAICompatConfig")
+            .field("base_url", &self.base_url)
+            .field("api_key", &self.api_key.as_ref().map(|_| "[REDACTED]"))
+            .field("default_model", &self.default_model)
+            .field("timeout", &self.timeout)
+            .finish()
+    }
 }
 
 impl Default for OpenAICompatConfig {
@@ -211,6 +230,7 @@ impl OpenAICompatConfig {
 #[serde(tag = "provider", rename_all = "kebab-case")]
 pub enum GatewayConfig {
     Ollama(OllamaConfig),
+    #[serde(rename = "openai-compat", alias = "openai_compat")]
     OpenaiCompat(OpenAICompatConfig),
 }
 
@@ -350,11 +370,21 @@ mod tests {
         match deserialized {
             GatewayConfig::OpenaiCompat(c) => {
                 assert_eq!(c.base_url, "https://api.example.com");
-                assert_eq!(c.api_key, Some("sk-test".to_string()));
+                // api_key is not serialised; it must be supplied at runtime
+                assert_eq!(c.api_key, None);
                 assert_eq!(c.default_model, "gpt-4");
             }
             _ => panic!("Expected OpenaiCompat variant"),
         }
+    }
+
+    #[test]
+    fn test_gateway_config_serde_accepts_underscore_alias() {
+        // Ensure config files using "openai_compat" (underscore) are accepted
+        let json = r#"{"provider":"openai_compat","base_url":"http://localhost:8080","default_model":"default","timeout":{"secs":30,"nanos":0}}"#;
+        let result: Result<GatewayConfig, _> = serde_json::from_str(json);
+        assert!(result.is_ok(), "openai_compat underscore alias should be accepted");
+        assert!(matches!(result.unwrap(), GatewayConfig::OpenaiCompat(_)));
     }
 
     #[test]
@@ -371,5 +401,31 @@ mod tests {
         cfg.base_url = "http://localhost:8080".to_string();
         cfg.default_model = "".to_string();
         assert!(cfg.validate().is_err());
+    }
+
+    #[test]
+    fn test_openai_compat_config_debug_redacts_key() {
+        let cfg = OpenAICompatConfig {
+            base_url: "http://localhost:8080".to_string(),
+            api_key: Some("sk-super-secret".to_string()),
+            default_model: "gpt-4".to_string(),
+            timeout: Duration::from_secs(30),
+        };
+        let debug_str = format!("{:?}", cfg);
+        assert!(!debug_str.contains("sk-super-secret"), "api_key must be redacted in Debug output");
+        assert!(debug_str.contains("REDACTED"), "Debug output should contain [REDACTED]");
+    }
+
+    #[test]
+    fn test_openai_compat_config_serialize_omits_key() {
+        let cfg = OpenAICompatConfig {
+            base_url: "http://localhost:8080".to_string(),
+            api_key: Some("sk-super-secret".to_string()),
+            default_model: "default".to_string(),
+            timeout: Duration::from_secs(30),
+        };
+        let json = serde_json::to_string(&cfg).unwrap();
+        assert!(!json.contains("sk-super-secret"), "api_key must not appear in serialized output");
+        assert!(!json.contains("api_key"), "api_key field must be omitted from serialized output");
     }
 }

--- a/model/src/config.rs
+++ b/model/src/config.rs
@@ -1,4 +1,6 @@
+use crate::provider::{ModelProvider, ModelResult};
 use serde::{Deserialize, Serialize};
+use std::sync::Arc;
 use std::time::Duration;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -167,6 +169,90 @@ mod kani_proofs {
     }
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OpenAICompatConfig {
+    pub base_url: String,
+    pub api_key: Option<String>,
+    pub default_model: String,
+    pub timeout: Duration,
+}
+
+impl Default for OpenAICompatConfig {
+    fn default() -> Self {
+        Self {
+            base_url: "http://localhost:8080".to_string(),
+            api_key: None,
+            default_model: "default".to_string(),
+            timeout: Duration::from_secs(30),
+        }
+    }
+}
+
+impl OpenAICompatConfig {
+    pub fn validate(&self) -> Result<(), String> {
+        if self.base_url.is_empty() {
+            return Err("Base URL cannot be empty".to_string());
+        }
+        if !self.base_url.starts_with("http://") && !self.base_url.starts_with("https://") {
+            return Err("Base URL must start with http:// or https://".to_string());
+        }
+        if self.default_model.is_empty() {
+            return Err("Default model cannot be empty".to_string());
+        }
+        if self.timeout.is_zero() {
+            return Err("Timeout must be greater than 0".to_string());
+        }
+        Ok(())
+    }
+}
+
+/// Unified gateway configuration for provider selection.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "provider", rename_all = "kebab-case")]
+pub enum GatewayConfig {
+    Ollama(OllamaConfig),
+    OpenaiCompat(OpenAICompatConfig),
+}
+
+impl Default for GatewayConfig {
+    fn default() -> Self {
+        GatewayConfig::Ollama(OllamaConfig::default())
+    }
+}
+
+impl GatewayConfig {
+    /// Build the appropriate `ModelProvider` from this configuration.
+    pub fn build_provider(&self) -> ModelResult<Arc<dyn ModelProvider>> {
+        match self {
+            #[cfg(feature = "ollama")]
+            GatewayConfig::Ollama(cfg) => {
+                let provider = crate::ollama::OllamaProvider::new(cfg.clone())?;
+                Ok(Arc::new(provider))
+            }
+            #[cfg(not(feature = "ollama"))]
+            GatewayConfig::Ollama(_) => Err(crate::provider::ModelError::InvalidConfig {
+                message: "Ollama feature is not enabled".to_string(),
+            }),
+            #[cfg(feature = "openai-compat")]
+            GatewayConfig::OpenaiCompat(cfg) => {
+                cfg.validate()
+                    .map_err(|msg| crate::provider::ModelError::InvalidConfig { message: msg })?;
+                let provider = crate::openai_compat::OpenAICompatProvider::new(
+                    &cfg.base_url,
+                    cfg.api_key.clone(),
+                    &cfg.default_model,
+                    cfg.timeout,
+                )?;
+                Ok(Arc::new(provider))
+            }
+            #[cfg(not(feature = "openai-compat"))]
+            GatewayConfig::OpenaiCompat(_) => Err(crate::provider::ModelError::InvalidConfig {
+                message: "openai-compat feature is not enabled".to_string(),
+            }),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -232,5 +318,58 @@ mod tests {
             config.default_context_length,
             deserialized.default_context_length
         );
+    }
+
+    #[test]
+    fn test_default_gateway_config_is_ollama() {
+        let gw = GatewayConfig::default();
+        assert!(matches!(gw, GatewayConfig::Ollama(_)));
+    }
+
+    #[test]
+    fn test_gateway_config_serde_roundtrip_ollama() {
+        let gw = GatewayConfig::Ollama(OllamaConfig::default());
+        let json = serde_json::to_string(&gw).unwrap();
+        assert!(json.contains("\"provider\":\"ollama\""));
+        let deserialized: GatewayConfig = serde_json::from_str(&json).unwrap();
+        assert!(matches!(deserialized, GatewayConfig::Ollama(_)));
+    }
+
+    #[test]
+    fn test_gateway_config_serde_roundtrip_openai_compat() {
+        let cfg = OpenAICompatConfig {
+            base_url: "https://api.example.com".to_string(),
+            api_key: Some("sk-test".to_string()),
+            default_model: "gpt-4".to_string(),
+            timeout: Duration::from_secs(60),
+        };
+        let gw = GatewayConfig::OpenaiCompat(cfg);
+        let json = serde_json::to_string(&gw).unwrap();
+        assert!(json.contains("\"provider\":\"openai-compat\""));
+        let deserialized: GatewayConfig = serde_json::from_str(&json).unwrap();
+        match deserialized {
+            GatewayConfig::OpenaiCompat(c) => {
+                assert_eq!(c.base_url, "https://api.example.com");
+                assert_eq!(c.api_key, Some("sk-test".to_string()));
+                assert_eq!(c.default_model, "gpt-4");
+            }
+            _ => panic!("Expected OpenaiCompat variant"),
+        }
+    }
+
+    #[test]
+    fn test_openai_compat_config_validation() {
+        let mut cfg = OpenAICompatConfig::default();
+        assert!(cfg.validate().is_ok());
+
+        cfg.base_url = "".to_string();
+        assert!(cfg.validate().is_err());
+
+        cfg.base_url = "ftp://bad".to_string();
+        assert!(cfg.validate().is_err());
+
+        cfg.base_url = "http://localhost:8080".to_string();
+        cfg.default_model = "".to_string();
+        assert!(cfg.validate().is_err());
     }
 }

--- a/model/src/config.rs
+++ b/model/src/config.rs
@@ -383,7 +383,10 @@ mod tests {
         // Ensure config files using "openai_compat" (underscore) are accepted
         let json = r#"{"provider":"openai_compat","base_url":"http://localhost:8080","default_model":"default","timeout":{"secs":30,"nanos":0}}"#;
         let result: Result<GatewayConfig, _> = serde_json::from_str(json);
-        assert!(result.is_ok(), "openai_compat underscore alias should be accepted");
+        assert!(
+            result.is_ok(),
+            "openai_compat underscore alias should be accepted"
+        );
         assert!(matches!(result.unwrap(), GatewayConfig::OpenaiCompat(_)));
     }
 
@@ -412,8 +415,14 @@ mod tests {
             timeout: Duration::from_secs(30),
         };
         let debug_str = format!("{:?}", cfg);
-        assert!(!debug_str.contains("sk-super-secret"), "api_key must be redacted in Debug output");
-        assert!(debug_str.contains("REDACTED"), "Debug output should contain [REDACTED]");
+        assert!(
+            !debug_str.contains("sk-super-secret"),
+            "api_key must be redacted in Debug output"
+        );
+        assert!(
+            debug_str.contains("REDACTED"),
+            "Debug output should contain [REDACTED]"
+        );
     }
 
     #[test]
@@ -425,7 +434,13 @@ mod tests {
             timeout: Duration::from_secs(30),
         };
         let json = serde_json::to_string(&cfg).unwrap();
-        assert!(!json.contains("sk-super-secret"), "api_key must not appear in serialized output");
-        assert!(!json.contains("api_key"), "api_key field must be omitted from serialized output");
+        assert!(
+            !json.contains("sk-super-secret"),
+            "api_key must not appear in serialized output"
+        );
+        assert!(
+            !json.contains("api_key"),
+            "api_key field must be omitted from serialized output"
+        );
     }
 }

--- a/model/src/lib.rs
+++ b/model/src/lib.rs
@@ -1,10 +1,12 @@
 pub mod config;
 pub mod judge;
 pub mod ollama;
+#[cfg(feature = "openai-compat")]
+pub mod openai_compat;
 pub mod provider;
 pub mod types;
 
-pub use config::{ModelDefaults, OllamaConfig};
+pub use config::{GatewayConfig, ModelDefaults, OllamaConfig, OpenAICompatConfig};
 pub use judge::{JudgeConfig, ModelJudge, ValidationCriteria, ValidationMetrics, ValidationResult};
 pub use provider::{ModelError, ModelProvider, ModelResult, StreamingModelProvider};
 pub use types::{
@@ -16,6 +18,9 @@ pub use types::{
 #[cfg(feature = "ollama")]
 pub use ollama::OllamaProvider;
 
+#[cfg(feature = "openai-compat")]
+pub use openai_compat::OpenAICompatProvider;
+
 pub mod prelude {
     pub use crate::config::*;
     pub use crate::judge::*;
@@ -24,4 +29,7 @@ pub mod prelude {
 
     #[cfg(feature = "ollama")]
     pub use crate::ollama::*;
+
+    #[cfg(feature = "openai-compat")]
+    pub use crate::openai_compat::*;
 }

--- a/model/src/openai_compat.rs
+++ b/model/src/openai_compat.rs
@@ -1,0 +1,529 @@
+use crate::provider::{ModelError, ModelProvider, ModelResult};
+use crate::types::{
+    ChatMessage, ChatRequest, ChatResponse, Choice, FinishReason, FunctionCall, MessageRole,
+    ModelInfo, ToolCall, ToolDefinition, Usage,
+};
+use async_trait::async_trait;
+use serde::Deserialize;
+use serde_json::Value;
+use std::time::Duration;
+use tracing::{debug, info};
+
+/// A provider that speaks the OpenAI-compatible `/v1/chat/completions` API.
+///
+/// Works with vLLM, LiteLLM, OpenRouter, llama.cpp server, and any endpoint
+/// that implements the OpenAI chat completion spec.
+pub struct OpenAICompatProvider {
+    base_url: String,
+    api_key: Option<String>,
+    http_client: reqwest::Client,
+    default_model: String,
+}
+
+impl OpenAICompatProvider {
+    pub fn new(
+        base_url: impl Into<String>,
+        api_key: Option<String>,
+        default_model: impl Into<String>,
+        timeout: Duration,
+    ) -> ModelResult<Self> {
+        let base_url = base_url.into();
+        if base_url.is_empty() {
+            return Err(ModelError::InvalidConfig {
+                message: "Base URL cannot be empty".to_string(),
+            });
+        }
+        if !base_url.starts_with("http://") && !base_url.starts_with("https://") {
+            return Err(ModelError::InvalidConfig {
+                message: "Base URL must start with http:// or https://".to_string(),
+            });
+        }
+
+        let base_url = base_url.trim_end_matches('/').to_string();
+
+        let http_client = reqwest::Client::builder()
+            .timeout(timeout)
+            .build()
+            .map_err(|e| ModelError::Unknown {
+                message: format!("Failed to build HTTP client: {}", e),
+            })?;
+
+        Ok(Self {
+            base_url,
+            api_key,
+            http_client,
+            default_model: default_model.into(),
+        })
+    }
+
+    fn messages_to_json(messages: &[ChatMessage]) -> Vec<Value> {
+        messages
+            .iter()
+            .map(|msg| {
+                let role = match &msg.role {
+                    MessageRole::System => "system",
+                    MessageRole::User => "user",
+                    MessageRole::Assistant => "assistant",
+                    MessageRole::Tool => "tool",
+                };
+
+                let mut obj = serde_json::json!({
+                    "role": role,
+                });
+
+                // OpenAI spec: content can be null for assistant messages with tool_calls
+                match &msg.content {
+                    Some(c) => obj["content"] = Value::String(c.clone()),
+                    None => obj["content"] = Value::Null,
+                }
+
+                if let Some(tool_calls) = &msg.tool_calls {
+                    if !tool_calls.is_empty() {
+                        let tc_json: Vec<Value> = tool_calls
+                            .iter()
+                            .map(|tc| {
+                                serde_json::json!({
+                                    "id": tc.id,
+                                    "type": "function",
+                                    "function": {
+                                        "name": tc.function.name,
+                                        "arguments": tc.function.arguments.to_string()
+                                    }
+                                })
+                            })
+                            .collect();
+                        obj["tool_calls"] = Value::Array(tc_json);
+                    }
+                }
+
+                if let Some(tool_call_id) = &msg.tool_call_id {
+                    obj["tool_call_id"] = Value::String(tool_call_id.clone());
+                }
+
+                obj
+            })
+            .collect()
+    }
+
+    fn tools_to_json(tools: &[ToolDefinition]) -> Vec<Value> {
+        tools
+            .iter()
+            .map(|tool| {
+                serde_json::json!({
+                    "type": "function",
+                    "function": tool.function
+                })
+            })
+            .collect()
+    }
+
+    fn parse_response(raw: OpenAIRawResponse) -> ModelResult<ChatResponse> {
+        let choices = raw
+            .choices
+            .into_iter()
+            .map(|c| {
+                let tool_calls = c.message.tool_calls.map(|tcs| {
+                    tcs.into_iter()
+                        .map(|tc| ToolCall {
+                            id: tc.id,
+                            function: FunctionCall {
+                                name: tc.function.name,
+                                arguments: serde_json::from_str(&tc.function.arguments)
+                                    .unwrap_or(Value::String(tc.function.arguments)),
+                            },
+                        })
+                        .collect()
+                });
+
+                let finish_reason = match c.finish_reason.as_deref() {
+                    Some("tool_calls") => Some(FinishReason::ToolCalls),
+                    Some("length") => Some(FinishReason::Length),
+                    Some("content_filter") => Some(FinishReason::ContentFilter),
+                    _ => Some(FinishReason::Stop),
+                };
+
+                Choice {
+                    message: ChatMessage {
+                        role: MessageRole::Assistant,
+                        content: c.message.content,
+                        tool_calls,
+                        tool_call_id: None,
+                    },
+                    finish_reason,
+                }
+            })
+            .collect();
+
+        let usage = raw.usage.map(|u| Usage {
+            prompt_tokens: u.prompt_tokens,
+            completion_tokens: u.completion_tokens,
+            total_tokens: u.total_tokens,
+        });
+
+        Ok(ChatResponse { choices, usage })
+    }
+
+    fn apply_auth(&self, req: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
+        if let Some(key) = &self.api_key {
+            req.bearer_auth(key)
+        } else {
+            req
+        }
+    }
+}
+
+// ---------- OpenAI wire types (private) ----------
+
+#[derive(Deserialize)]
+struct OpenAIRawResponse {
+    choices: Vec<OpenAIRawChoice>,
+    usage: Option<OpenAIRawUsage>,
+}
+
+#[derive(Deserialize)]
+struct OpenAIRawChoice {
+    message: OpenAIRawMessage,
+    finish_reason: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct OpenAIRawMessage {
+    content: Option<String>,
+    tool_calls: Option<Vec<OpenAIRawToolCall>>,
+}
+
+#[derive(Deserialize)]
+struct OpenAIRawToolCall {
+    id: String,
+    function: OpenAIRawFunction,
+}
+
+#[derive(Deserialize)]
+struct OpenAIRawFunction {
+    name: String,
+    arguments: String,
+}
+
+#[derive(Deserialize)]
+struct OpenAIRawUsage {
+    prompt_tokens: u32,
+    completion_tokens: u32,
+    total_tokens: u32,
+}
+
+#[derive(Deserialize)]
+struct OpenAIModelsResponse {
+    data: Vec<OpenAIModelEntry>,
+}
+
+#[derive(Deserialize)]
+struct OpenAIModelEntry {
+    id: String,
+}
+
+// ---------- ModelProvider impl ----------
+
+#[async_trait]
+impl ModelProvider for OpenAICompatProvider {
+    async fn chat(&self, request: ChatRequest) -> ModelResult<ChatResponse> {
+        let model = if request.model.is_empty() {
+            &self.default_model
+        } else {
+            &request.model
+        };
+        debug!("OpenAI-compat chat request with model: {}", model);
+
+        let messages = Self::messages_to_json(&request.messages);
+
+        let mut payload = serde_json::json!({
+            "model": model,
+            "messages": messages,
+        });
+
+        if let Some(temp) = request.temperature {
+            payload["temperature"] = serde_json::json!(temp);
+        }
+        if let Some(max) = request.max_tokens {
+            payload["max_tokens"] = serde_json::json!(max);
+        }
+
+        if let Some(tools) = &request.tools {
+            if !tools.is_empty() {
+                payload["tools"] = Value::Array(Self::tools_to_json(tools));
+            }
+        }
+
+        let url = format!("{}/v1/chat/completions", self.base_url);
+
+        let req = self.http_client.post(&url).json(&payload);
+        let req = self.apply_auth(req);
+
+        let response = req.send().await.map_err(|e| {
+            if e.is_timeout() {
+                ModelError::ServiceUnavailable {
+                    message: "Request timeout".to_string(),
+                }
+            } else if e.is_connect() {
+                ModelError::ServiceUnavailable {
+                    message: "Cannot connect to OpenAI-compatible service".to_string(),
+                }
+            } else {
+                ModelError::Network(e)
+            }
+        })?;
+
+        let status = response.status();
+        if status == reqwest::StatusCode::UNAUTHORIZED || status == reqwest::StatusCode::FORBIDDEN {
+            return Err(ModelError::Authentication);
+        }
+        if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+            return Err(ModelError::RateLimit);
+        }
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            return Err(ModelError::Unknown {
+                message: format!("OpenAI-compat API error {}: {}", status, body),
+            });
+        }
+
+        let raw: OpenAIRawResponse = response.json().await.map_err(|e| ModelError::Unknown {
+            message: format!("Failed to parse response: {}", e),
+        })?;
+
+        info!("OpenAI-compat chat request completed");
+
+        Self::parse_response(raw)
+    }
+
+    async fn list_models(&self) -> ModelResult<Vec<ModelInfo>> {
+        debug!("Listing models from OpenAI-compat endpoint");
+
+        let url = format!("{}/v1/models", self.base_url);
+        let req = self.http_client.get(&url);
+        let req = self.apply_auth(req);
+
+        let response = req.send().await.map_err(|e| {
+            if e.is_connect() {
+                ModelError::ServiceUnavailable {
+                    message: "Cannot connect to OpenAI-compatible service".to_string(),
+                }
+            } else {
+                ModelError::Network(e)
+            }
+        })?;
+
+        if !response.status().is_success() {
+            let body = response.text().await.unwrap_or_default();
+            return Err(ModelError::Unknown {
+                message: format!("Failed to list models: {}", body),
+            });
+        }
+
+        let raw: OpenAIModelsResponse = response.json().await.map_err(|e| ModelError::Unknown {
+            message: format!("Failed to parse models response: {}", e),
+        })?;
+
+        Ok(raw
+            .data
+            .into_iter()
+            .map(|m| ModelInfo {
+                name: m.id,
+                size: None,
+                digest: None,
+                modified_at: None,
+            })
+            .collect())
+    }
+
+    async fn health_check(&self) -> ModelResult<()> {
+        debug!("Health check against OpenAI-compat endpoint");
+
+        let url = format!("{}/v1/models", self.base_url);
+        let req = self.http_client.get(&url);
+        let req = self.apply_auth(req);
+
+        let response = req.send().await.map_err(|e| {
+            if e.is_connect() {
+                ModelError::ServiceUnavailable {
+                    message: "Cannot connect to OpenAI-compatible service".to_string(),
+                }
+            } else {
+                ModelError::Network(e)
+            }
+        })?;
+
+        if response.status().is_success() {
+            Ok(())
+        } else {
+            Err(ModelError::ServiceUnavailable {
+                message: format!("Health check returned status {}", response.status()),
+            })
+        }
+    }
+
+    fn provider_name(&self) -> &'static str {
+        "openai-compat"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::ChatMessage;
+
+    #[test]
+    fn test_request_body_serialization() {
+        let messages = vec![
+            ChatMessage::system("You are helpful"),
+            ChatMessage::user("Hello"),
+        ];
+        let json_msgs = OpenAICompatProvider::messages_to_json(&messages);
+
+        assert_eq!(json_msgs.len(), 2);
+        assert_eq!(json_msgs[0]["role"], "system");
+        assert_eq!(json_msgs[0]["content"], "You are helpful");
+        assert_eq!(json_msgs[1]["role"], "user");
+        assert_eq!(json_msgs[1]["content"], "Hello");
+    }
+
+    #[test]
+    fn test_request_body_with_tool_calls() {
+        let msg = ChatMessage::assistant_with_tools(
+            None,
+            vec![ToolCall {
+                id: "call_1".to_string(),
+                function: FunctionCall {
+                    name: "read_file".to_string(),
+                    arguments: serde_json::json!({"path": "/tmp/foo"}),
+                },
+            }],
+        );
+        let json_msgs = OpenAICompatProvider::messages_to_json(&[msg]);
+
+        assert_eq!(json_msgs[0]["role"], "assistant");
+        assert!(json_msgs[0]["content"].is_null());
+        let tc = &json_msgs[0]["tool_calls"][0];
+        assert_eq!(tc["id"], "call_1");
+        assert_eq!(tc["type"], "function");
+        assert_eq!(tc["function"]["name"], "read_file");
+        // OpenAI spec: arguments is a string
+        assert!(tc["function"]["arguments"].is_string());
+    }
+
+    #[test]
+    fn test_response_deserialization() {
+        let raw_json = r#"{
+            "id": "chatcmpl-123",
+            "object": "chat.completion",
+            "choices": [{
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": "Hello! How can I help you?"
+                },
+                "finish_reason": "stop"
+            }],
+            "usage": {
+                "prompt_tokens": 10,
+                "completion_tokens": 8,
+                "total_tokens": 18
+            }
+        }"#;
+
+        let raw: OpenAIRawResponse = serde_json::from_str(raw_json).unwrap();
+        let response = OpenAICompatProvider::parse_response(raw).unwrap();
+
+        assert_eq!(response.choices.len(), 1);
+        assert_eq!(response.choices[0].message.role, MessageRole::Assistant);
+        assert_eq!(
+            response.choices[0].message.content.as_deref(),
+            Some("Hello! How can I help you?")
+        );
+        assert_eq!(response.choices[0].finish_reason, Some(FinishReason::Stop));
+
+        let usage = response.usage.unwrap();
+        assert_eq!(usage.prompt_tokens, 10);
+        assert_eq!(usage.completion_tokens, 8);
+        assert_eq!(usage.total_tokens, 18);
+    }
+
+    #[test]
+    fn test_response_with_tool_calls() {
+        let raw_json = r#"{
+            "choices": [{
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": null,
+                    "tool_calls": [{
+                        "id": "call_abc",
+                        "type": "function",
+                        "function": {
+                            "name": "read_file",
+                            "arguments": "{\"path\":\"/tmp/test\"}"
+                        }
+                    }]
+                },
+                "finish_reason": "tool_calls"
+            }],
+            "usage": null
+        }"#;
+
+        let raw: OpenAIRawResponse = serde_json::from_str(raw_json).unwrap();
+        let response = OpenAICompatProvider::parse_response(raw).unwrap();
+
+        assert_eq!(
+            response.choices[0].finish_reason,
+            Some(FinishReason::ToolCalls)
+        );
+        let tool_calls = response.choices[0].message.tool_calls.as_ref().unwrap();
+        assert_eq!(tool_calls.len(), 1);
+        assert_eq!(tool_calls[0].id, "call_abc");
+        assert_eq!(tool_calls[0].function.name, "read_file");
+        assert_eq!(
+            tool_calls[0].function.arguments,
+            serde_json::json!({"path": "/tmp/test"})
+        );
+    }
+
+    #[test]
+    fn test_provider_constructor_validation() {
+        let result = OpenAICompatProvider::new("", None, "gpt-4", Duration::from_secs(30));
+        assert!(result.is_err());
+
+        let result = OpenAICompatProvider::new("not-a-url", None, "gpt-4", Duration::from_secs(30));
+        assert!(result.is_err());
+
+        let result = OpenAICompatProvider::new(
+            "http://localhost:8080",
+            None,
+            "gpt-4",
+            Duration::from_secs(30),
+        );
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_provider_name() {
+        let provider = OpenAICompatProvider::new(
+            "http://localhost:8080",
+            None,
+            "gpt-4",
+            Duration::from_secs(30),
+        )
+        .unwrap();
+        assert_eq!(provider.provider_name(), "openai-compat");
+    }
+
+    #[test]
+    fn test_trailing_slash_stripped() {
+        let provider = OpenAICompatProvider::new(
+            "http://localhost:8080/",
+            None,
+            "gpt-4",
+            Duration::from_secs(30),
+        )
+        .unwrap();
+        assert_eq!(provider.base_url, "http://localhost:8080");
+    }
+}

--- a/model/src/openai_compat.rs
+++ b/model/src/openai_compat.rs
@@ -286,7 +286,11 @@ impl ModelProvider for OpenAICompatProvider {
             let body = response.text().await.unwrap_or_default();
             // Truncate to avoid leaking large or sensitive response bodies
             // (some gateways reflect authentication context in error payloads).
-            let body = if body.len() > 512 { &body[..512] } else { &body };
+            let body = if body.len() > 512 {
+                &body[..512]
+            } else {
+                &body
+            };
             return Err(ModelError::Unknown {
                 message: format!("OpenAI-compat API error {}: {}", status, body),
             });

--- a/model/src/openai_compat.rs
+++ b/model/src/openai_compat.rs
@@ -135,6 +135,9 @@ impl OpenAICompatProvider {
                         .collect()
                 });
 
+                // `finish_reason` may be absent (null) or carry an unrecognised value from a
+                // non-standard endpoint. Both map to `Stop` as a safe default. This behaviour
+                // is explicitly tested by `test_response_finish_reason_null_becomes_stop`.
                 let finish_reason = match c.finish_reason.as_deref() {
                     Some("tool_calls") => Some(FinishReason::ToolCalls),
                     Some("length") => Some(FinishReason::Length),
@@ -281,6 +284,9 @@ impl ModelProvider for OpenAICompatProvider {
         }
         if !status.is_success() {
             let body = response.text().await.unwrap_or_default();
+            // Truncate to avoid leaking large or sensitive response bodies
+            // (some gateways reflect authentication context in error payloads).
+            let body = if body.len() > 512 { &body[..512] } else { &body };
             return Err(ModelError::Unknown {
                 message: format!("OpenAI-compat API error {}: {}", status, body),
             });
@@ -525,5 +531,24 @@ mod tests {
         )
         .unwrap();
         assert_eq!(provider.base_url, "http://localhost:8080");
+    }
+
+    #[test]
+    fn test_response_finish_reason_null_becomes_stop() {
+        // Documents intentional behaviour: absent/null finish_reason maps to Stop.
+        // Update this assertion if the mapping changes in future.
+        let raw_json = r#"{"choices":[{"index":0,"message":{"role":"assistant","content":"hi"},"finish_reason":null}],"usage":null}"#;
+        let raw: OpenAIRawResponse = serde_json::from_str(raw_json).unwrap();
+        let resp = OpenAICompatProvider::parse_response(raw).unwrap();
+        assert_eq!(resp.choices[0].finish_reason, Some(FinishReason::Stop));
+    }
+
+    #[test]
+    fn test_response_finish_reason_unknown_string_becomes_stop() {
+        // An unrecognised finish_reason from a non-standard endpoint also maps to Stop.
+        let raw_json = r#"{"choices":[{"index":0,"message":{"role":"assistant","content":"hi"},"finish_reason":"unknown_future_value"}],"usage":null}"#;
+        let raw: OpenAIRawResponse = serde_json::from_str(raw_json).unwrap();
+        let resp = OpenAICompatProvider::parse_response(raw).unwrap();
+        assert_eq!(resp.choices[0].finish_reason, Some(FinishReason::Stop));
     }
 }


### PR DESCRIPTION
## Summary

- Adds `OpenAICompatProvider` implementing `ModelProvider` for any OpenAI-compatible endpoint (vLLM, LiteLLM, OpenRouter, Ollama `/v1`)
- Introduces `GatewayConfig` enum with serde-tagged dispatch between Ollama and OpenAI-compat providers
- Adds CLI flags (`--provider`, `--api-base`, `--api-key`) for runtime provider selection
- `OllamaProvider` preserved unchanged for backward compatibility
- Includes unit tests for request/response serialization and config serde roundtrip

## Test plan

- [x] All existing tests pass (OllamaProvider unchanged)
- [x] New unit tests for OpenAI-compat serialization
- [ ] `cargo clippy` clean
- [ ] CI green

Closes #124

https://claude.ai/code/session_01ShDykYG2muaykPpmqbzv4A