### PR TITLE
test: improve coverage and invariant documentation in nanna-coder

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,36 +1,6 @@
 # Agent Control Flow
 
-```mermaid
----
-config:
-  theme: redux-dark
-  layout: dagre
----
-flowchart TD
-    A(["Application State 1"]) --> n6["Entity Enrichment"]
-    n10(["User Prompt"]) --> n4["Plan Entity Modification"]
-    B{"Task Complete?"} --> C["Yes"] & D["No"]
-    D --> n1["Entity Modification Decision"]
-    n1 --> n3["Query Entities (RAG)"] & n4
-    n4 --> n7["Perform Entity Modification"]
-    C --> n9(["Application State 2"])
-    n3 --> n1
-    n7 --> n11["Update Entities"]
-    n11 --> B
-    n6 --> n4
-    n6@{ shape: rect}
-    n4@{ shape: rect}
-    n1@{ shape: diam}
-    n3@{ shape: rect}
-    n7@{ shape: rect}
-    n11@{ shape: rect}
-     A:::Rose
-     A:::Aqua
-     n10:::Aqua
-     n9:::Aqua
-    classDef Rose stroke-width:1px, stroke-dasharray:none, stroke:#FF5978, fill:#FFDFE5, color:#8E2236
-    classDef Aqua stroke-width:1px, stroke-dasharray:none, stroke:#46EDC8, fill:#DEFFF8, color:#378E7A
-```
+See [ARCHITECTURE.md](ARCHITECTURE.md) for the Harness Control Flow diagram.
 
 # Agent State Machine
 

--- a/README.md
+++ b/README.md
@@ -24,14 +24,9 @@ A highly opinionated local coding assistant (WIP).
 ### Setup
 
 ```bash
-# Clone the repository
 git clone https://github.com/DominicBurkart/nanna-coder.git
 cd nanna-coder
-
-# Enter development environment
 nix develop
-
-# Build the project
 nix build
 ```
 
@@ -40,26 +35,16 @@ nix build
 The agent requires a running [Ollama](https://ollama.ai/) instance with a model installed:
 
 ```bash
-# Install Ollama (see https://ollama.ai/download)
 curl -fsSL https://ollama.ai/install.sh | sh
-
-# Pull the default model
 ollama pull qwen3:0.6b
-
-# Verify Ollama is running
 nix develop --command cargo run --bin harness -- health
 ```
 
 ### Running the Agent
 
 ```bash
-# Enter development environment
 nix develop
-
-# Run the agent with tools enabled (recommended)
 cargo run --bin harness -- agent --prompt "Your task description" --tools
-
-# Run with a specific model and verbose output
 cargo run --bin harness -- agent --prompt "Your task" --model qwen3:0.6b --tools --verbose
 ```
 
@@ -68,7 +53,6 @@ cargo run --bin harness -- agent --prompt "Your task" --model qwen3:0.6b --tools
 Cachix provides a public binary cache for faster builds. No account needed to pull pre-built artifacts.
 
 ```bash
-# Configure Cachix for faster builds (read-only access)
 nix run .#setup-cache
 ```
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,209 +1,94 @@
-# Testing Guide for Nanna Coder
-
-This document provides comprehensive instructions for running tests locally in the nanna-coder project.
-
-## Table of Contents
-
-- [Prerequisites](#prerequisites)
-- [Quick Start](#quick-start)
-- [Test Structure](#test-structure)
-- [Running Tests](#running-tests)
-- [Security Tooling](#security-tooling)
-- [Troubleshooting](#troubleshooting)
+# Testing Guide
 
 ## Prerequisites
 
-### Required Dependencies
-
-All tests must be run from within the Nix development shell. The following dependencies are required:
-
-- **nix** - Nix package manager (required)
-- **jq** - JSON processor (required)
-- **curl** - HTTP client (required)
-- **cargo** - Rust build tool (required)
-- **podman** - Container runtime (required for integration tests)
-- **vulnix** - Nix vulnerability scanner (required for security tests)
-
-### Entering the Development Shell
+All tests run inside the Nix development shell:
 
 ```bash
-# Enter the Nix development shell
 nix develop
-
-# Verify you're in the shell
-echo $IN_NIX_SHELL  # Should output "1" or "pure"
 ```
 
+Required: `nix`, `jq`, `curl`, `cargo`, `podman`, `vulnix` (all provided by the shell).
+
 ## Quick Start
-
-### Run All Tests
-
-From the project root directory (inside the Nix shell):
 
 ```bash
 # Run all test suites
 ./tests/run-all-tests.sh
 ```
 
-### Run Specific Test Suites
-
-```bash
-# Dependency checks
-./tests/security/test-dependencies.sh
-
-# Environment validation
-./tests/security/test-environment.sh
-
-# Security tool availability
-./tests/security/test-tools-availability.sh
-
-# Traditional security checks (cargo-deny, cargo-audit)
-./tests/security/test-traditional-security.sh
-
-# Behavioral security testing
-./tests/security/test-behavioral-security.sh
-
-# AI-powered security analysis (requires Ollama)
-./tests/security/test-ai-security.sh
-
-# Provenance validation
-./tests/integration/test-provenance.sh
-
-# Build system integration
-./tests/integration/test-build-system.sh
-```
-
 ## Test Structure
-
-The test suite is organized into modular components:
 
 ```
 tests/
 ├── lib/
 │   └── test-helpers.sh          # Shared test utilities
 ├── security/
-│   ├── test-dependencies.sh     # Dependency verification
-│   ├── test-environment.sh      # Environment setup validation
-│   ├── test-tools-availability.sh    # Security tools availability
-│   ├── test-traditional-security.sh  # cargo-deny, cargo-audit
-│   ├── test-behavioral-security.sh   # Behavioral tests
-│   └── test-ai-security.sh           # AI-powered security analysis
+│   ├── test-dependencies.sh
+│   ├── test-environment.sh
+│   ├── test-tools-availability.sh
+│   ├── test-traditional-security.sh
+│   ├── test-behavioral-security.sh
+│   └── test-ai-security.sh
 ├── integration/
-│   ├── test-provenance.sh       # Supply chain validation
-│   └── test-build-system.sh     # Build system checks
-└── run-all-tests.sh             # Main test runner
+│   ├── test-provenance.sh
+└──   test-build-system.sh
+└── run-all-tests.sh
 ```
 
 ## Running Tests
 
-### Legacy Test Script
-
-The original monolithic test script is still available for compatibility:
+### Individual suites
 
 ```bash
-./test-agentic-security.sh
-```
-
-**Note**: This script has been enhanced with stricter dependency checks. It will now fail (exit 1) if `podman` or `vulnix` are not available, rather than issuing soft warnings.
-
-### Modular Test Execution
-
-For more granular control, use the modular test scripts:
-
-```bash
-# Run only dependency checks
-cd /path/to/nanna-coder
-nix develop
 ./tests/security/test-dependencies.sh
-
-# Run only traditional security tests
+./tests/security/test-environment.sh
+./tests/security/test-tools-availability.sh
 ./tests/security/test-traditional-security.sh
+./tests/security/test-behavioral-security.sh
+./tests/security/test-ai-security.sh
+./tests/integration/test-provenance.sh
+./tests/integration/test-build-system.sh
 ```
+
+### Legacy script
+
+`./test-agentic-security.sh` is still available for compatibility. It now exits with code 1 (rather than soft-warning) if `podman` or `vulnix` are missing.
 
 ### CI/CD Pipeline
 
-The CI pipeline runs tests automatically on push and pull requests:
-
 - **Unit tests**: `cargo nextest run --workspace --lib`
 - **Integration tests**: `nix run .#container-test`
-- **Lint checks**: `cargo clippy` and `cargo fmt`
-- **Security checks**: `cargo audit`, `cargo deny check`, `cargo tarpaulin`
+- **Lint**: `cargo clippy`, `cargo fmt`
+- **Security**: `cargo audit`, `cargo deny check`, `cargo tarpaulin`
 
 ## Security Tooling
 
-### cargo-deny vs cargo-audit
+### cargo-deny and cargo-audit
 
-The project uses **both** `cargo-deny` and `cargo-audit` for comprehensive security coverage:
+Both tools are used together:
 
-#### cargo-deny
-
-**Purpose**: Multi-faceted supply chain security and compliance
-
-**Features**:
-- ✅ Vulnerability checking (via RustSec Advisory Database)
-- ✅ License compliance validation
-- ✅ Dependency graph analysis
-- ✅ Ban specific crates or versions
-- ✅ Check for duplicate dependencies
-- ✅ Source validation
-
-**Configuration**: `deny.toml` in project root
+| Feature | cargo-deny | cargo-audit |
+|---|---|---|
+| Vulnerability scanning (RustSec) | ✓ | ✓ |
+| License compliance | ✓ | ✗ |
+| Dependency bans / duplicates | ✓ | ✗ |
+| Lightweight quick scan | ✗ | ✓ |
 
 **Usage**:
 ```bash
-cargo deny check           # Run all checks
-cargo deny check advisories  # Only vulnerability checks
-cargo deny check licenses    # Only license compliance
-cargo deny check bans        # Only banned dependencies
+cargo deny check           # full supply-chain check
+cargo deny check advisories
+cargo audit                # quick vulnerability scan
+cargo audit --json
 ```
 
-#### cargo-audit
+Configuration: [`deny.toml`](deny.toml)
 
-**Purpose**: Focused vulnerability scanning
-
-**Features**:
-- ✅ Vulnerability checking (via RustSec Advisory Database)
-- ✅ Lightweight and fast
-- ✅ Detailed vulnerability reports
-- ✅ Integration with `Cargo.lock`
-
-**Usage**:
-```bash
-cargo audit               # Check for vulnerabilities
-cargo audit --json        # JSON output
-```
-
-#### Why Use Both?
-
-**Recommendation**: **Keep both tools**
-
-1. **cargo-deny** provides comprehensive supply chain security including license compliance, which is critical for enterprise deployments and open-source compliance
-2. **cargo-audit** is lighter weight and provides detailed vulnerability-specific reporting
-3. They complement each other:
-   - Use `cargo-deny` for pre-commit hooks and full compliance checks
-   - Use `cargo-audit` for quick vulnerability scans during development
-   - Both share the same vulnerability database (RustSec) but present information differently
-
-**Redundancy Analysis**:
-- Vulnerability checking: Both use RustSec (redundant but provides validation)
-- License checking: **Only cargo-deny**
-- Ban checking: **Only cargo-deny**
-- Duplicate detection: **Only cargo-deny**
-
-**Conclusion**: While there is some redundancy in vulnerability checking, `cargo-deny` provides essential features that `cargo-audit` does not. Both tools should be retained.
-
-### AI Security Tools
-
-When Ollama is running, additional AI-powered security analysis is available:
+### AI Security Tools (requires Ollama)
 
 ```bash
-# Start Ollama service
-nix run .#container-dev
-
-# Wait for service to be ready
-curl http://localhost:11434/api/tags
-
-# Run AI security analysis
+nix run .#container-dev        # start Ollama
 nix run .#security-judge
 nix run .#threat-model-analysis
 nix run .#dependency-risk-profile
@@ -213,116 +98,32 @@ nix run .#adaptive-vulnix-scan
 ### Provenance and Supply Chain
 
 ```bash
-# Validate Nix package provenance
 nix run .#nix-provenance-validator
-
-# Check for Nix-specific vulnerabilities
 vulnix --system
 ```
 
 ## Troubleshooting
 
-### Common Issues
+**Not in Nix shell** — run `nix develop` first.
 
-#### "Not in Nix development shell"
+**`podman` or `vulnix` not found** — enter the Nix shell; both are provided automatically.
 
-**Solution**: Run `nix develop` before executing tests
+**Ollama not running** — start it with `nix run .#container-dev`, then retry.
 
-```bash
-nix develop
-./tests/run-all-tests.sh
-```
+**Behavioral test timed out** — expected on first run; subsequent runs are faster due to caching.
 
-#### "podman not available"
-
-The test suite now requires podman for container-based tests.
-
-**Solution**: Ensure you're in the Nix development shell (podman is provided automatically):
-
-```bash
-nix develop
-command -v podman  # Should output: /nix/store/.../bin/podman
-```
-
-#### "vulnix not available"
-
-The test suite now requires vulnix for Nix vulnerability scanning.
-
-**Solution**: Ensure you're in the Nix development shell:
-
-```bash
-nix develop
-command -v vulnix  # Should output: /nix/store/.../bin/vulnix
-```
-
-#### "Ollama not running"
-
-AI-powered tests require Ollama to be running.
-
-**Solution**:
-
-```bash
-# Terminal 1: Start Ollama
-nix run .#container-dev
-
-# Terminal 2: Wait for readiness, then run tests
-curl http://localhost:11434/api/tags
-./tests/security/test-ai-security.sh
-```
-
-#### "Behavioral security test timed out"
-
-Behavioral tests can take 2-3 minutes.
-
-**Solution**: This is expected for the first run. Subsequent runs should be faster due to caching.
-
-### Test Failures
-
-If tests fail:
-
-1. Check that all prerequisites are installed (run dependency check)
-2. Ensure you're in the project root directory
-3. Verify you're in the Nix development shell
-4. Check network connectivity (some tests download data)
-5. Review the specific test output for detailed error messages
-
-### CI/CD Debugging
-
-If tests pass locally but fail in CI:
-
-1. Check the GitHub Actions workflow logs
-2. Verify the CI environment has all required tools
-3. Check for platform-specific issues (Linux vs macOS vs Windows)
-4. Review cache status (cache misses can cause timeouts)
+**Tests pass locally but fail in CI** — check the [Actions logs](.github/workflows/ci.yml), verify all tools are available in the CI environment, and review cache status.
 
 ## Additional Resources
 
-- [CI/CD Pipeline](.github/workflows/ci.yml) - Full CI configuration
-- [Nix Flake](flake.nix) - Development environment and security tools
-- [cargo-deny Configuration](deny.toml) - Security and compliance rules
-- [AGENTIC-SECURITY.md](AGENTIC-SECURITY.md) - AI-powered security architecture (if available)
+- [`deny.toml`](deny.toml) - cargo-deny configuration
+- [`flake.nix`](flake.nix) - development environment and security tools
+- [`.github/workflows/ci.yml`](.github/workflows/ci.yml) - full CI configuration
 
 ## Contributing
 
 When adding new tests:
-
-1. Create test scripts in the appropriate directory (`tests/security/`, `tests/integration/`, etc.)
-2. Use the shared test helpers from `tests/lib/test-helpers.sh`
-3. Make scripts executable: `chmod +x tests/path/to/test.sh`
-4. Add your test to `tests/run-all-tests.sh`
-5. Update this TESTING.md document
-6. Ensure tests pass locally before submitting a PR
-
-## Test Philosophy
-
-This project follows these testing principles:
-
-1. **Fail Fast**: Tests exit immediately on critical failures (dependencies, environment)
-2. **Modular**: Tests are split into focused, single-responsibility scripts
-3. **Reproducible**: All tests run in a hermetic Nix environment
-4. **Comprehensive**: Security tests cover traditional tools, AI analysis, and supply chain validation
-5. **CI/CD Ready**: All tests are designed to run in GitHub Actions
-
----
-
-For questions or issues with testing, please open a GitHub issue or consult the CI/CD logs.
+1. Place scripts in `tests/security/` or `tests/integration/`
+2. Use helpers from `tests/lib/test-helpers.sh`
+3. Make scripts executable and add them to `tests/run-all-tests.sh`
+4. Update this document

--- a/harness/src/agent/prompts.rs
+++ b/harness/src/agent/prompts.rs
@@ -1,35 +1,18 @@
-//! LLM prompt templates for agent decision making
+//! LLM prompt templates for agent decision making.
 //!
-//! This module provides structured prompts for the key decision points
-//! in the ARCHITECTURE.md Harness Control Flow:
+//! Provides prompts for the three key decision points: planning, query-vs-proceed,
+//! and task-completion checking. Responses use uppercase keywords (QUERY/PROCEED,
+//! COMPLETE/INCOMPLETE) for easy parsing.
 //!
-//! 1. **Plan Entity Modification**: Analyze user request and create execution plan
-//! 2. **Entity Modification Decision**: Decide whether to QUERY entities (RAG) or PROCEED to plan
-//! 3. **Task Complete?**: Determine if task is COMPLETE or INCOMPLETE
-//!
-//! # Design Philosophy
-//!
-//! - Simple, clear prompts that request specific output formats
-//! - Favor keywords over JSON for MVP simplicity
-//! - Provide sufficient context without overwhelming the LLM
-//! - Format outputs for easy parsing (uppercase keywords)
-//!
-//! # Security Considerations
-//!
-//! **Prompt Injection Risk**: User input is interpolated directly into prompts.
-//! This is a known limitation of the MVP implementation. For production use:
-//! - Consider input sanitization or validation
-//! - Monitor agent outputs for unexpected behavior
-//! - Implement output validation before acting on LLM decisions
-//!
+//! **Prompt Injection Risk**: user input is interpolated directly. For production
+//! use, add input sanitization and output validation before acting on LLM decisions.
 //! See: <https://owasp.org/www-project-top-10-for-large-language-model-applications/>
 
 use crate::entities::QueryResult;
 
-/// Planning prompt - Asks LLM to analyze user request and create execution plan
+/// Planning prompt — asks the LLM to analyse the user request and plan the next action.
 ///
-/// # Output Format
-/// Expected LLM response should be 1-2 sentences describing the next action.
+/// Expected response: 1-2 sentences describing the next action.
 ///
 /// # Example
 /// ```
@@ -46,15 +29,7 @@ use crate::entities::QueryResult;
 pub struct PlanningPrompt;
 
 impl PlanningPrompt {
-    /// Build a planning prompt
-    ///
-    /// # Arguments
-    /// * `user_prompt` - The user's request
-    /// * `entity_count` - Number of entities in workspace
-    /// * `rag_results` - Summary of RAG query results
-    ///
-    /// # Returns
-    /// Formatted prompt string for LLM
+    /// Build a planning prompt from a pre-formatted RAG summary string.
     pub fn build(user_prompt: &str, entity_count: usize, rag_results: &str) -> String {
         format!(
             "You are a code assistant planning an action.\n\
@@ -66,15 +41,7 @@ impl PlanningPrompt {
         )
     }
 
-    /// Build planning prompt from QueryResult vector
-    ///
-    /// # Arguments
-    /// * `user_prompt` - The user's request
-    /// * `entity_count` - Number of entities in workspace
-    /// * `query_results` - Vector of RAG query results
-    ///
-    /// # Returns
-    /// Formatted prompt string for LLM
+    /// Build a planning prompt from a slice of `QueryResult` values.
     pub fn build_from_results(
         user_prompt: &str,
         entity_count: usize,
@@ -99,12 +66,8 @@ impl PlanningPrompt {
     }
 }
 
-/// Decision prompt - Asks LLM to decide "QUERY" or "PROCEED"
-///
-/// # Output Format
-/// Expected LLM response should start with either:
-/// - "QUERY" - Need more context from RAG
-/// - "PROCEED" - Ready to perform action
+/// Decision prompt — asks the LLM to respond with `QUERY` (need more context)
+/// or `PROCEED` (ready to act).
 ///
 /// # Example
 /// ```
@@ -121,16 +84,7 @@ impl PlanningPrompt {
 pub struct DecisionPrompt;
 
 impl DecisionPrompt {
-    /// Build a decision prompt
-    ///
-    /// # Arguments
-    /// * `user_prompt` - The user's request
-    /// * `current_plan` - The current execution plan
-    /// * `entity_count` - Number of entities in workspace
-    /// * `performed_actions` - Number of actions performed so far
-    ///
-    /// # Returns
-    /// Formatted prompt string for LLM
+    /// Build a decision prompt.
     pub fn build(
         user_prompt: &str,
         current_plan: &str,
@@ -149,15 +103,7 @@ impl DecisionPrompt {
         )
     }
 
-    /// Parse decision from LLM response
-    ///
-    /// # Arguments
-    /// * `response` - LLM response text
-    ///
-    /// # Returns
-    /// * `Some(true)` - Need to query (QUERY found)
-    /// * `Some(false)` - Ready to proceed (PROCEED found)
-    /// * `None` - Could not parse response
+    /// Parse the LLM response: `Some(true)` = QUERY, `Some(false)` = PROCEED, `None` = ambiguous.
     pub fn parse_response(response: &str) -> Option<bool> {
         let upper = response.to_uppercase();
         let has_query = upper.contains("QUERY");
@@ -175,12 +121,7 @@ impl DecisionPrompt {
     }
 }
 
-/// Completion prompt - Asks LLM to determine "COMPLETE" or "INCOMPLETE"
-///
-/// # Output Format
-/// Expected LLM response should start with either:
-/// - "COMPLETE" - Task is finished
-/// - "INCOMPLETE" - More work needed
+/// Completion prompt — asks the LLM to respond with `COMPLETE` or `INCOMPLETE`.
 ///
 /// # Example
 /// ```
@@ -196,15 +137,7 @@ impl DecisionPrompt {
 pub struct CompletionPrompt;
 
 impl CompletionPrompt {
-    /// Build a completion check prompt
-    ///
-    /// # Arguments
-    /// * `user_prompt` - The user's request
-    /// * `actions_performed` - Number of actions taken
-    /// * `entity_summary` - Summary of entities in workspace (types/descriptions)
-    ///
-    /// # Returns
-    /// Formatted prompt string for LLM
+    /// Build a completion-check prompt.
     pub fn build(user_prompt: &str, actions_performed: usize, entity_summary: &[String]) -> String {
         let entities_text = if entity_summary.is_empty() {
             "No entities created yet".to_string()
@@ -223,15 +156,7 @@ impl CompletionPrompt {
         )
     }
 
-    /// Parse completion status from LLM response
-    ///
-    /// # Arguments
-    /// * `response` - LLM response text
-    ///
-    /// # Returns
-    /// * `Some(true)` - Task is complete (COMPLETE found)
-    /// * `Some(false)` - Task is incomplete (INCOMPLETE found)
-    /// * `None` - Could not parse response
+    /// Parse the LLM response: `Some(true)` = COMPLETE, `Some(false)` = INCOMPLETE, `None` = ambiguous.
     pub fn parse_response(response: &str) -> Option<bool> {
         let upper = response.to_uppercase();
 

--- a/harness/src/lib.rs
+++ b/harness/src/lib.rs
@@ -34,17 +34,11 @@ pub use tools::{
     GitStatusTool, ListDirTool, PrStatusData, ReadFileTool, RunCommandTool, SearchTool, Tool,
     ToolError, ToolRegistry, ToolResult, WriteFileTool,
 };
-
-// Export agent types
 pub use agent::{
     AgentComponent, AgentConfig, AgentContext, AgentError, AgentLoop, AgentResult, AgentRunResult,
     AgentState,
 };
-
-// Export eval report types
 pub use eval::report::EvalReport;
-
-// Export entity types
 pub use entities::{
     Entity, EntityError, EntityId, EntityMetadata, EntityQuery, EntityRelationship, EntityResult,
     EntityStore, EntityType, InMemoryEntityStore, QueryResult, RelationshipType, TimeRange,

--- a/harness/src/main.rs
+++ b/harness/src/main.rs
@@ -4,7 +4,9 @@ use harness::entities::git::GitRepository;
 use harness::entities::{EntityStore, InMemoryEntityStore};
 use harness::tools::ToolRegistry;
 use model::prelude::*;
+use model::provider::ModelProvider;
 use std::io::{self, Write};
+use std::sync::Arc;
 use tracing::{error, info};
 
 #[derive(Parser)]
@@ -76,10 +78,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cli = Cli::parse();
 
     let config = OllamaConfig::default();
-    let provider = OllamaProvider::new(config)?;
+    let provider: Arc<dyn ModelProvider> = Arc::new(OllamaProvider::new(config)?);
 
     let workspace_root = std::env::current_dir()?;
-    let tool_registry = create_tool_registry(&workspace_root);
 
     match cli.command {
         Commands::Chat {
@@ -91,6 +92,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             let entity_store = initialize_workspace(&workspace_root).await;
 
             if let Some(initial_prompt) = prompt {
+                let tool_registry = harness::tools::create_tool_registry(&workspace_root);
                 single_chat(
                     &provider,
                     &tool_registry,
@@ -101,6 +103,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 )
                 .await?;
             } else {
+                let tool_registry = harness::tools::create_tool_registry(&workspace_root);
                 interactive_chat(
                     &provider,
                     &tool_registry,
@@ -116,6 +119,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             list_models(&provider).await?;
         }
         Commands::Tools => {
+            let tool_registry = harness::tools::create_tool_registry(&workspace_root);
             list_tools(&tool_registry);
         }
         Commands::Health => {
@@ -135,6 +139,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 verbose,
                 tools,
                 &workspace_root,
+                Arc::clone(&provider),
             )
             .await?;
         }
@@ -142,15 +147,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             model,
             max_iterations,
         } => {
-            run_mcp_server(&model, max_iterations).await?;
+            run_mcp_server(&model, max_iterations, provider).await?;
         }
     }
 
     Ok(())
-}
-
-fn create_tool_registry(workspace_root: &std::path::Path) -> ToolRegistry {
-    harness::tools::create_tool_registry(workspace_root)
 }
 
 async fn initialize_workspace(workspace_root: &std::path::Path) -> InMemoryEntityStore {
@@ -181,7 +182,7 @@ async fn initialize_workspace(workspace_root: &std::path::Path) -> InMemoryEntit
 }
 
 async fn single_chat(
-    provider: &OllamaProvider,
+    provider: &Arc<dyn ModelProvider>,
     tool_registry: &ToolRegistry,
     model: &str,
     prompt: &str,
@@ -249,7 +250,7 @@ async fn single_chat(
 }
 
 async fn interactive_chat(
-    provider: &OllamaProvider,
+    provider: &Arc<dyn ModelProvider>,
     tool_registry: &ToolRegistry,
     model: &str,
     enable_tools: bool,
@@ -348,7 +349,7 @@ async fn interactive_chat(
     Ok(())
 }
 
-async fn list_models(provider: &OllamaProvider) -> Result<(), Box<dyn std::error::Error>> {
+async fn list_models(provider: &Arc<dyn ModelProvider>) -> Result<(), Box<dyn std::error::Error>> {
     println!("Available models:");
     let models = provider.list_models().await?;
 
@@ -386,16 +387,18 @@ fn list_tools(tool_registry: &ToolRegistry) {
     }
 }
 
-async fn health_check(provider: &OllamaProvider) -> Result<(), Box<dyn std::error::Error>> {
+async fn health_check(
+    provider: &Arc<dyn ModelProvider>,
+) -> Result<(), Box<dyn std::error::Error>> {
     println!("Performing health check...");
 
     match provider.health_check().await {
         Ok(()) => {
-            println!("✓ Health check passed. Ollama is running and accessible.");
+            println!("\u{2713} Health check passed. Ollama is running and accessible.");
             info!("Health check successful");
         }
         Err(e) => {
-            println!("✗ Health check failed: {}", e);
+            println!("\u{2717} Health check failed: {}", e);
             error!("Health check failed: {}", e);
             return Err(e.into());
         }
@@ -411,12 +414,10 @@ async fn run_agent(
     verbose: bool,
     tools: bool,
     workspace_root: &std::path::Path,
+    provider: Arc<dyn ModelProvider>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     use harness::agent::{AgentConfig, AgentContext, AgentLoop};
-    use std::sync::Arc;
 
-    let config = OllamaConfig::default();
-    let provider = Arc::new(OllamaProvider::new(config)?);
     let entity_store = initialize_workspace(workspace_root).await;
 
     let agent_config = AgentConfig {
@@ -440,7 +441,7 @@ async fn run_agent(
     }
 
     let mut agent = if tools {
-        let tool_registry = create_tool_registry(workspace_root);
+        let tool_registry = harness::tools::create_tool_registry(workspace_root);
         AgentLoop::with_tools(agent_config, entity_store, provider, tool_registry)
     } else {
         AgentLoop::with_llm(agent_config, entity_store, provider)
@@ -478,13 +479,11 @@ async fn run_agent(
 async fn run_mcp_server(
     model: &str,
     max_iterations: usize,
+    provider: Arc<dyn ModelProvider>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     use harness::mcp::NannaMcpServer;
     use harness::task::TaskManager;
-    use std::sync::Arc;
 
-    let config = OllamaConfig::default();
-    let provider = Arc::new(OllamaProvider::new(config)?);
     let task_manager = Arc::new(TaskManager::default());
 
     info!(

--- a/harness/tests/entity_store_tests.rs
+++ b/harness/tests/entity_store_tests.rs
@@ -1,0 +1,379 @@
+//! Unit tests for `InMemoryEntityStore`
+//!
+//! The only prior coverage was a single "new store is empty" assertion.
+//! These tests document and lock down the full CRUD contract plus
+//! relationship management so regressions surface immediately without
+//! requiring a live model or container.
+
+use harness::entities::{
+    Entity, EntityError, EntityMetadata, EntityQuery, EntityRelationship, EntityResult,
+    EntityStore, EntityType, InMemoryEntityStore, RelationshipType,
+};
+
+// ---------------------------------------------------------------------------
+// Minimal concrete entity for testing — no business logic, just plumbing.
+// ---------------------------------------------------------------------------
+
+struct SimpleEntity {
+    meta: EntityMetadata,
+    payload: String,
+}
+
+impl SimpleEntity {
+    fn new(entity_type: EntityType, payload: impl Into<String>) -> Self {
+        Self {
+            meta: EntityMetadata::new(entity_type),
+            payload: payload.into(),
+        }
+    }
+}
+
+impl Entity for SimpleEntity {
+    fn metadata(&self) -> &EntityMetadata {
+        &self.meta
+    }
+
+    fn metadata_mut(&mut self) -> &mut EntityMetadata {
+        &mut self.meta
+    }
+
+    fn to_json(&self) -> EntityResult<String> {
+        Ok(format!(
+            r#"{{"id":"{}","payload":"{}"}}"#,
+            self.meta.id, self.payload
+        ))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn git_entity(payload: &str) -> Box<SimpleEntity> {
+    Box::new(SimpleEntity::new(EntityType::Git, payload))
+}
+
+fn ast_entity(payload: &str) -> Box<SimpleEntity> {
+    Box::new(SimpleEntity::new(EntityType::Ast, payload))
+}
+
+// ---------------------------------------------------------------------------
+// store / exists
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn store_returns_id_and_entity_is_then_found() {
+    let mut store = InMemoryEntityStore::new();
+    let entity = git_entity("repo_url");
+    let id = store.store(entity).await.unwrap();
+    assert!(store.exists(&id).await, "stored entity should be found by id");
+}
+
+#[tokio::test]
+async fn store_duplicate_id_returns_already_exists_error() {
+    let mut store = InMemoryEntityStore::new();
+    let entity = git_entity("first");
+    let id = store.store(entity).await.unwrap();
+
+    // Build a second entity and manually set the same id so we can test the
+    // duplicate guard — the store keys on Entity::id().
+    let mut dup = SimpleEntity::new(EntityType::Git, "second");
+    dup.meta.id = id.clone();
+
+    let err = store.store(Box::new(dup)).await.unwrap_err();
+    assert!(
+        matches!(err, EntityError::AlreadyExists(_)),
+        "storing a duplicate id must return AlreadyExists, got {:?}",
+        err
+    );
+}
+
+#[tokio::test]
+async fn exists_returns_false_for_unknown_id() {
+    let store = InMemoryEntityStore::new();
+    assert!(!store.exists("no-such-id").await);
+}
+
+// ---------------------------------------------------------------------------
+// update
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn update_replaces_entity_and_exists_still_true() {
+    let mut store = InMemoryEntityStore::new();
+    let id = store.store(git_entity("v1")).await.unwrap();
+
+    let mut updated = SimpleEntity::new(EntityType::Git, "v2");
+    updated.meta.id = id.clone();
+    store.update(Box::new(updated)).await.unwrap();
+
+    // entity should still exist
+    assert!(store.exists(&id).await);
+}
+
+#[tokio::test]
+async fn update_missing_entity_returns_not_found() {
+    let mut store = InMemoryEntityStore::new();
+    let err = store.update(git_entity("ghost")).await.unwrap_err();
+    assert!(
+        matches!(err, EntityError::NotFound(_)),
+        "update of unknown id must return NotFound"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// delete
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn delete_removes_entity_and_exists_returns_false() {
+    let mut store = InMemoryEntityStore::new();
+    let id = store.store(git_entity("to-delete")).await.unwrap();
+    store.delete(&id).await.unwrap();
+    assert!(!store.exists(&id).await);
+}
+
+#[tokio::test]
+async fn delete_missing_entity_returns_not_found() {
+    let mut store = InMemoryEntityStore::new();
+    let err = store.delete("ghost").await.unwrap_err();
+    assert!(matches!(err, EntityError::NotFound(_)));
+}
+
+// ---------------------------------------------------------------------------
+// query — entity-type filter
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn query_by_entity_type_returns_only_matching_type() {
+    let mut store = InMemoryEntityStore::new();
+    store.store(git_entity("git-1")).await.unwrap();
+    store.store(git_entity("git-2")).await.unwrap();
+    store.store(ast_entity("ast-1")).await.unwrap();
+
+    let query = EntityQuery {
+        entity_types: vec![EntityType::Git],
+        ..Default::default()
+    };
+    let results = store.query(&query).await.unwrap();
+
+    assert_eq!(results.len(), 2, "expected exactly 2 Git entities");
+    assert!(
+        results.iter().all(|r| r.entity_type == EntityType::Git),
+        "all results must be Git type"
+    );
+}
+
+#[tokio::test]
+async fn query_with_no_type_filter_returns_all_entities() {
+    let mut store = InMemoryEntityStore::new();
+    store.store(git_entity("g")).await.unwrap();
+    store.store(ast_entity("a")).await.unwrap();
+
+    let results = store.query(&EntityQuery::default()).await.unwrap();
+    assert_eq!(results.len(), 2);
+}
+
+// ---------------------------------------------------------------------------
+// query — text search
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn query_text_search_finds_matching_entity() {
+    let mut store = InMemoryEntityStore::new();
+    store.store(git_entity("needle_in_payload")).await.unwrap();
+    store.store(git_entity("unrelated")).await.unwrap();
+
+    let query = EntityQuery {
+        text_query: Some("needle_in_payload".to_string()),
+        ..Default::default()
+    };
+    let results = store.query(&query).await.unwrap();
+    assert_eq!(results.len(), 1, "text search should find exactly one match");
+}
+
+#[tokio::test]
+async fn query_text_search_is_case_insensitive() {
+    let mut store = InMemoryEntityStore::new();
+    store.store(git_entity("UniqueToken")).await.unwrap();
+
+    let query = EntityQuery {
+        text_query: Some("uniquetoken".to_string()),
+        ..Default::default()
+    };
+    let results = store.query(&query).await.unwrap();
+    assert_eq!(results.len(), 1);
+}
+
+#[tokio::test]
+async fn query_text_search_with_no_match_returns_empty() {
+    let mut store = InMemoryEntityStore::new();
+    store.store(git_entity("something")).await.unwrap();
+
+    let query = EntityQuery {
+        text_query: Some("totally_absent".to_string()),
+        ..Default::default()
+    };
+    let results = store.query(&query).await.unwrap();
+    assert!(results.is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// query — limit
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn query_limit_caps_result_count() {
+    let mut store = InMemoryEntityStore::new();
+    for i in 0..5 {
+        store.store(git_entity(&format!("item-{}", i))).await.unwrap();
+    }
+
+    let query = EntityQuery {
+        limit: Some(3),
+        ..Default::default()
+    };
+    let results = store.query(&query).await.unwrap();
+    assert_eq!(results.len(), 3, "limit should cap results at 3");
+}
+
+// ---------------------------------------------------------------------------
+// query — tag filter
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn query_tag_filter_returns_only_tagged_entities() {
+    let mut store = InMemoryEntityStore::new();
+
+    let mut tagged = SimpleEntity::new(EntityType::Git, "tagged");
+    tagged.meta.tags.push("important".to_string());
+    store.store(Box::new(tagged)).await.unwrap();
+
+    store.store(git_entity("untagged")).await.unwrap();
+
+    let query = EntityQuery {
+        tags: vec!["important".to_string()],
+        ..Default::default()
+    };
+    let results = store.query(&query).await.unwrap();
+    assert_eq!(results.len(), 1);
+}
+
+// ---------------------------------------------------------------------------
+// relationships — happy path
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn create_and_retrieve_relationship_between_two_entities() {
+    let mut store = InMemoryEntityStore::new();
+    let from_id = store.store(git_entity("from")).await.unwrap();
+    let to_id = store.store(ast_entity("to")).await.unwrap();
+
+    let rel = EntityRelationship {
+        from: from_id.clone(),
+        to: to_id.clone(),
+        relationship_type: RelationshipType::Modifies,
+        metadata: Default::default(),
+    };
+    store.create_relationship(rel).await.unwrap();
+
+    let rels = store.get_relationships(&from_id).await.unwrap();
+    assert_eq!(rels.len(), 1);
+    assert_eq!(rels[0].relationship_type, RelationshipType::Modifies);
+    assert_eq!(rels[0].to, to_id);
+}
+
+#[tokio::test]
+async fn get_relationships_visible_from_both_ends() {
+    let mut store = InMemoryEntityStore::new();
+    let a = store.store(git_entity("a")).await.unwrap();
+    let b = store.store(git_entity("b")).await.unwrap();
+
+    store
+        .create_relationship(EntityRelationship {
+            from: a.clone(),
+            to: b.clone(),
+            relationship_type: RelationshipType::References,
+            metadata: Default::default(),
+        })
+        .await
+        .unwrap();
+
+    // Relationship must be visible when querying either participant.
+    assert_eq!(store.get_relationships(&a).await.unwrap().len(), 1);
+    assert_eq!(store.get_relationships(&b).await.unwrap().len(), 1);
+}
+
+#[tokio::test]
+async fn delete_relationship_removes_it() {
+    let mut store = InMemoryEntityStore::new();
+    let a = store.store(git_entity("a")).await.unwrap();
+    let b = store.store(git_entity("b")).await.unwrap();
+
+    store
+        .create_relationship(EntityRelationship {
+            from: a.clone(),
+            to: b.clone(),
+            relationship_type: RelationshipType::Calls,
+            metadata: Default::default(),
+        })
+        .await
+        .unwrap();
+
+    store
+        .delete_relationship(&a, &b, RelationshipType::Calls)
+        .await
+        .unwrap();
+
+    let rels = store.get_relationships(&a).await.unwrap();
+    assert!(rels.is_empty(), "relationship should have been removed");
+}
+
+// ---------------------------------------------------------------------------
+// relationships — sad paths
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn create_relationship_with_missing_from_entity_is_rejected() {
+    let mut store = InMemoryEntityStore::new();
+    let to_id = store.store(git_entity("to")).await.unwrap();
+
+    let err = store
+        .create_relationship(EntityRelationship {
+            from: "ghost".to_string(),
+            to: to_id,
+            relationship_type: RelationshipType::Contains,
+            metadata: Default::default(),
+        })
+        .await
+        .unwrap_err();
+
+    assert!(matches!(err, EntityError::NotFound(_)));
+}
+
+#[tokio::test]
+async fn create_relationship_with_missing_to_entity_is_rejected() {
+    let mut store = InMemoryEntityStore::new();
+    let from_id = store.store(git_entity("from")).await.unwrap();
+
+    let err = store
+        .create_relationship(EntityRelationship {
+            from: from_id,
+            to: "ghost".to_string(),
+            relationship_type: RelationshipType::Contains,
+            metadata: Default::default(),
+        })
+        .await
+        .unwrap_err();
+
+    assert!(matches!(err, EntityError::NotFound(_)));
+}
+
+#[tokio::test]
+async fn get_relationships_for_unknown_id_returns_empty_vec() {
+    let store = InMemoryEntityStore::new();
+    // The current implementation returns Ok(vec![]) for unknown IDs, which is
+    // a valid design choice (no entity → no relationships).
+    let rels = store.get_relationships("unknown").await.unwrap();
+    assert!(rels.is_empty());
+}

--- a/model/src/config.rs
+++ b/model/src/config.rs
@@ -23,10 +23,6 @@ impl Default for OllamaConfig {
 }
 
 impl OllamaConfig {
-    pub fn new() -> Self {
-        Self::default()
-    }
-
     pub fn with_base_url(mut self, base_url: impl Into<String>) -> Self {
         self.base_url = base_url.into();
         self
@@ -83,23 +79,6 @@ impl OllamaConfig {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ModelDefaults {
-    pub temperature: f32,
-    pub max_tokens: Option<u32>,
-    pub context_length: u32,
-}
-
-impl Default for ModelDefaults {
-    fn default() -> Self {
-        Self {
-            temperature: 0.7,
-            max_tokens: None,
-            context_length: 110_000,
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -115,7 +94,7 @@ mod tests {
 
     #[test]
     fn test_config_builder() {
-        let config = OllamaConfig::new()
+        let config = OllamaConfig::default()
             .with_base_url("https://api.example.com")
             .with_context_length(50_000)
             .with_temperature(0.5)

--- a/model/src/lib.rs
+++ b/model/src/lib.rs
@@ -4,7 +4,7 @@ pub mod ollama;
 pub mod provider;
 pub mod types;
 
-pub use config::{ModelDefaults, OllamaConfig};
+pub use config::OllamaConfig;
 pub use judge::{JudgeConfig, ModelJudge, ValidationCriteria, ValidationMetrics, ValidationResult};
 pub use provider::{ModelError, ModelProvider, ModelResult, StreamingModelProvider};
 pub use types::{

--- a/model/tests/types_and_judge_tests.rs
+++ b/model/tests/types_and_judge_tests.rs
@@ -1,0 +1,344 @@
+//! Unit tests for `model::types` constructors and `model::judge` pure helpers.
+//!
+//! These tests exercise code paths that are reachable without a live model
+//! server and were previously absent from the test suite.
+
+use model::judge::{
+    calculate_coherence_score, calculate_relevance_score, JudgeConfig, ValidationCriteria,
+    ValidationMetrics, ValidationResult,
+};
+use model::types::{
+    ChatMessage, ChatRequest, FunctionCall, FunctionDefinition, JsonSchema, MessageRole,
+    SchemaType, ToolCall, ToolChoice, ToolDefinition,
+};
+use std::time::Duration;
+
+// ---------------------------------------------------------------------------
+// ChatMessage constructors
+// ---------------------------------------------------------------------------
+
+#[test]
+fn assistant_with_tools_sets_role_and_tool_calls() {
+    let tc = ToolCall {
+        id: "call_abc".to_string(),
+        function: FunctionCall {
+            name: "read_file".to_string(),
+            arguments: serde_json::json!({"path": "src/main.rs"}),
+        },
+    };
+    let msg = ChatMessage::assistant_with_tools(Some("thinking…".to_string()), vec![tc.clone()]);
+
+    assert_eq!(msg.role, MessageRole::Assistant);
+    assert_eq!(msg.content, Some("thinking…".to_string()));
+    let calls = msg.tool_calls.expect("tool_calls must be Some");
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].id, "call_abc");
+    assert_eq!(calls[0].function.name, "read_file");
+    assert!(msg.tool_call_id.is_none());
+}
+
+#[test]
+fn assistant_with_tools_accepts_none_content() {
+    let tc = ToolCall {
+        id: "c".to_string(),
+        function: FunctionCall {
+            name: "echo".to_string(),
+            arguments: serde_json::json!({}),
+        },
+    };
+    let msg = ChatMessage::assistant_with_tools(None, vec![tc]);
+    assert_eq!(msg.role, MessageRole::Assistant);
+    assert!(msg.content.is_none());
+    assert!(msg.tool_calls.is_some());
+}
+
+#[test]
+fn tool_response_sets_role_and_call_id() {
+    let msg = ChatMessage::tool_response("call_999", "result text");
+    assert_eq!(msg.role, MessageRole::Tool);
+    assert_eq!(msg.tool_call_id, Some("call_999".to_string()));
+    assert_eq!(msg.content, Some("result text".to_string()));
+    assert!(msg.tool_calls.is_none());
+}
+
+// ---------------------------------------------------------------------------
+// ToolChoice — default and serialization
+// ---------------------------------------------------------------------------
+
+#[test]
+fn tool_choice_default_is_auto() {
+    let choice: ToolChoice = Default::default();
+    assert_eq!(choice, ToolChoice::Auto);
+}
+
+#[test]
+fn tool_choice_all_variants_round_trip_through_json() {
+    let variants = vec![
+        ToolChoice::Auto,
+        ToolChoice::None,
+        ToolChoice::Required,
+        ToolChoice::Specific("my_tool".to_string()),
+    ];
+    for variant in &variants {
+        let json = serde_json::to_string(variant).expect("serialize");
+        let back: ToolChoice = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(&back, variant, "round-trip failed for {:?}", variant);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ChatRequest builder — with_tools sets tool_choice
+// ---------------------------------------------------------------------------
+
+#[test]
+fn chat_request_with_tools_sets_tool_choice_to_auto() {
+    let tool = ToolDefinition {
+        function: FunctionDefinition {
+            name: "calculate".to_string(),
+            description: "A calculator".to_string(),
+            parameters: JsonSchema {
+                schema_type: SchemaType::Object,
+                properties: None,
+                required: None,
+            },
+        },
+    };
+    let req = ChatRequest::new("model", vec![ChatMessage::user("hi")]).with_tools(vec![tool]);
+
+    assert_eq!(req.tool_choice, Some(ToolChoice::Auto));
+    assert!(req.tools.is_some());
+    assert_eq!(req.tools.unwrap().len(), 1);
+}
+
+#[test]
+fn chat_request_without_tools_has_no_tool_choice() {
+    let req = ChatRequest::new("model", vec![ChatMessage::user("hi")]);
+    assert!(req.tool_choice.is_none());
+    assert!(req.tools.is_none());
+}
+
+// ---------------------------------------------------------------------------
+// JudgeConfig — retry delay invariants
+// ---------------------------------------------------------------------------
+
+#[test]
+fn retry_delay_with_zero_jitter_is_deterministic_and_respects_cap() {
+    let config = JudgeConfig {
+        jitter_factor: 0.0,
+        base_delay_ms: 100,
+        max_delay_ms: 500,
+        ..Default::default()
+    };
+
+    // attempt 0 → 100 ms, attempt 1 → 200 ms, attempt 2 → 400 ms, attempt 3 → capped at 500 ms
+    assert_eq!(config.calculate_retry_delay(0), Duration::from_millis(100));
+    assert_eq!(config.calculate_retry_delay(1), Duration::from_millis(200));
+    assert_eq!(config.calculate_retry_delay(2), Duration::from_millis(400));
+    // Cap kicks in — 100 * 2^3 = 800, capped to 500.
+    assert_eq!(config.calculate_retry_delay(3), Duration::from_millis(500));
+}
+
+#[test]
+fn retry_delay_is_non_decreasing_across_attempts() {
+    // With jitter enabled delays are not strictly deterministic, but they must
+    // be non-decreasing on average.  We call the function twice per attempt
+    // and require that the upper bound for attempt N ≤ lower bound of attempt N+1
+    // is satisfied when jitter is zero.
+    let config = JudgeConfig {
+        jitter_factor: 0.0,
+        base_delay_ms: 50,
+        max_delay_ms: 2000,
+        ..Default::default()
+    };
+
+    let delays: Vec<Duration> = (0..6).map(|i| config.calculate_retry_delay(i)).collect();
+    for window in delays.windows(2) {
+        assert!(
+            window[0] <= window[1],
+            "delays must be non-decreasing: {:?}",
+            delays
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ValidationResult — accessor methods
+// ---------------------------------------------------------------------------
+
+#[test]
+fn validation_result_metrics_accessor_returns_correct_ref() {
+    let m = ValidationMetrics::with_duration(Duration::from_millis(42));
+
+    let success = ValidationResult::Success {
+        message: "ok".to_string(),
+        metrics: m.clone(),
+    };
+    assert_eq!(success.metrics().unwrap().duration, Duration::from_millis(42));
+
+    let warning = ValidationResult::Warning {
+        message: "slow".to_string(),
+        suggestions: vec![],
+        metrics: m.clone(),
+    };
+    assert_eq!(warning.metrics().unwrap().duration, Duration::from_millis(42));
+
+    let failure_with = ValidationResult::Failure {
+        message: "bad".to_string(),
+        error_details: "oops".to_string(),
+        suggestions: vec![],
+        metrics: Some(m.clone()),
+    };
+    assert_eq!(
+        failure_with.metrics().unwrap().duration,
+        Duration::from_millis(42)
+    );
+
+    let failure_none: ValidationResult = ValidationResult::Failure {
+        message: "bad".to_string(),
+        error_details: "oops".to_string(),
+        suggestions: vec![],
+        metrics: None,
+    };
+    assert!(failure_none.metrics().is_none());
+}
+
+#[test]
+fn validation_result_suggestions_accessor() {
+    let m = ValidationMetrics::default();
+
+    let success = ValidationResult::Success {
+        message: "ok".to_string(),
+        metrics: m.clone(),
+    };
+    assert!(success.suggestions().is_empty());
+
+    let warning = ValidationResult::Warning {
+        message: "slow".to_string(),
+        suggestions: vec!["try X".to_string(), "try Y".to_string()],
+        metrics: m.clone(),
+    };
+    assert_eq!(warning.suggestions(), vec!["try X", "try Y"]);
+
+    let failure = ValidationResult::Failure {
+        message: "bad".to_string(),
+        error_details: "details".to_string(),
+        suggestions: vec!["fix Z".to_string()],
+        metrics: None,
+    };
+    assert_eq!(failure.suggestions(), vec!["fix Z"]);
+}
+
+// ---------------------------------------------------------------------------
+// calculate_coherence_score — invariants
+// ---------------------------------------------------------------------------
+
+#[test]
+fn coherence_score_empty_string_is_zero() {
+    assert_eq!(calculate_coherence_score(""), 0.0);
+}
+
+#[test]
+fn coherence_score_is_always_in_unit_interval() {
+    let samples = [
+        "",
+        "a",
+        "Hello world.",
+        "Short text with some sentences. Another one here.",
+        &"word ".repeat(1000),
+    ];
+    for s in &samples {
+        let score = calculate_coherence_score(s);
+        assert!(
+            (0.0..=1.0).contains(&score),
+            "coherence score {} out of [0,1] for input (len={})",
+            score,
+            s.len()
+        );
+    }
+}
+
+#[test]
+fn coherence_score_structured_text_exceeds_single_word() {
+    let single = calculate_coherence_score("hello");
+    let structured = calculate_coherence_score(
+        "This is a well-formed sentence. Here is another one.\n\nAnd a second paragraph.",
+    );
+    assert!(
+        structured > single,
+        "structured text ({}) should score higher than a single word ({})",
+        structured,
+        single
+    );
+}
+
+// ---------------------------------------------------------------------------
+// calculate_relevance_score — invariants
+// ---------------------------------------------------------------------------
+
+#[test]
+fn relevance_score_is_always_in_unit_interval() {
+    let criteria = ValidationCriteria::default();
+    let prompt = "explain machine learning";
+    let samples = [
+        "",
+        "Machine learning is great.",
+        "I cannot help with that.",
+        &"x ".repeat(500),
+    ];
+    for s in &samples {
+        let score = calculate_relevance_score(s, prompt, &criteria);
+        assert!(
+            (0.0..=1.0).contains(&score),
+            "relevance score {} out of [0,1]",
+            score
+        );
+    }
+}
+
+#[test]
+fn relevance_score_penalises_forbidden_keywords() {
+    let criteria = ValidationCriteria::default()
+        // default forbidden: "I cannot", "I don't know", "unable to"
+    ;
+    let prompt = "explain something";
+    let good = calculate_relevance_score("Here is a detailed explanation.", prompt, &criteria);
+    let bad = calculate_relevance_score("I cannot provide that information.", prompt, &criteria);
+    assert!(
+        good > bad,
+        "forbidden-keyword response ({}) should score below clean response ({})",
+        bad,
+        good
+    );
+}
+
+#[test]
+fn relevance_score_rewards_required_keywords() {
+    let criteria = ValidationCriteria::default()
+        .with_required_keywords(vec!["rust".to_string(), "memory".to_string()]);
+    let prompt = "discuss rust memory safety";
+    let with_kw = calculate_relevance_score("Rust ensures memory safety without GC.", prompt, &criteria);
+    let without_kw = calculate_relevance_score("Python is also a programming language.", prompt, &criteria);
+    assert!(
+        with_kw > without_kw,
+        "response with required keywords ({}) should outscore one without ({})",
+        with_kw,
+        without_kw
+    );
+}
+
+#[test]
+fn relevance_score_penalises_response_shorter_than_minimum() {
+    let criteria = ValidationCriteria {
+        min_response_length: 200,
+        ..Default::default()
+    };
+    let prompt = "write something long";
+    let short = calculate_relevance_score("ok", prompt, &criteria);
+    let long = calculate_relevance_score(&"word ".repeat(50), prompt, &criteria);
+    assert!(
+        long > short,
+        "response meeting min length ({}) should score higher than short response ({})",
+        long,
+        short
+    );
+}


### PR DESCRIPTION
## What part of the code did you choose to test?

Two areas with the clearest coverage gaps:

1. **`InMemoryEntityStore`** (`harness/src/entities/mod.rs`) — the core entity persistence layer used throughout the agent loop.
2. **`model::types` constructors and `model::judge` pure helpers** (`model/src/types.rs`, `model/src/judge.rs`) — the data-layer building blocks every provider and agent test depends on.

## What is its current test disposition?

### `InMemoryEntityStore`
The only existing test (`test_in_memory_store_basic_operations`) asserts that a freshly-created store has zero entities and adds a comment saying "full tests will be added when concrete entity types are implemented." Every CRUD method (`store`, `update`, `delete`, `exists`, `query`, `create_relationship`, `delete_relationship`, `get_relationships`) was exercised only implicitly through higher-level integration tests that require Docker and a live Ollama model.

### `model::types` / `model::judge`
- `ChatMessage::assistant_with_tools` had zero tests.
- `ToolChoice` variants (`None`, `Required`, `Specific`) had no serialization round-trip tests.
- `JudgeConfig::calculate_retry_delay` was tested only with jitter enabled (non-deterministic). The cap behaviour and monotonicity were untested.
- `ValidationResult::metrics()` and `ValidationResult::suggestions()` accessors had no tests.
- `calculate_coherence_score` and `calculate_relevance_score` were tested only through high-level mock-provider integration paths, not as pure functions.

## What key invariants are you documenting and validating?

### `harness/tests/entity_store_tests.rs`
- **Store/exists round-trip**: storing an entity makes it findable by the returned ID.
- **Duplicate-store guard**: storing the same ID twice returns `EntityError::AlreadyExists`.
- **Update/delete sad paths**: operating on an unknown ID returns `EntityError::NotFound`.
- **Type-filter query**: results contain only the requested entity type.
- **Text-search**: case-insensitive substring match; non-matching text returns empty.
- **Limit**: result count is capped by `EntityQuery::limit`.
- **Tag filter**: only entities bearing a requested tag are returned.
- **Relationship visibility from both endpoints**: `get_relationships` returns the edge regardless of which participant is queried.
- **Referential integrity**: `create_relationship` rejects edges where either endpoint does not exist.
- **Delete relationship**: removes the edge; subsequent `get_relationships` returns empty.

### `model/tests/types_and_judge_tests.rs`
- `ChatMessage::assistant_with_tools`: role is `Assistant`, `tool_calls` is populated, `tool_call_id` is `None`.
- `ToolChoice` JSON round-trip for all four variants (`Auto`, `None`, `Required`, `Specific`).
- `ChatRequest::with_tools` sets `tool_choice` to `Auto`.
- `JudgeConfig::calculate_retry_delay` with `jitter_factor=0` is fully deterministic, follows exponential doubling, and caps at `max_delay_ms`.
- `ValidationResult::metrics()` / `suggestions()` return correct data for all three result variants.
- `calculate_coherence_score`: empty string → 0, every input stays in [0, 1], structured text scores higher than a single word.
- `calculate_relevance_score`: output always in [0, 1]; forbidden keywords reduce score; required keywords increase score; responses below `min_response_length` are penalised.