### PR TITLE
[nanna-coder] Architecture: Deduplicate tool-call loop and share provider

### DIFF
--- a/harness/src/main.rs
+++ b/harness/src/main.rs
@@ -5,6 +5,7 @@ use harness::entities::{EntityStore, InMemoryEntityStore};
 use harness::tools::ToolRegistry;
 use model::prelude::*;
 use std::io::{self, Write};
+use std::sync::Arc;
 use tracing::{error, info};
 
 #[derive(Parser)]
@@ -75,11 +76,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let cli = Cli::parse();
 
-    let config = OllamaConfig::default();
-    let provider = OllamaProvider::new(config)?;
-
+    let provider = Arc::new(OllamaProvider::new(OllamaConfig::default())?);
     let workspace_root = std::env::current_dir()?;
-    let tool_registry = create_tool_registry(&workspace_root);
+    let tool_registry = harness::tools::create_tool_registry(&workspace_root);
 
     match cli.command {
         Commands::Chat {
@@ -135,6 +134,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 verbose,
                 tools,
                 &workspace_root,
+                Arc::clone(&provider),
             )
             .await?;
         }
@@ -142,15 +142,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             model,
             max_iterations,
         } => {
-            run_mcp_server(&model, max_iterations).await?;
+            run_mcp_server(&model, max_iterations, Arc::clone(&provider)).await?;
         }
     }
 
     Ok(())
-}
-
-fn create_tool_registry(workspace_root: &std::path::Path) -> ToolRegistry {
-    harness::tools::create_tool_registry(workspace_root)
 }
 
 async fn initialize_workspace(workspace_root: &std::path::Path) -> InMemoryEntityStore {
@@ -180,6 +176,61 @@ async fn initialize_workspace(workspace_root: &std::path::Path) -> InMemoryEntit
     store
 }
 
+/// Execute a single LLM turn, handling any tool calls and appending results to `messages`.
+///
+/// Returns `true` if the conversation should continue (tool calls were made),
+/// or `false` if the model produced a final text response.
+async fn execute_turn(
+    provider: &OllamaProvider,
+    tool_registry: &ToolRegistry,
+    model: &str,
+    temperature: f32,
+    enable_tools: bool,
+    messages: &mut Vec<ChatMessage>,
+) -> Result<bool, Box<dyn std::error::Error>> {
+    let mut request = ChatRequest::new(model, messages.clone()).with_temperature(temperature);
+    if enable_tools {
+        request = request.with_tools(tool_registry.get_definitions());
+    }
+
+    let response = provider.chat(request).await?;
+    let choice = &response.choices[0];
+
+    if let Some(content) = &choice.message.content {
+        println!("Assistant: {}", content);
+    }
+
+    if let Some(tool_calls) = &choice.message.tool_calls {
+        println!("\n[Tool calls]");
+        for tool_call in tool_calls {
+            println!(
+                "  Calling {}: {:?}",
+                tool_call.function.name, tool_call.function.arguments
+            );
+            let result_text = match tool_registry
+                .execute(&tool_call.function.name, tool_call.function.arguments.clone())
+                .await
+            {
+                Ok(result) => {
+                    println!("  -> {}", result);
+                    result.to_string()
+                }
+                Err(e) => {
+                    error!("Tool execution failed: {}", e);
+                    format!("Error: {}", e)
+                }
+            };
+            messages.push(choice.message.clone());
+            messages.push(ChatMessage::tool_response(tool_call.id.clone(), result_text));
+        }
+        println!();
+        return Ok(true);
+    }
+
+    messages.push(choice.message.clone());
+    Ok(false)
+}
+
 async fn single_chat(
     provider: &OllamaProvider,
     tool_registry: &ToolRegistry,
@@ -189,62 +240,9 @@ async fn single_chat(
     temperature: f32,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let mut messages = vec![ChatMessage::user(prompt)];
-
-    loop {
-        let mut request = ChatRequest::new(model, messages.clone()).with_temperature(temperature);
-
-        if enable_tools {
-            let tool_definitions = tool_registry.get_definitions();
-            request = request.with_tools(tool_definitions);
-        }
-
-        let response = provider.chat(request).await?;
-        let choice = &response.choices[0];
-
-        if let Some(content) = &choice.message.content {
-            println!("Assistant: {}", content);
-        }
-
-        if let Some(tool_calls) = &choice.message.tool_calls {
-            println!("\nTool calls:");
-            for tool_call in tool_calls {
-                println!(
-                    "  Calling {}: {:?}",
-                    tool_call.function.name, tool_call.function.arguments
-                );
-
-                match tool_registry
-                    .execute(
-                        &tool_call.function.name,
-                        tool_call.function.arguments.clone(),
-                    )
-                    .await
-                {
-                    Ok(result) => {
-                        println!("  Result: {}", result);
-                        messages.push(choice.message.clone());
-                        messages.push(ChatMessage::tool_response(
-                            tool_call.id.clone(),
-                            result.to_string(),
-                        ));
-                    }
-                    Err(e) => {
-                        error!("Tool execution failed: {}", e);
-                        messages.push(choice.message.clone());
-                        messages.push(ChatMessage::tool_response(
-                            tool_call.id.clone(),
-                            format!("Error: {}", e),
-                        ));
-                    }
-                }
-            }
-
-            continue;
-        }
-
-        break;
-    }
-
+    while execute_turn(provider, tool_registry, model, temperature, enable_tools, &mut messages)
+        .await?
+    {}
     Ok(())
 }
 
@@ -286,63 +284,9 @@ async fn interactive_chat(
         }
 
         messages.push(ChatMessage::user(input));
-
-        loop {
-            let mut request =
-                ChatRequest::new(model, messages.clone()).with_temperature(temperature);
-
-            if enable_tools {
-                let tool_definitions = tool_registry.get_definitions();
-                request = request.with_tools(tool_definitions);
-            }
-
-            let response = provider.chat(request).await?;
-            let choice = &response.choices[0];
-
-            if let Some(content) = &choice.message.content {
-                println!("Assistant: {}", content);
-            }
-
-            if let Some(tool_calls) = &choice.message.tool_calls {
-                println!("\n[Tool calls]");
-                for tool_call in tool_calls {
-                    println!(
-                        "  Calling {}: {:?}",
-                        tool_call.function.name, tool_call.function.arguments
-                    );
-
-                    match tool_registry
-                        .execute(
-                            &tool_call.function.name,
-                            tool_call.function.arguments.clone(),
-                        )
-                        .await
-                    {
-                        Ok(result) => {
-                            println!("  -> {}", result);
-                            messages.push(choice.message.clone());
-                            messages.push(ChatMessage::tool_response(
-                                tool_call.id.clone(),
-                                result.to_string(),
-                            ));
-                        }
-                        Err(e) => {
-                            error!("Tool execution failed: {}", e);
-                            messages.push(choice.message.clone());
-                            messages.push(ChatMessage::tool_response(
-                                tool_call.id.clone(),
-                                format!("Error: {}", e),
-                            ));
-                        }
-                    }
-                }
-                println!();
-                continue;
-            }
-
-            messages.push(choice.message.clone());
-            break;
-        }
+        while execute_turn(provider, tool_registry, model, temperature, enable_tools, &mut messages)
+            .await?
+        {}
     }
 
     Ok(())
@@ -411,12 +355,10 @@ async fn run_agent(
     verbose: bool,
     tools: bool,
     workspace_root: &std::path::Path,
+    provider: Arc<OllamaProvider>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     use harness::agent::{AgentConfig, AgentContext, AgentLoop};
-    use std::sync::Arc;
 
-    let config = OllamaConfig::default();
-    let provider = Arc::new(OllamaProvider::new(config)?);
     let entity_store = initialize_workspace(workspace_root).await;
 
     let agent_config = AgentConfig {
@@ -440,7 +382,7 @@ async fn run_agent(
     }
 
     let mut agent = if tools {
-        let tool_registry = create_tool_registry(workspace_root);
+        let tool_registry = harness::tools::create_tool_registry(workspace_root);
         AgentLoop::with_tools(agent_config, entity_store, provider, tool_registry)
     } else {
         AgentLoop::with_llm(agent_config, entity_store, provider)
@@ -478,13 +420,11 @@ async fn run_agent(
 async fn run_mcp_server(
     model: &str,
     max_iterations: usize,
+    provider: Arc<OllamaProvider>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     use harness::mcp::NannaMcpServer;
     use harness::task::TaskManager;
-    use std::sync::Arc;
 
-    let config = OllamaConfig::default();
-    let provider = Arc::new(OllamaProvider::new(config)?);
     let task_manager = Arc::new(TaskManager::default());
 
     info!(


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Extract a single `execute_turn` helper that encapsulates one LLM request/response cycle (including tool dispatch), eliminating ~60 lines of duplicated code that was copy-pasted between `single_chat` and `interactive_chat`
- Build `OllamaProvider` once in `main` as `Arc<OllamaProvider>` and pass it down to `run_agent` and `run_mcp_server`, removing redundant provider construction calls inside each subcommand handler
- Remove the trivial `create_tool_registry` wrapper function that added indirection with no value

## Test plan

- [ ] `cargo build --workspace` passes
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings` passes
- [ ] `cargo nextest run --workspace --all-features` passes
- [ ] `harness chat --prompt "hello"` works end-to-end
- [ ] `harness agent --prompt "hello"` works end-to-end

https://claude.ai/code/session_015qvaT243enNQXYo7QXJudF
EOF
)