### PR TITLE
[nanna-coder] Clarity: Fix misleading stubs and remove duplicated documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,36 +1,6 @@
 # Agent Control Flow
 
-```mermaid
----
-config:
-  theme: redux-dark
-  layout: dagre
----
-flowchart TD
-    A(["Application State 1"]) --> n6["Entity Enrichment"]
-    n10(["User Prompt"]) --> n4["Plan Entity Modification"]
-    B{"Task Complete?"} --> C["Yes"] & D["No"]
-    D --> n1["Entity Modification Decision"]
-    n1 --> n3["Query Entities (RAG)"] & n4
-    n4 --> n7["Perform Entity Modification"]
-    C --> n9(["Application State 2"])
-    n3 --> n1
-    n7 --> n11["Update Entities"]
-    n11 --> B
-    n6 --> n4
-    n6@{ shape: rect}
-    n4@{ shape: rect}
-    n1@{ shape: diam}
-    n3@{ shape: rect}
-    n7@{ shape: rect}
-    n11@{ shape: rect}
-     A:::Rose
-     A:::Aqua
-     n10:::Aqua
-     n9:::Aqua
-    classDef Rose stroke-width:1px, stroke-dasharray:none, stroke:#FF5978, fill:#FFDFE5, color:#8E2236
-    classDef Aqua stroke-width:1px, stroke-dasharray:none, stroke:#46EDC8, fill:#DEFFF8, color:#378E7A
-```
+See the "Harness Control Flow" diagram in [ARCHITECTURE.md](ARCHITECTURE.md).
 
 # Agent State Machine
 

--- a/harness/src/agent/decision.rs
+++ b/harness/src/agent/decision.rs
@@ -1,15 +1,17 @@
-//! Entity Modification Decision logic for the agent (ARCHITECTURE.md)
+//! Entity Modification Decision (placeholder)
 //!
-//! This module implements the "Entity Modification Decision" node from the
-//! Harness Control Flow diagram: given the current entity state, decide
-//! whether to **Query Entities (RAG)** for more context or proceed to
-//! **Plan Entity Modification**.
+//! This module is a **stub** for the "Entity Modification Decision" node in the
+//! ARCHITECTURE.md Harness Control Flow diagram. The node decides whether the
+//! agent should query entities for more context (RAG) or proceed to plan the
+//! next modification.
 //!
-//! The implementation is currently a stub and needs further problem definition.
+//! The actual decision logic lives in [`crate::agent::prompts::DecisionPrompt`],
+//! which builds and parses QUERY/PROCEED LLM responses. This module will hold
+//! higher-level orchestration once the interface is stabilised.
 
 use thiserror::Error;
 
-/// Errors related to entity modification decisions
+/// Errors produced by entity modification decision logic.
 #[derive(Error, Debug)]
 pub enum DecisionError {
     #[error("Entity modification decision error: {0}")]
@@ -17,30 +19,3 @@ pub enum DecisionError {
 }
 
 pub type DecisionResult<T> = Result<T, DecisionError>;
-
-/// Entity Modification Decision (ARCHITECTURE.md)
-///
-/// Determine whether additional entity context is needed (query) or
-/// whether the agent can proceed to plan the next modification.
-///
-/// # Note
-/// This is a stub implementation that requires further problem definition.
-pub fn entity_modification_decision() -> DecisionResult<()> {
-    unimplemented!(
-        "Entity modification decision logic requires further problem definition. \
-         This should analyze context and determine next actions."
-    )
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    #[should_panic(
-        expected = "Entity modification decision logic requires further problem definition"
-    )]
-    fn test_entity_modification_decision_unimplemented() {
-        let _ = entity_modification_decision();
-    }
-}


### PR DESCRIPTION
## Summary

- Rewrite `harness/src/agent/decision.rs` module doc to honestly describe it as a placeholder stub; remove the `entity_modification_decision()` function that panicked with `unimplemented!()` and its accompanying test, keeping only `DecisionError` / `DecisionResult<T>` which will be needed when real orchestration logic is added
- Replace the copy-pasted "Agent Control Flow" flowchart in `AGENTS.md` with a one-line cross-reference to the canonical "Harness Control Flow" diagram in `ARCHITECTURE.md`, eliminating 30 lines of duplicated mermaid markup that would drift out of sync

## Test plan

- [ ] `cargo build --workspace` passes
- [ ] `cargo nextest run --workspace --all-features` passes (panicking stub test is removed, not just skipped)
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings` passes

https://claude.ai/code/session_015qvaT243enNQXYo7QXJudF