### PR TITLE
refactor(main): eliminate provider duplication and trivial wrapper

### DIFF
--- a/harness/src/main.rs
+++ b/harness/src/main.rs
@@ -2,9 +2,9 @@ use clap::{Parser, Subcommand};
 use harness::entities::ast::WorkspaceScanner;
 use harness::entities::git::GitRepository;
 use harness::entities::{EntityStore, InMemoryEntityStore};
-use harness::tools::ToolRegistry;
 use model::prelude::*;
 use std::io::{self, Write};
+use std::sync::Arc;
 use tracing::{error, info};
 
 #[derive(Parser)]
@@ -75,11 +75,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let cli = Cli::parse();
 
-    let config = OllamaConfig::default();
-    let provider = OllamaProvider::new(config)?;
+    let provider: Arc<dyn ModelProvider> = Arc::new(OllamaProvider::new(OllamaConfig::default())?);
 
     let workspace_root = std::env::current_dir()?;
-    let tool_registry = create_tool_registry(&workspace_root);
+    let tool_registry = harness::tools::create_tool_registry(&workspace_root);
 
     match cli.command {
         Commands::Chat {
@@ -135,6 +134,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 verbose,
                 tools,
                 &workspace_root,
+                Arc::clone(&provider),
             )
             .await?;
         }
@@ -142,15 +142,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             model,
             max_iterations,
         } => {
-            run_mcp_server(&model, max_iterations).await?;
+            run_mcp_server(&model, max_iterations, Arc::clone(&provider)).await?;
         }
     }
 
     Ok(())
-}
-
-fn create_tool_registry(workspace_root: &std::path::Path) -> ToolRegistry {
-    harness::tools::create_tool_registry(workspace_root)
 }
 
 async fn initialize_workspace(workspace_root: &std::path::Path) -> InMemoryEntityStore {
@@ -181,8 +177,8 @@ async fn initialize_workspace(workspace_root: &std::path::Path) -> InMemoryEntit
 }
 
 async fn single_chat(
-    provider: &OllamaProvider,
-    tool_registry: &ToolRegistry,
+    provider: &Arc<dyn ModelProvider>,
+    tool_registry: &harness::tools::ToolRegistry,
     model: &str,
     prompt: &str,
     enable_tools: bool,
@@ -249,8 +245,8 @@ async fn single_chat(
 }
 
 async fn interactive_chat(
-    provider: &OllamaProvider,
-    tool_registry: &ToolRegistry,
+    provider: &Arc<dyn ModelProvider>,
+    tool_registry: &harness::tools::ToolRegistry,
     model: &str,
     enable_tools: bool,
     temperature: f32,
@@ -348,7 +344,7 @@ async fn interactive_chat(
     Ok(())
 }
 
-async fn list_models(provider: &OllamaProvider) -> Result<(), Box<dyn std::error::Error>> {
+async fn list_models(provider: &Arc<dyn ModelProvider>) -> Result<(), Box<dyn std::error::Error>> {
     println!("Available models:");
     let models = provider.list_models().await?;
 
@@ -370,7 +366,7 @@ async fn list_models(provider: &OllamaProvider) -> Result<(), Box<dyn std::error
     Ok(())
 }
 
-fn list_tools(tool_registry: &ToolRegistry) {
+fn list_tools(tool_registry: &harness::tools::ToolRegistry) {
     println!("Available tools:");
     let tools = tool_registry.list_tools();
 
@@ -386,7 +382,7 @@ fn list_tools(tool_registry: &ToolRegistry) {
     }
 }
 
-async fn health_check(provider: &OllamaProvider) -> Result<(), Box<dyn std::error::Error>> {
+async fn health_check(provider: &Arc<dyn ModelProvider>) -> Result<(), Box<dyn std::error::Error>> {
     println!("Performing health check...");
 
     match provider.health_check().await {
@@ -411,12 +407,10 @@ async fn run_agent(
     verbose: bool,
     tools: bool,
     workspace_root: &std::path::Path,
+    provider: Arc<dyn ModelProvider>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     use harness::agent::{AgentConfig, AgentContext, AgentLoop};
-    use std::sync::Arc;
 
-    let config = OllamaConfig::default();
-    let provider = Arc::new(OllamaProvider::new(config)?);
     let entity_store = initialize_workspace(workspace_root).await;
 
     let agent_config = AgentConfig {
@@ -440,7 +434,7 @@ async fn run_agent(
     }
 
     let mut agent = if tools {
-        let tool_registry = create_tool_registry(workspace_root);
+        let tool_registry = harness::tools::create_tool_registry(workspace_root);
         AgentLoop::with_tools(agent_config, entity_store, provider, tool_registry)
     } else {
         AgentLoop::with_llm(agent_config, entity_store, provider)
@@ -478,13 +472,11 @@ async fn run_agent(
 async fn run_mcp_server(
     model: &str,
     max_iterations: usize,
+    provider: Arc<dyn ModelProvider>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     use harness::mcp::NannaMcpServer;
     use harness::task::TaskManager;
-    use std::sync::Arc;
 
-    let config = OllamaConfig::default();
-    let provider = Arc::new(OllamaProvider::new(config)?);
     let task_manager = Arc::new(TaskManager::default());
 
     info!(


### PR DESCRIPTION
## Summary

This PR makes three targeted improvements to `harness/src/main.rs` with no new dependencies or logic changes.

### Action items

- **Remove `create_tool_registry` wrapper function** — the function was a one-liner that only called `harness::tools::create_tool_registry`. It added an indirection layer with no semantic value (no error handling, no transformation, not even a doc comment). All three call-sites now call the underlying function directly. This removes 4 lines of dead indirection.

- **Eliminate duplicate `OllamaProvider` initialization** — `main()` constructed `OllamaProvider::new(OllamaConfig::default())` for `Chat`/`Models`/`Health` commands, but `run_agent` and `run_mcp_server` each silently constructed their *own* `OllamaProvider::new(OllamaConfig::default())`, ignoring the one from `main()`. This meant the `Agent` and `McpServe` subcommands always paid the construction cost twice. The fix creates a single `Arc<dyn ModelProvider>` at startup and threads it through both functions.

- **Unify `Arc` and `ModelProvider` trait usage** — with the above change, `Arc<dyn ModelProvider>` replaces the concrete `OllamaProvider` in all helper-function signatures. This is also a step toward the architecture's stated goal of provider-agnosticism (the concrete type is now only named once, at the top of `main()`). The `use std::sync::Arc` import moves from inside individual `async fn` bodies to the module level, and the now-unused `use harness::tools::ToolRegistry` import is dropped.

### What was reviewed but not changed

- `monitoring.rs`, `observability.rs`, `telemetry.rs` — These three modules (~107 KB combined) contain stub implementations with mostly-hardcoded values. They are referenced by `agent/eval.rs`, so they cannot be safely removed at this time. The evaluation framework's use of `ObservabilitySystem` is guarded by `collect_observability: false` in all test configurations, so the stubs never cause false signals in CI. These are candidates for a future refactor once the evaluation path matures.
- No changes to `lib.rs` re-exports, entity definitions, MCP protocol implementation, or test files.

https://claude.ai/code/session_018Uk9aCCyjsv4r1aGQr7SV7