### PR TITLE
fix: arch compliance — trait abstraction, DRY, explicit public API

### DIFF
--- a/harness/src/main.rs
+++ b/harness/src/main.rs
@@ -4,6 +4,7 @@ use harness::entities::git::GitRepository;
 use harness::entities::{EntityStore, InMemoryEntityStore};
 use harness::tools::ToolRegistry;
 use model::prelude::*;
+use model::provider::ModelProvider;
 use std::io::{self, Write};
 use tracing::{error, info};
 
@@ -180,8 +181,8 @@ async fn initialize_workspace(workspace_root: &std::path::Path) -> InMemoryEntit
     store
 }
 
-async fn single_chat(
-    provider: &OllamaProvider,
+async fn single_chat<P: ModelProvider>(
+    provider: &P,
     tool_registry: &ToolRegistry,
     model: &str,
     prompt: &str,
@@ -248,8 +249,8 @@ async fn single_chat(
     Ok(())
 }
 
-async fn interactive_chat(
-    provider: &OllamaProvider,
+async fn interactive_chat<P: ModelProvider>(
+    provider: &P,
     tool_registry: &ToolRegistry,
     model: &str,
     enable_tools: bool,
@@ -348,7 +349,9 @@ async fn interactive_chat(
     Ok(())
 }
 
-async fn list_models(provider: &OllamaProvider) -> Result<(), Box<dyn std::error::Error>> {
+async fn list_models<P: ModelProvider>(
+    provider: &P,
+) -> Result<(), Box<dyn std::error::Error>> {
     println!("Available models:");
     let models = provider.list_models().await?;
 
@@ -386,16 +389,18 @@ fn list_tools(tool_registry: &ToolRegistry) {
     }
 }
 
-async fn health_check(provider: &OllamaProvider) -> Result<(), Box<dyn std::error::Error>> {
+async fn health_check<P: ModelProvider>(
+    provider: &P,
+) -> Result<(), Box<dyn std::error::Error>> {
     println!("Performing health check...");
 
     match provider.health_check().await {
         Ok(()) => {
-            println!("✓ Health check passed. Ollama is running and accessible.");
+            println!("\u{2713} Health check passed. Ollama is running and accessible.");
             info!("Health check successful");
         }
         Err(e) => {
-            println!("✗ Health check failed: {}", e);
+            println!("\u{2717} Health check failed: {}", e);
             error!("Health check failed: {}", e);
             return Err(e.into());
         }

--- a/model/src/config.rs
+++ b/model/src/config.rs
@@ -23,10 +23,6 @@ impl Default for OllamaConfig {
 }
 
 impl OllamaConfig {
-    pub fn new() -> Self {
-        Self::default()
-    }
-
     pub fn with_base_url(mut self, base_url: impl Into<String>) -> Self {
         self.base_url = base_url.into();
         self
@@ -115,7 +111,7 @@ mod tests {
 
     #[test]
     fn test_config_builder() {
-        let config = OllamaConfig::new()
+        let config = OllamaConfig::default()
             .with_base_url("https://api.example.com")
             .with_context_length(50_000)
             .with_temperature(0.5)

--- a/model/src/lib.rs
+++ b/model/src/lib.rs
@@ -17,11 +17,15 @@ pub use types::{
 pub use ollama::OllamaProvider;
 
 pub mod prelude {
-    pub use crate::config::*;
-    pub use crate::judge::*;
-    pub use crate::provider::*;
-    pub use crate::types::*;
+    pub use crate::config::{ModelDefaults, OllamaConfig};
+    pub use crate::judge::{JudgeConfig, ModelJudge, ValidationCriteria, ValidationMetrics, ValidationResult};
+    pub use crate::provider::{ModelError, ModelProvider, ModelResult, StreamingModelProvider};
+    pub use crate::types::{
+        ChatMessage, ChatRequest, ChatResponse, Choice, FinishReason, FunctionCall,
+        FunctionDefinition, JsonSchema, MessageRole, ModelInfo, PropertySchema, SchemaType,
+        ToolCall, ToolChoice, ToolDefinition, Usage,
+    };
 
     #[cfg(feature = "ollama")]
-    pub use crate::ollama::*;
+    pub use crate::ollama::OllamaProvider;
 }


### PR DESCRIPTION
## Summary

Audit of the codebase against ARCHITECTURE.md / AGENTS.md / TESTING.md guidelines. Three clear violations fixed; no behaviour changes.

---

## Violations found and fixed

### 1. Harness helper functions bypassed the `ModelProvider` abstraction (`harness/src/main.rs`)

**Violation:** `single_chat`, `interactive_chat`, `list_models`, and `health_check` all accepted `&OllamaProvider` (the concrete Ollama implementation) instead of the `ModelProvider` trait. This couples the harness binary directly to the Ollama provider, contradicting the layered architecture shown in ARCHITECTURE.md where the Harness Queries the Model through an abstraction boundary, not a concrete type.

**Fix:** Changed each function to a generic `<P: ModelProvider>` bound. The `main` function still constructs `OllamaProvider` at the single entry point (as it should), but all helper logic now works against the trait.

---

### 2. `OllamaConfig::new()` was a one-line alias for `Default::default()` (`model/src/config.rs`)

**Violation:** The project's architecture docs and Rust idiom both establish that types implement `Default` as the canonical zero-argument constructor. `OllamaConfig::new()` was a public method that contained only `Self::default()`, adding a second name for the same operation. This violates the DRY principle stated throughout the project docs.

**Fix:** Removed `OllamaConfig::new()`. The one call-site in `test_config_builder` that used `.new()` is updated to use `.default()`. All other call-sites already used `OllamaConfig::default()`.

---

### 3. `model::prelude` used glob re-exports (`pub use crate::config::*`) (`model/src/lib.rs`)

**Violation:** The `prelude` module used `pub use crate::config::*`, `pub use crate::judge::*`, etc. Glob re-exports make the public API surface implicit — it is impossible to audit what is exported without reading every source module. The architecture documents a clean, explicit model crate API.

**Fix:** Replaced each glob with the same explicit item list already used in the top-level `lib.rs` re-exports. The exported items are unchanged; only the form of the re-export is explicit now.

---

## What was not changed

- No behaviour changes.
- No new features.
- `harness/Cargo.toml` still lists `reqwest` as a direct dependency (used in `tools.rs` for HTTP-based tool calls). Removing it would require a larger refactor of the tool layer and is a separate concern.
- `monitoring.rs`, `observability.rs`, and `telemetry.rs` overlap significantly (three separate systems doing metrics/health/tracing). This is worth consolidating in a follow-up, but the overlap pre-dates any documented guideline specifying which should be the canonical module, so no change was made here.

https://claude.ai/code/session_01TEgxmgXgnN2ByXi3WWLYcp