### PR TITLE
eval: switch CI E2E model to gemma4:e4b

### DIFF
--- a/harness/tests/dev_container_integration.rs
+++ b/harness/tests/dev_container_integration.rs
@@ -17,7 +17,7 @@ use tokio::time::timeout;
 const MAX_ATTEMPTS: usize = 5;
 const MAX_TURNS: usize = 32;
 const TEST_TIMEOUT: Duration = Duration::from_secs(600);
-const E2E_MODEL: &str = "qwen3:0.6b";
+const E2E_MODEL: &str = "gemma4:e4b";
 
 fn example_repo_path() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))

--- a/harness/tests/integration_tests.rs
+++ b/harness/tests/integration_tests.rs
@@ -27,7 +27,7 @@ use tokio::time::{sleep, timeout};
 // use futures::future; // Reserved for future concurrent test implementation
 
 // E2E test configuration
-const E2E_MODEL: &str = "qwen3:0.6b";
+const E2E_MODEL: &str = "gemma4:e4b";
 const E2E_TIMEOUT: Duration = Duration::from_secs(300);
 const CONTAINER_STARTUP_WAIT: Duration = Duration::from_secs(30);
 const HEALTH_CHECK_TIMEOUT: Duration = Duration::from_secs(60);

--- a/harness/tests/nanna_self_dev_integration.rs
+++ b/harness/tests/nanna_self_dev_integration.rs
@@ -17,7 +17,7 @@ use tokio::time::timeout;
 const MAX_ATTEMPTS: usize = 5;
 const MAX_TURNS: usize = 32;
 const TEST_TIMEOUT: Duration = Duration::from_secs(600);
-const E2E_MODEL: &str = "qwen3:0.6b";
+const E2E_MODEL: &str = "gemma4:e4b";
 const ORIGINAL_HELP_STRING: &str = "A CLI tool for interacting with language models";
 
 fn workspace_root() -> PathBuf {

--- a/nix/containers.nix
+++ b/nix/containers.nix
@@ -211,11 +211,11 @@ let
       homepage = "https://ollama.com/library/mistral";
     };
     "gemma" = {
-      name = "gemma:2b";
+      name = "gemma4:e4b";
       hash = "sha256-0000000000000000000000000000000000000000000="; # Placeholder
-      description = "Gemma 2B - Lightweight model for development (Ollama)";
-      size = "1.4GB";
-      homepage = "https://ollama.com/library/gemma";
+      description = "Gemma 4 E4B - Larger Gemma 4 variant for CI evaluation (Ollama)";
+      size = "~4GB";
+      homepage = "https://ollama.com/library/gemma4";
     };
   };
 


### PR DESCRIPTION
## Summary

- Updates `E2E_MODEL` in all three integration test suites (`integration_tests.rs`, `dev_container_integration.rs`, `nanna_self_dev_integration.rs`) from `qwen3:0.6b` to `gemma4:e4b`
- Updates the `gemma` entry in the model registry (`nix/containers.nix`) to `gemma4:e4b`

## Purpose

Evaluating whether CI passes with the larger `gemma4:e4b` model. This is a draft PR — merge only once CI results confirm the model works end-to-end.

## Test plan

- [ ] `integration-container` job passes with `gemma4:e4b` pulling and responding correctly
- [ ] `dev_container_integration` tests pass
- [ ] `nanna_self_dev_integration` tests pass
- [ ] No regressions in unit/lint/security jobs