### PR TITLE
refactor(harness/main): eliminate redundant provider constructions and duplicated tool-call dispatch; add tool unit tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,20 +6,20 @@ Thank you for your interest in contributing!
 
 // TODO https://github.com/DominicBurkart/nanna-coder/issues/175
 
-## Testing 
+## Testing
 
 See [TESTING.md](./TESTING.md)
 
 ## License
 
-All contributions fall under the [project license](./LICENSE). 
+All contributions fall under the [project license](./LICENSE).
 
-## Github Issues
+## GitHub Issues
 
-If an issue is *entirely* completed with a PR, include `Closes #<issue numer>` (example: "closes #10") in the PR description ([github linking docs](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue)). 
+If an issue is *entirely* completed with a PR, include `Closes #<issue number>` in the PR description ([GitHub docs](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue)).
 
-Otherwise, you can comment on the issue with a link to your PR and highlight the remaining completion work in the PR description. 
+Otherwise, comment on the issue with a link to your PR and note any remaining work in the PR description.
 
 ## Architectural Changes
 
-Changes to the current architecture as [documented](https://github.com/DominicBurkart/nanna-coder/blob/main/ARCHITECTURE.md) must be introduced in the form of a Github Issue and approved. Incidental architectural changes (for example, to unblock a feature PR) are inappropriate and should be flagged during review.
+Changes to the [current architecture](ARCHITECTURE.md) must be introduced as a GitHub Issue and approved before implementation. Incidental architectural changes (e.g., to unblock a feature PR) are inappropriate and should be flagged during review.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Nanna Coder
 
-A coding agent for coding agents. Designed for background agents to defer straightforward work to local models or by other model providers.
+A coding agent for coding agents. Designed for background agents to defer straightforward work to local models or other model providers.
 
 ## Documentation
 
@@ -9,6 +9,7 @@ A coding agent for coding agents. Designed for background agents to defer straig
 - [TESTING.md](TESTING.md) - Testing strategy and guidelines
 
 ## Technologies
+
 - [Ollama](https://ollama.ai/)
 - [Nix](https://nixos.org/)
 - [Podman](https://podman.io/)
@@ -18,26 +19,22 @@ A coding agent for coding agents. Designed for background agents to defer straig
 ## Quick Start
 
 ### Prerequisites
+
 - Nix with flakes enabled
 - (Optional) Cachix account for faster builds
 
 ### Setup
 
 ```bash
-# Clone the repository
 git clone https://github.com/DominicBurkart/nanna-coder.git
 cd nanna-coder
-
-# Enter development environment
 nix develop
-
-# Build the project
 nix build
 ```
 
 ### LLM Setup (Ollama)
 
-The agent requires a running [Ollama](https://ollama.ai/) instance with a model installed:
+The agent requires a running [Ollama](https://ollama.ai/) instance:
 
 ```bash
 # Install Ollama (see https://ollama.ai/download)
@@ -53,10 +50,9 @@ nix develop --command cargo run --bin harness -- health
 ### Running the Agent
 
 ```bash
-# Enter development environment
 nix develop
 
-# Run the agent with tools enabled (recommended)
+# Run with tools enabled (recommended)
 cargo run --bin harness -- agent --prompt "Your task description" --tools
 
 # Run with a specific model and verbose output
@@ -69,13 +65,12 @@ cargo run --bin harness -- agent --prompt "Your task" --model qwen3:0.6b --tools
 nix develop --command cargo build --release --bin harness && claude mcp add nanna -- "$(pwd)/target/release/harness" mcp-serve --model gemma4:e4b
 ```
 
-### Using Cachix (Optional but Recommended)
+### Cachix (Optional)
 
-Cachix provides a public binary cache for faster builds. No account needed to pull pre-built artifacts.
+Pull pre-built artifacts without an account:
 
 ```bash
-# Configure Cachix for faster builds (read-only access)
 nix run .#setup-cache
 ```
 
-See [CACHIX_SETUP.md](CACHIX_SETUP.md) for push access setup (maintainers only).
+See [CACHIX_SETUP.md](CACHIX_SETUP.md) for push access (maintainers only).

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,93 +1,55 @@
-# Testing Guide for Nanna Coder
-
-This document provides comprehensive instructions for running tests locally in the nanna-coder project.
+# Testing Guide
 
 ## Contributing
 
 When adding new tests:
 
 1. Create test scripts in the appropriate directory (`tests/security/`, `tests/integration/`, etc.)
-2. Use the shared test helpers from `tests/lib/test-helpers.sh`
+2. Use shared helpers from `tests/lib/test-helpers.sh`
 3. Make scripts executable: `chmod +x tests/path/to/test.sh`
 4. Add your test to `tests/run-all-tests.sh`
-5. Update this TESTING.md document
+5. Update this document
 6. Ensure tests pass locally before submitting a PR
 
 ## Test Philosophy
 
-This project follows these testing principles:
-
-1. **Fail Fast**: Tests exit immediately on critical failures (dependencies, environment)
-2. **Modular**: Tests are split into focused, single-responsibility scripts
-3. **Reproducible**: All tests run in a hermetic Nix environment
-4. **Comprehensive**: Security tests cover traditional tools, AI analysis, and supply chain validation
-5. **CI/CD Ready**: All tests are designed to run in GitHub Actions
+1. **Fail Fast**: Exit immediately on critical failures (missing dependencies, bad environment)
+2. **Modular**: Focused, single-responsibility scripts
+3. **Reproducible**: Hermetic Nix environment
+4. **Comprehensive**: Security tests cover traditional tools, AI analysis, and supply chain
+5. **CI/CD Ready**: All tests run in GitHub Actions
 
 ## Prerequisites
 
-### Required Dependencies
-
-All tests must be run from within the Nix development shell. The following dependencies are required:
-
-- **nix** - Nix package manager (required)
-- **jq** - JSON processor (required)
-- **curl** - HTTP client (required)
-- **cargo** - Rust build tool (required)
-- **podman** - Container runtime (required for integration tests)
-- **vulnix** - Nix vulnerability scanner (required for security tests)
-
-### Entering the Development Shell
+All tests must run inside the Nix development shell:
 
 ```bash
-# Enter the Nix development shell
 nix develop
-
-# Verify you're in the shell
 echo $IN_NIX_SHELL  # Should output "1" or "pure"
 ```
 
+Required tools (all provided by `nix develop`):
+
+- **nix**, **jq**, **curl**, **cargo**, **podman**, **vulnix**
+
 ## Quick Start
-
-### Run All Tests
-
-From the project root directory (inside the Nix shell):
 
 ```bash
 # Run all test suites
 ./tests/run-all-tests.sh
-```
 
-### Run Specific Test Suites
-
-```bash
-# Dependency checks
+# Run individual suites
 ./tests/security/test-dependencies.sh
-
-# Environment validation
 ./tests/security/test-environment.sh
-
-# Security tool availability
 ./tests/security/test-tools-availability.sh
-
-# Traditional security checks (cargo-deny, cargo-audit)
 ./tests/security/test-traditional-security.sh
-
-# Behavioral security testing
 ./tests/security/test-behavioral-security.sh
-
-# AI-powered security analysis (requires Ollama)
 ./tests/security/test-ai-security.sh
-
-# Provenance validation
 ./tests/integration/test-provenance.sh
-
-# Build system integration
 ./tests/integration/test-build-system.sh
 ```
 
 ## Test Structure
-
-The test suite is organized into modular components:
 
 ```
 tests/
@@ -96,69 +58,51 @@ tests/
 ├── security/
 │   ├── test-dependencies.sh     # Dependency verification
 │   ├── test-environment.sh      # Environment setup validation
-│   ├── test-tools-availability.sh    # Security tools availability
+│   ├── test-tools-availability.sh
 │   ├── test-traditional-security.sh  # cargo-deny, cargo-audit
-│   ├── test-behavioral-security.sh   # Behavioral tests
-│   └── test-ai-security.sh           # AI-powered security analysis
+│   ├── test-behavioral-security.sh
+│   └── test-ai-security.sh
 ├── integration/
 │   ├── test-provenance.sh       # Supply chain validation
-│   └── test-build-system.sh     # Build system checks
-└── run-all-tests.sh             # Main test runner
+│   └── test-build-system.sh
+└── run-all-tests.sh
 ```
 
-## Running Tests
-
-```bash
-# Run only dependency checks
-cd /path/to/nanna-coder
-nix develop
-./tests/security/test-dependencies.sh
-
-# Run only traditional security tests
-./tests/security/test-traditional-security.sh
-```
-
-### CI/CD Pipeline
-
-The CI pipeline runs tests automatically on push and pull requests:
+## CI/CD Pipeline
 
 - **Unit tests**: `cargo nextest run --workspace --lib`
 - **Integration tests**: `nix run .#container-test`
-- **Lint checks**: `cargo clippy` and `cargo fmt`
-- **Security checks**: `cargo audit`, `cargo deny check`, `cargo tarpaulin`
+- **Lint**: `cargo clippy`, `cargo fmt`
+- **Security**: `cargo audit`, `cargo deny check`, `cargo tarpaulin`
 
 ## Security Tooling
 
-**Configuration**: `deny.toml` in project root
+### cargo-deny
 
-**Usage**:
+Configuration: `deny.toml`
+
 ```bash
-cargo deny check           # Run all checks
-cargo deny check advisories  # Only vulnerability checks
-cargo deny check licenses    # Only license compliance
-cargo deny check bans        # Only banned dependencies
+cargo deny check             # All checks
+cargo deny check advisories  # Vulnerability checks only
+cargo deny check licenses    # License compliance only
+cargo deny check bans        # Banned dependencies only
 ```
 
-#### cargo-audit
+### cargo-audit
 
-**Usage**:
 ```bash
-cargo audit               # Check for vulnerabilities
-cargo audit --json        # JSON output
+cargo audit         # Check for vulnerabilities
+cargo audit --json  # JSON output
 ```
 
-### AI Security Tools
-
-When Ollama is running, additional AI-powered security analysis is available:
+### AI Security Tools (requires Ollama)
 
 ```bash
-# Start Ollama service
+# Terminal 1: start Ollama
 nix run .#container-dev
 
-# Wait for service to be ready
-curl http://localhost:11434/api/tags
-
-# Run AI security analysis
+# Terminal 2: run AI security analysis
+curl http://localhost:11434/api/tags  # wait for readiness
 nix run .#security-judge
 nix run .#threat-model-analysis
 nix run .#dependency-risk-profile
@@ -168,95 +112,29 @@ nix run .#adaptive-vulnix-scan
 ### Provenance and Supply Chain
 
 ```bash
-# Validate Nix package provenance
 nix run .#nix-provenance-validator
-
-# Check for Nix-specific vulnerabilities
 vulnix --system
 ```
 
 ## Troubleshooting
 
-### Common Issues
-
-#### "Not in Nix development shell"
-
-**Solution**: Run `nix develop` before executing tests
+All common issues (missing `podman`, `vulnix`, Ollama not running, behavioral test timeouts) are solved by ensuring you are inside the Nix development shell:
 
 ```bash
 nix develop
-./tests/run-all-tests.sh
 ```
 
-#### "podman not available"
-
-The test suite now requires podman for container-based tests.
-
-**Solution**: Ensure you're in the Nix development shell (podman is provided automatically):
-
-```bash
-nix develop
-command -v podman  # Should output: /nix/store/.../bin/podman
-```
-
-#### "vulnix not available"
-
-The test suite now requires vulnix for Nix vulnerability scanning.
-
-**Solution**: Ensure you're in the Nix development shell:
-
-```bash
-nix develop
-command -v vulnix  # Should output: /nix/store/.../bin/vulnix
-```
-
-#### "Ollama not running"
-
-AI-powered tests require Ollama to be running.
-
-**Solution**:
-
-```bash
-# Terminal 1: Start Ollama
-nix run .#container-dev
-
-# Terminal 2: Wait for readiness, then run tests
-curl http://localhost:11434/api/tags
-./tests/security/test-ai-security.sh
-```
-
-#### "Behavioral security test timed out"
-
-Behavioral tests can take 2-3 minutes.
-
-**Solution**: This is expected for the first run. Subsequent runs should be faster due to caching.
-
-### Test Failures
-
-If tests fail:
-
-1. Check that all prerequisites are installed (run dependency check)
-2. Ensure you're in the project root directory
-3. Verify you're in the Nix development shell
-4. Check network connectivity (some tests download data)
-5. Review the specific test output for detailed error messages
-
-### CI/CD Debugging
+The shell provides `podman`, `vulnix`, and all other required tools. Behavioral security tests can take 2-3 minutes on the first run; subsequent runs are faster due to caching.
 
 If tests pass locally but fail in CI:
 
-1. Check the GitHub Actions workflow logs
+1. Check GitHub Actions workflow logs
 2. Verify the CI environment has all required tools
-3. Check for platform-specific issues (Linux vs macOS vs Windows)
+3. Check for platform-specific issues
 4. Review cache status (cache misses can cause timeouts)
 
 ## Additional Resources
 
-- [CI/CD Pipeline](.github/workflows/ci.yml) - Full CI configuration
-- [Nix Flake](flake.nix) - Development environment and security tools
-- [cargo-deny Configuration](deny.toml) - Security and compliance rules
-- [AGENTIC-SECURITY.md](AGENTIC-SECURITY.md) - AI-powered security architecture (if available)
-
----
-
-For questions or issues with testing, please open a GitHub issue or consult the CI/CD logs.
+- [CI/CD Pipeline](.github/workflows/ci.yml)
+- [Nix Flake](flake.nix)
+- [cargo-deny Configuration](deny.toml)

--- a/framing/ci-caching.md
+++ b/framing/ci-caching.md
@@ -1,33 +1,28 @@
-GitHub Actions provides a caching mechanism through the official `actions/cache` action that can be used to cache dependencies and build outputs to speed up workflows. This caching can be used on GitHub-hosted runners as well as self-hosted runners.
+# CI Caching Options
 
-For small open-source projects using GitHub-hosted runners:
-- Caching is supported directly by GitHub Actions using `actions/cache` where cache keys can be based on OS, file hashes, or other parameters.
-- The cache is stored by GitHub, and there is a 10 GB cache size limit per repository.
-- This works well to avoid repeated downloads of dependencies and build artifacts during CI runs.
+## GitHub Actions (`actions/cache`)
 
-For self-hosted runners or ephemeral runners:
-- The cache is still uploaded/downloaded from GitHub's storage, which can be slower and introduce latency.
-- There are community requests and some experimental approaches to use local or cluster storage (e.g., persistent volumes or S3 storage) as cache backends, but this is not natively supported by GitHub Actions.
-- Some third-party tools or workarounds exist to help with local cache storage for self-hosted runners, but they require setup and aren't official GitHub features.
+- Supported on both GitHub-hosted and self-hosted runners
+- Cache is stored in GitHub's cloud storage (10 GB limit per repo)
+- Keys can be based on OS, file hashes, or arbitrary parameters
+- Works well for dependency and build artifact caching in small open-source projects
 
-Therefore, if the question is about having caching like Cachix (a dedicated caching service for Nix builds) but using only GitHub CI runners for a small open-source project, this is feasible using `actions/cache` on GitHub-hosted runners, with caching done via GitHub's storage. 
+## Self-Hosted / Ephemeral Runners
 
-However, if the desire is to have local caching on the runners themselves (to avoid GitHub cache storage overhead or to share cache across self-hosted runners without going to GitHub's cloud), that is not directly supported by GitHub Actions by default. Such local caching setups require additional infrastructure or third-party solutions.
+- Cache is still uploaded/downloaded from GitHub's cloud storage, which adds latency
+- Local or cluster-local cache backends (e.g., persistent volumes, S3) are **not** natively supported
+- Third-party tools exist for local cache storage but require custom setup
 
-In summary:
-- Yes, similar caching is possible with GitHub CI runners using the official cache action for dependencies/builds.
-- This caching is cloud cache maintained by GitHub, not local runner-level cache.
-- Local caching on self-hosted runners similar to Cachix would require custom setup or external tools.
+## Summary
 
-This matches common use for small open-source projects relying on GitHub's infrastructure for cache storage and speedup of CI runs.[4][5][9]
+| Scenario | Feasible? | Notes |
+|---|---|---|
+| Cache via `actions/cache` on GitHub-hosted runners | Yes | Standard approach; cache stored in GitHub cloud |
+| Local runner-level cache (like Cachix) | No (by default) | Requires custom infrastructure or external tools |
 
-[1](https://docs.gitlab.com/ci/caching/)
-[2](https://github.com/actions/actions-runner-controller/issues/2726)
-[3](https://www.reddit.com/r/github/comments/1d0hpmy/are_there_options_for_local_cacheartifacts_on/)
-[4](https://github.com/actions/cache)
-[5](https://github.com/orgs/community/discussions/18549)
-[6](https://docs.github.com/actions/using-github-hosted-runners/about-github-hosted-runners)
-[7](https://martijnhols.nl/blog/migrating-away-from-martijnhols-actions-cache)
-[8](https://depot.dev/blog/comparing-github-actions-and-depot-runners-for-2x-faster-builds)
-[9](https://docs.github.com/en/actions/reference/workflows-and-actions/dependency-caching)
-[10](https://synacktiv.com/publications/github-actions-exploitation-self-hosted-runners)
+For Nix-specific binary caching in CI, this project uses [Cachix](https://cachix.org/). See [CACHIX_SETUP.md](../CACHIX_SETUP.md).
+
+## References
+
+- [actions/cache](https://github.com/actions/cache)
+- [GitHub Actions dependency caching docs](https://docs.github.com/en/actions/reference/workflows-and-actions/dependency-caching)

--- a/framing/nix-packaging.md
+++ b/framing/nix-packaging.md
@@ -1,72 +1,19 @@
-<img src="https://r2cdn.perplexity.ai/pplx-full-logo-primary-dark%402x.png" style="height:64px;margin-right:32px"/>
+# Nix Packaging: Containerized Rust Apps with Podman
 
-# architecturally, how can I design a containerized rust application that manages all of its dependencies with Nix (including services e.g. ollama) while maintaining complete isolation from the runtime system?
+This document summarizes the architectural approach for building and distributing containerized Rust applications (including external services like Ollama) using Nix, with complete runtime isolation.
 
-To design a containerized Rust application that manages all dependencies with Nix (including external services like Ollama) while maintaining complete isolation from the runtime system, architecturally consider the following:
+## Core Approach
 
-### Using Nix to Manage Rust Dependencies
+- Build the Rust binary with `rustPlatform.buildRustPackage`, resolving all Cargo dependencies through Nix for reproducible builds.
+- Build a minimal OCI container image with Nix (`buildImage` / `buildLayeredImage`) containing the Rust binary and all runtime dependencies — no system packages, no external downloads at runtime.
+- Package external services (e.g., Ollama) as separate Nix-built containers; communicate over defined network interfaces.
+- Orchestrate multiple containers with **Podman pods** or **systemd + Quadlet**.
 
-- Use Nix's `buildRustPackage` (or `rustPlatform.buildRustPackage`) to build the Rust application. This allows packaging Rust crates with dependencies resolved and built fully through Nix rather than Cargo's internal downloader. It provides reproducible builds and binary caching benefits.
-- Integrate Cargo with Nix carefully, as Cargo by itself usually manages dependencies independently. Override the Rust compiler (`RUSTC`) or patch build flags to ensure dependency linking happens via Nix paths, not external downloads.
-- Lock dependencies through Cargo.lock and use Nix expressions to produce complete build environments for Rust projects, avoiding runtime dependency on Cargo or external services.[^1_1][^1_3][^1_4]
-
-
-### Container Isolation with Nix
-
-- Build the container image using Nix directly to have full control over the runtime environment and dependencies, ensuring nothing leaks in or out except explicitly allowed interfaces. This means no reliance on system-installed packages.
-- Bundle your Rust binary and all its required libraries inside the container image using Nix, avoiding runtime package manager commands or network fetches.
-- For complete isolation, also package external services like Ollama with Nix, ensuring their runtime dependencies are captured inside the environment. Use Nix's ability to define multiple services or packages together in one environment.
-- Use scratch or minimal base container images and layer the Nix-built runtime, forcing the container to run exactly the specified environment without external side effects or dependencies.[^1_2][^1_3]
-
-
-### Summary Architectural Approach
-
-- Use Nix flakes or nixpkgs to define the entire application's build and runtime dependency graph, including Rust crates and any external service dependencies.
-- Produce a Docker or OCI container fully from Nix build outputs, minimizing external runtime dependencies.
-- Configure services like Ollama as part of the Nix environment (e.g., systemd or service wrappers) inside the container to ensure isolation and manageability.
-- Ensure Rust compilation via `buildRustPackage` or custom overrides for Cargo to fit Nix's declarative model, providing full reproducibility and isolation.
-
-This approach yields a containerized Rust app fully isolated from the host runtime and managing all dependencies via Nix, including complex external services.
-
-If desired, I can provide example Nix expressions or Dockerfile snippets for this setup. Would that be helpful?
-<span style="display:none">[^1_10][^1_5][^1_6][^1_7][^1_8][^1_9]</span>
-
-<div style="text-align: center">⁂</div>
-
-[^1_1]: https://hadean.com/blog/managing-rust-dependencies-with-nix-part-i/
-
-[^1_2]: https://fasterthanli.me/series/building-a-rust-service-with-nix
-
-[^1_3]: https://dev.to/misterio/how-to-package-a-rust-app-using-nix-3lh3
-
-[^1_4]: https://hadean.com/blog/managing-rust-dependencies-with-nix-part-ii/
-
-[^1_5]: https://www.reddit.com/r/NixOS/comments/1fnh78r/could_rust_simply_use_nix_as_its_package_manager/
-
-[^1_6]: https://discourse.nixos.org/t/introducing-brioche-a-new-nix-like-package-manager-written-in-rust/46447
-
-[^1_7]: https://www.youtube.com/watch?v=Ss1IXtYnpsg
-
-[^1_8]: https://crates.io/crates/nix/dependencies
-
-[^1_9]: https://artemis.sh/2023/07/08/nix-rust-project-with-git-dependencies.html
-
-[^1_10]: https://discourse.nixos.org/t/how-do-i-install-rust/7491
-
-
----
-
-# Please do provide some examples (I use podman).
-
-Here is an example approach using Nix to build and containerize a Rust application with Podman while managing all dependencies including services, with complete runtime isolation.
-
-### Step 1: Define Rust project build with Nix
-
-Create a `flake.nix` using `buildRustPackage` to manage Rust dependencies and build the Rust binary fully reproducibly:
+## Example Nix Flake
 
 ```nix
 {
-  description = "Rust app with Nix and container";
+  description = "Rust app with Nix container";
 
   inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
 
@@ -80,11 +27,9 @@ Create a `flake.nix` using `buildRustPackage` to manage Rust dependencies and bu
         version = "0.1.0";
         src = ./.;
         cargoLock = ./Cargo.lock;
-        # Additional service deps e.g. Ollama can be added here with overlays or deps
       };
 
-      # Container image from this build
-      containerImages.${system}.myRustAppImage = pkgs.buildImage {
+      packages.${system}.myRustAppImage = pkgs.buildImage {
         name = "myrustapp-container";
         contents = [ self.packages.${system}.myRustApp ];
         config = {
@@ -96,152 +41,48 @@ Create a `flake.nix` using `buildRustPackage` to manage Rust dependencies and bu
 }
 ```
 
-
-### Step 2: Build the container image with Nix
-
-Build the Rust package and the container image:
+Build and run:
 
 ```bash
 nix build .#myRustApp
-nix build .#containerImages.x86_64-linux.myRustAppImage
-```
-
-This creates an OCI container image fully containing the Rust binary and all its dependencies managed by Nix.
-
-### Step 3: Run container with Podman
-
-Load and run the image with Podman (compatible with rootless Podman):
-
-```bash
+nix build .#myRustAppImage
 podman load < result
 podman run --rm -it myrustapp-container
 ```
 
+## Multi-Container Orchestration
 
-### Step 4: Managing external services (e.g., Ollama)
+### Podman Pods
 
-- If Ollama is available as a Nix package or can be packaged yourself, add it as a dependency in the flake and include its binaries and libs in the container image `contents`.
-- Alternatively, run Ollama as a separate Nix-built service container and communicate over defined network ports.
-- This maintains isolation, all services managed declaratively via Nix.
-
-***
-
-This architecture enables full build and runtime dependency control via Nix, produces an isolated container image with Podman, and supports extending to multi-service setups with Ollama fully dependency-captured in Nix.
-
-If requested, a specific example for packaging Ollama or multi-container orchestration under Nix can be supplied. This example is adaptable to Podman's rootless mode for local development and deployment.
-
-Would you like a detailed example of including Ollama or configuring the Nix build for multi-service container systems?Here is an example approach using Nix flakes and Podman to build and containerize your Rust application with full dependency management and isolation:
-
-```nix
-{
-  description = "Rust app with Nix container";
-
-  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
-
-  outputs = { self, nixpkgs }: let
-    system = "x86_64-linux";
-    pkgs = import nixpkgs { inherit system; };
-  in {
-    packages.${system}.myRustApp = pkgs.rustPlatform.buildRustPackage {
-      pname = "myRustApp";
-      version = "0.1.0";
-      src = ./.;
-      cargoLock = ./Cargo.lock;
-      # Add services like Ollama here as dependencies if available in nixpkgs
-    };
-
-    containerImages.${system}.myRustAppImage = pkgs.buildImage {
-      name = "myrustapp-container";
-      contents = [
-        self.packages.${system}.myRustApp
-        # add Ollama here if packaged
-      ];
-      config = {
-        Cmd = [ "${self.packages.${system}.myRustApp}/bin/myRustApp" ];
-        Env = [ "RUST_LOG=info" ];
-      };
-    };
-  };
-}
-```
-
-Build with:
+Containers in a pod share a network namespace and communicate over `localhost`:
 
 ```bash
-nix build .#myRustApp
-nix build .#containerImages.x86_64-linux.myRustAppImage
-```
-
-Then load and run the container image in Podman (rootless compatible):
-
-```bash
-podman load < result
-podman run --rm -it myrustapp-container
-```
-
-This design keeps your Rust app and all dependencies including external services (like Ollama, if added to `contents`) fully isolated and reproducible inside the container, managed declaratively by Nix.
-
-If you want, I can provide an example on how to package Ollama or orchestrate multiple Nix-built service containers. Just ask!
-<span style="display:none">[^2_1][^2_2][^2_3][^2_4][^2_5][^2_6][^2_7][^2_8]</span>
-
-<div style="text-align: center">⁂</div>
-
-[^2_1]: https://community.fly.io/t/running-reproducible-rust-a-fly-and-nix-love-story/3781
-
-[^2_2]: https://github.com/ES-Nix/podman-rootless
-
-[^2_3]: https://www.reddit.com/r/Nix/comments/1ai1vfo/best_way_to_run_podmandockercontainerd_in_a_nix/
-
-[^2_4]: https://discourse.nixos.org/t/rootless-podman-setup-with-home-manager/57905
-
-[^2_5]: https://nixcademy.com/posts/auto-update-containers/
-
-[^2_6]: https://fasterthanli.me/series/building-a-rust-service-with-nix/part-11
-
-[^2_7]: https://discourse.nixos.org/t/podman-docker-in-nixos-container-ideally-in-unprivileged-one/22909
-
-[^2_8]: https://github.com/containers/podman/discussions/25813
-
-
----
-
-# please do show how to orchestrate multiple containers!
-
-To orchestrate multiple containers (such as your Rust app and Ollama service) with Podman in a Nix-managed environment, you can use one of the following practical approaches:
-
-### 1. Podman Pods (Kubernetes-Compatible Pod Concept)
-
-- A Pod is a group of containers sharing the same network namespace and some resources.
-- You define a pod and add multiple containers (e.g., Rust app and Ollama) to it.
-- Containers in the pod can communicate via localhost and share volumes.
-
-Example CLI commands:
-
-```bash
-# Create a pod named 'app-pod'
 podman pod create --name app-pod -p 8080:8080
-
-# Add Rust app container to the pod
 podman create --pod app-pod --name rust-app myrustapp-container
-
-# Add Ollama container to the pod (replace with actual Ollama image packaged with Nix)
 podman create --pod app-pod --name ollama-service ollama-container
-
-# Start all containers in the pod
 podman pod start app-pod
 ```
 
-This allows running multiple isolated but network-shared containers with Podman rootless, keeping each container independently managed but grouped in one pod.[^3_2]
+### Systemd + Quadlet
 
-### 2. Systemd + Podman (with Quadlet for service orchestration)
+Quadlet creates systemd services from Podman container definitions.
 
-- Quadlet is a tool to create systemd services from Podman containers.
-- You create individual `.container` files describing each container and their configuration (ports, volumes, environment).
-- Systemd manages container lifecycles, with dependencies, automatic restarts, etc.
+`ollama-service.container`:
+```ini
+[Unit]
+Description=Ollama Service Container
 
-Example `rust-app.container` service:
+[Container]
+Image=ollama-container
+PublishPort=11434:11434
+Restart=always
 
+[Install]
+WantedBy=default.target
 ```
+
+`rust-app.container`:
+```ini
 [Unit]
 Description=Rust Application Container
 Requires=ollama-service.service
@@ -257,181 +98,32 @@ Environment=RUST_LOG=info
 WantedBy=default.target
 ```
 
-Example `ollama-service.container` service:
-
-```
-[Unit]
-Description=Ollama Service Container
-
-[Container]
-Image=ollama-container
-PublishPort=5000:5000
-Restart=always
-
-[Install]
-WantedBy=default.target
-```
-
-Enable and start these services:
-
 ```bash
 systemctl --user enable rust-app.service ollama-service.service
 systemctl --user start rust-app.service ollama-service.service
 ```
 
-They will run isolated but managed by systemd, with explicit dependency ordering and restart policies.[^3_1]
-
-***
-
-### How Nix fits in
-
-- Use Nix to build both your Rust app and Ollama containers with all dependencies.
-- Each container image is output from Nix and imported into Podman.
-- Use Nix to generate container configs or systemd service files if desired for full declarative control.
-- This creates a reproducible, isolated multi-container environment managed via Podman pods or systemd+Podman service orchestration.
-
-Would you prefer a specific example setup with Nix flakes to build both containers and generate pod or Quadlet configs? That would show a full reproducible orchestration pipeline.
-<span style="display:none">[^3_3][^3_4][^3_5][^3_6][^3_7][^3_8]</span>
-
-<div style="text-align: center">⁂</div>
-
-[^3_1]: https://blog.stackademic.com/awesome-container-orchestration-with-quadlet-podman-for-the-win-e4bce5dd217f
-
-[^3_2]: https://tomsitcafe.com/2023/12/01/container-pod-orchestration-in-podman-with-kubernetes-compatibility/
-
-[^3_3]: https://www.reddit.com/r/Nix/comments/1ai1vfo/best_way_to_run_podmandockercontainerd_in_a_nix/
-
-[^3_4]: https://discourse.nixos.org/t/setting-run-user-with-oci-containers-and-systemd/9900
-
-[^3_5]: https://blog.devops.dev/docker-vs-podman-enhancing-security-in-container-orchestration-0020fe40115f
-
-[^3_6]: https://flox.dev/blog/nix-and-containers-why-not-both/
-
-[^3_7]: https://launchdarkly.com/blog/what-is-container-orchestration-exactly-everything/
-
-[^3_8]: https://balagetech.com/tutorials/
-
-
----
-
-# How portable is this solution? I would for this to be trivial to build and distribute for different targets (x86, apple silicon etc. with best-effort support for graphics cards).
-
-The solution using Nix + Podman for containerized multi-service Rust apps with complete dependency isolation is quite portable, with some important nuances across target platforms:
-
-### Cross-Platform Build Portability
-
-- Nix supports cross-platform package management with good support for x86_64 Linux, ARM64 (Apple Silicon), and other Linux architectures.
-- You can create Nix flakes that build reproducible container images for different targets by specifying the `system` attribute (e.g., `x86_64-linux`, `aarch64-linux`).
-- Cross-compiling for different CPU architectures (like Apple Silicon) is feasible though it may require custom overrides or using emulation like QEMU for non-native builds in some cases.
-- For multi-architecture containers, tools like `docker buildx` can be employed alongside Nix outputs to produce multi-platform OCI images ready for Podman or Docker.
-
-
-### Runtime Considerations
-
-- Containers build by Nix are Linux-based; thus, running them on macOS or Windows requires lightweight Linux VM layers (e.g., Podman's VM or Docker Desktop).
-- On Apple Silicon macOS, the VM can be ARM64-based, so building ARM64 container images via Nix on Apple Silicon hosts offers native performance.
-- Graphics card support is complex: GPU drivers and proper passthrough depend on the host OS and container runtime capabilities. Linux hosts with NVIDIA or AMD GPUs support passthrough but vary in complexity, while macOS or Windows GPU passthrough for containers is more limited.
-- Nix itself does not abstract GPU drivers, so you must package GPU dependencies and configure container runtimes accordingly outside Nix.
-
-
-### Summary of Portability
-
-| Aspect | Details |
-| :-- | :-- |
-| Build Systems | Nix enables declarative, reproducible multi-arch builds with cross-compilation and cache reuse |
-| Target Architectures | x86_64, aarch64 (Apple Silicon), and Linux ARM variants are supported |
-| Runtime Environment | Linux containers run in VMs on macOS/Windows via Podman/Docker VM layers |
-| GPU Support | Best on native Linux hosts with careful manual GPU driver and runtime config; limited on macOS/Windows |
-| Distribution | OCI images output from Nix are standard, portable, and usable with most modern container runtimes |
-
-This approach makes building, distributing, and running your containerized Rust app with full Nix-managed dependencies straightforward and reproducible on multiple platforms, as long as the container host supports running Linux containers (native or VM based).
-
-If needed, strategies to automate multi-arch builds with Nix flakes and Podman or handle GPU passthrough can be demonstrated.
-
-Let me know if full multi-platform build example or GPU integration instructions are desired![^4_1][^4_5][^4_9][^4_10]
-<span style="display:none">[^4_2][^4_3][^4_4][^4_6][^4_7][^4_8]</span>
-
-<div style="text-align: center">⁂</div>
-
-[^4_1]: https://news.ycombinator.com/item?id=33675310
-
-[^4_2]: https://www.reddit.com/r/NixOS/comments/1ajfl8c/nixoscontainer_vs_docker_and_friends/
-
-[^4_3]: http://sandervanderburg.blogspot.com/2020/07/on-using-nix-and-docker-as-deployment.html
-
-[^4_4]: https://discourse.nixos.org/t/tools-for-cross-platform-dev-envs-with-containers/28428
-
-[^4_5]: https://discourse.nixos.org/t/cross-compiling-docker-images-with-flakes/25716
-
-[^4_6]: https://acotten.com/2024/08/06/nix-package-management
-
-[^4_7]: https://determinate.systems/blog/nix-to-kubernetes/
-
-[^4_8]: https://mitchellh.com/writing/nix-with-dockerfiles
-
-[^4_9]: https://discourse.nixos.org/t/cross-platform-deployments/56606
-
-[^4_10]: https://nix.dev/tutorials/nixos/building-and-running-docker-images.html
-
-
----
-
-# Can you provide a final summary of this architecture, noting the key architectural constraints for the flake/multi-container approach and paths to support GPU access while maintaining total isolation from the system?
-
-The architecture for a containerized Rust application with full dependency management and multi-service orchestration using Nix and Podman can be summarized as follows:
-
-### Summary of Architecture
-
-- The Rust application and all its dependencies, including external services such as Ollama, are fully built and packaged declaratively with Nix using constructs like `buildRustPackage` and `buildImage` or `buildLayeredImage`.
-- Multi-container orchestration is achieved using Podman pods or systemd + Podman with Quadlet for service definitions, enabling isolated containers that share networking transparently and can express service dependencies.
-- Each container image is a fully reproducible, declarative Nix build output, ensuring exact dependency versions and no runtime dependence on external systems or package managers.
-- The entire system supports multi-architecture builds by specifying target platforms in Nix flakes and leveraging cross-compilation or emulation techniques (e.g., QEMU) to produce OCI images for x86_64, ARM64 (Apple Silicon), and others.
-- The container images are portable OCI format, distributable via container registries and runnable on Linux hosts or on macOS/Windows via VM-based Podman or Docker runtimes.
-
-
-### Key Architectural Constraints
-
-- The Nix flake must explicitly define the entire closure of dependencies for each container image, including all services, libraries, and tools, guaranteeing isolation.
-- Cross-compilation configuration is required per architecture, with fallback to emulation for unsupported native builds.
-- GPU support must be handled outside Nix for drivers and kernel modules but can be partially included by packaging GPU user-space libraries in the container image.
-- Container runtimes must be configured for privileged device passthrough (e.g., NVIDIA with `--gpus` flag) and security privileges without compromising isolation.
-- Podman pods or systemd + Quadlet introduce management abstraction but require careful network, volume, and lifecycle configuration to maintain container independence while enabling service coordination.
-
-
-### Paths to Support GPU Access While Maintaining Isolation
-
-- Package GPU user-space libraries (CUDA, ROCm, Mesa) inside Nix container images for consistent runtime environments.
-- Expose GPU devices at container runtime through Podman device passthrough options (`--device /dev/dri` or `--gpus`) without embedding privileged drivers inside the image.
-- Use rootless Podman with elevated privileges only for GPU device access, ensuring the container runtime is the only interface between hardware and the containerized environment.
-- Maintain separation of concerns: Nix handles immutable software stacks, while runtime device access is controlled by Podman and host kernel drivers.
-- For multi-architecture GPU support, build compatible GPU libraries per target architecture in container images and adapt passthrough configurations.
-
-***
-
-This architecture balances reproducibility, isolation, and portability by leveraging Nix for build-time guarantees and Podman for lightweight container orchestration. It also enables extending advanced use cases like GPU passthrough by combining declarative packaging with runtime device management outside Nix.
-
-If desired, example flakes for GPU-packaged containers or Podman pod + Quadlet service files for multi-container GPU-enabled setups can be provided.
-
-This approach offers best-effort cross-platform portability with strong isolation, reproducibility, and service orchestration.[^5_1][^5_2][^5_3][^5_4][^5_5]
-<span style="display:none">[^5_6][^5_7][^5_8][^5_9]</span>
-
-<div style="text-align: center">⁂</div>
-
-[^5_1]: https://github.com/nlewo/nix2container
-
-[^5_2]: https://wiki.nixos.org/wiki/Podman
-
-[^5_3]: https://developers.redhat.com/articles/2023/11/03/how-build-multi-architecture-container-images
-
-[^5_4]: http://blog.differentpla.net/blog/2025/04/30/multiarch-containers-podman-docker-2/
-
-[^5_5]: https://flox.dev/blog/nix-and-containers-why-not-both/
-
-[^5_6]: https://people.redhat.com/mskinner/rhug/q1.2024/Podman-PodmanDesktop.pdf
-
-[^5_7]: https://www.xda-developers.com/nixos-containers-are-pretty-exciting/
-
-[^5_8]: http://blog.differentpla.net/blog/2025/04/30/multiarch-containers-podman-docker-1/
-
-[^5_9]: https://blog.crafteo.io/2023/08/31/automated-reproducible-and-secure-development-ci-environments-package-management-1-3/
-
+## Architectural Constraints
+
+- The Nix flake must declare the **complete closure** of dependencies for each container image.
+- Cross-compilation is required per target architecture; use QEMU emulation as a fallback for unsupported native builds.
+- GPU drivers and kernel modules cannot be packaged inside Nix container images — expose GPU devices at runtime via Podman device passthrough (`--device /dev/dri`, `--gpus all`).
+- GPU user-space libraries (CUDA, ROCm, Mesa) can be packaged inside the container image for a consistent runtime.
+- Podman pods and Quadlet require explicit network, volume, and lifecycle configuration.
+
+## Portability
+
+| Target | Support |
+|---|---|
+| x86_64 Linux | Native |
+| aarch64 Linux / Apple Silicon | Native (build on host or cross-compile) |
+| macOS / Windows | Linux containers via Podman VM |
+| NVIDIA/AMD GPU | Linux hosts with device passthrough; limited on macOS/Windows |
+
+## References
+
+- [buildRustPackage docs](https://nixos.org/manual/nixpkgs/stable/#rust)
+- [nix2container](https://github.com/nlewo/nix2container)
+- [Podman on NixOS](https://wiki.nixos.org/wiki/Podman)
+- [Quadlet guide](https://blog.stackademic.com/awesome-container-orchestration-with-quadlet-podman-for-the-win-e4bce5dd217f)
+- [Building a Rust service with Nix](https://fasterthanli.me/series/building-a-rust-service-with-nix)

--- a/framing/reproducibility-recs.md
+++ b/framing/reproducibility-recs.md
@@ -1,43 +1,20 @@
-<img src="https://r2cdn.perplexity.ai/pplx-full-logo-primary-dark%402x.png" style="height:64px;margin-right:32px"/>
+# Reproducibility Recommendations for Rust / Multi-Language Apps with Nix
 
-# what are your recommendations for creating reproducible rust / multi-language applications using nix?
+## Key Practices
 
-Here are recommendations for creating reproducible Rust and multi-language applications using Nix, based on the latest expert approaches and real-world usage patterns:
+- **Use Nix flakes** as the central declarative tool for managing dependencies, toolchains, and build environments. Flakes provide unified dependency declarations and fully reproducible builds with identical environments across developers and CI.
+- **Pin exact versions** of core toolchains (Rust, Node.js, etc.) via overlays in your flake configuration to prevent version drift.
+- **Use Cachix** (or another binary cache) to share precompiled artifacts across the team and CI, avoiding redundant recompilation of large Rust projects.
+- **Separate dependency compilation from source builds**: build and cache dependencies once, then compile source incrementally.
+- **Use `rust-overlay`** for advanced Rust toolchain management inside Nix (simplifies specifying Rust versions and integrating Cargo).
+- **Produce OCI containers from Nix** using `buildImage` / `buildLayeredImage` to guarantee reproducible, hermetic runtime environments.
+- **Compose derivations per language**: for multi-language pipelines (Rust, TypeScript, etc.), create isolated Nix derivations whose outputs are consumed by downstream builds.
 
-- Use Nix flakes as the central declarative tool for managing dependencies, toolchains, and build environments consistently across Rust, TypeScript, or other languages. Flakes allow unified dependency declarations and fully reproducible builds with identical environments for all developers and CI systems.[^1_1]
-- In your flake configuration, use overlays to pin exact versions of core languages and tools such as Rust, Node.js, and yarn. This prevents version conflicts and ensures everyone uses the same toolchains.[^1_1]
-- Leverage binary caches like Cachix to greatly speed up builds by reusing precompiled artifacts across your team or CI. This is essential for large Rust projects or multi-language builds.[^1_1]
-- Structure your Rust builds to separate dependency compilation from source code builds. Build and cache dependencies once, then build your source faster on subsequent builds. This also benefits continuous integration workflows.[^1_1]
-- Programmatically coordinate between Rust and other languages' build steps (e.g., compiling Rust to WebAssembly and then consuming it in TypeScript). Nix flakes allow you to automate these cross-language workflows in a single reproducible pipeline.[^1_1]
-- Use tools like rust-overlay for advanced Rust toolchain management inside Nix, which simplifies specifying Rust versions and integrating Cargo dependencies into Nix builds.[^1_5][^1_1]
-- Adopt incremental adoption of Nix flakes if you are new, starting with the critical Rust build pipelines, then expand as your team grows more comfortable.[^1_1]
-- Develop deployment and packaging pipelines using Nix's hermetic build system to ensure reproducible Rust builds on any platform without being affected by system-level dependencies.[^1_5]
-- For multi-stage builds involving multiple languages (Rust, TypeScript, Kotlin, etc.), create isolated, composable Nix derivations or flakes that produce artifacts consumable by downstream builds, ensuring each step is reproducible and versioned.[^1_6]
+## References
 
-These practices together deliver reliable, reproducible builds and development environments for complex multi-language applications centered on Rust. They reduce build failures, improve developer onboarding, and enable consistent CI and deployment.
-
-If desired, I can provide an example Nix flake configuration illustrating these patterns. Would that be helpful?
-<span style="display:none">[^1_10][^1_2][^1_3][^1_4][^1_7][^1_8][^1_9]</span>
-
-<div style="text-align: center">⁂</div>
-
-[^1_1]: https://sgolovin.live/managing-multi-language-development-environments-with-nix-flakes
-
-[^1_2]: https://filtra.io/rust/interviews/flox-mar-24
-
-[^1_3]: https://www.reddit.com/r/rust/comments/a27fhg/looking_for_documentation_on_deploying_rust/
-
-[^1_4]: https://tweag.io/blog/2022-09-22-rust-nix/
-
-[^1_5]: https://community.fly.io/t/running-reproducible-rust-a-fly-and-nix-love-story/3781
-
-[^1_6]: https://discourse.nixos.org/t/using-nix-for-a-multi-stage-build-with-multiple-languages-involved/26807
-
-[^1_7]: https://discourse.nixos.org/t/introducing-brioche-a-new-nix-like-package-manager-written-in-rust/46447
-
-[^1_8]: https://www.youtube.com/watch?v=Ss1IXtYnpsg
-
-[^1_9]: https://dennybritz.com/posts/adopting-nix/
-
-[^1_10]: https://github.com/nix-community/awesome-nix
-
+- [Managing Rust dependencies with Nix (Part I)](https://hadean.com/blog/managing-rust-dependencies-with-nix-part-i/)
+- [Managing Rust dependencies with Nix (Part II)](https://hadean.com/blog/managing-rust-dependencies-with-nix-part-ii/)
+- [How to package a Rust app with Nix](https://dev.to/misterio/how-to-package-a-rust-app-using-nix-3lh3)
+- [rust-overlay](https://github.com/oxalica/rust-overlay)
+- [Tweag: Rust + Nix](https://tweag.io/blog/2022-09-22-rust-nix/)
+- [Managing multi-language dev environments with Nix flakes](https://sgolovin.live/managing-multi-language-development-environments-with-nix-flakes)

--- a/harness/src/main.rs
+++ b/harness/src/main.rs
@@ -4,7 +4,9 @@ use harness::entities::git::GitRepository;
 use harness::entities::{EntityStore, InMemoryEntityStore};
 use harness::tools::ToolRegistry;
 use model::prelude::*;
+use model::provider::ModelProvider;
 use std::io::{self, Write};
+use std::sync::Arc;
 use tracing::{error, info};
 
 #[derive(Parser)]
@@ -75,11 +77,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let cli = Cli::parse();
 
-    let config = OllamaConfig::default();
-    let provider = OllamaProvider::new(config)?;
+    let provider: Arc<dyn ModelProvider> =
+        Arc::new(OllamaProvider::new(OllamaConfig::default())?);
 
     let workspace_root = std::env::current_dir()?;
-    let tool_registry = create_tool_registry(&workspace_root);
+    let tool_registry = harness::tools::create_tool_registry(&workspace_root);
 
     match cli.command {
         Commands::Chat {
@@ -135,6 +137,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 verbose,
                 tools,
                 &workspace_root,
+                Arc::clone(&provider),
             )
             .await?;
         }
@@ -142,15 +145,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             model,
             max_iterations,
         } => {
-            run_mcp_server(&model, max_iterations).await?;
+            run_mcp_server(&model, max_iterations, Arc::clone(&provider)).await?;
         }
     }
 
     Ok(())
-}
-
-fn create_tool_registry(workspace_root: &std::path::Path) -> ToolRegistry {
-    harness::tools::create_tool_registry(workspace_root)
 }
 
 async fn initialize_workspace(workspace_root: &std::path::Path) -> InMemoryEntityStore {
@@ -180,8 +179,52 @@ async fn initialize_workspace(workspace_root: &std::path::Path) -> InMemoryEntit
     store
 }
 
+/// Execute all tool calls in a model response, append assistant + tool-response
+/// messages to `messages`, and return whether any tool calls were made.
+async fn dispatch_tool_calls(
+    tool_registry: &ToolRegistry,
+    messages: &mut Vec<ChatMessage>,
+    choice: &model::types::Choice,
+) -> bool {
+    let Some(tool_calls) = &choice.message.tool_calls else {
+        return false;
+    };
+
+    for tool_call in tool_calls {
+        println!(
+            "  Calling {}: {:?}",
+            tool_call.function.name, tool_call.function.arguments
+        );
+
+        let response_content = match tool_registry
+            .execute(
+                &tool_call.function.name,
+                tool_call.function.arguments.clone(),
+            )
+            .await
+        {
+            Ok(result) => {
+                println!("  Result: {}", result);
+                result.to_string()
+            }
+            Err(e) => {
+                error!("Tool execution failed: {}", e);
+                format!("Error: {}", e)
+            }
+        };
+
+        messages.push(choice.message.clone());
+        messages.push(ChatMessage::tool_response(
+            tool_call.id.clone(),
+            response_content,
+        ));
+    }
+
+    true
+}
+
 async fn single_chat(
-    provider: &OllamaProvider,
+    provider: &dyn ModelProvider,
     tool_registry: &ToolRegistry,
     model: &str,
     prompt: &str,
@@ -194,8 +237,7 @@ async fn single_chat(
         let mut request = ChatRequest::new(model, messages.clone()).with_temperature(temperature);
 
         if enable_tools {
-            let tool_definitions = tool_registry.get_definitions();
-            request = request.with_tools(tool_definitions);
+            request = request.with_tools(tool_registry.get_definitions());
         }
 
         let response = provider.chat(request).await?;
@@ -205,40 +247,7 @@ async fn single_chat(
             println!("Assistant: {}", content);
         }
 
-        if let Some(tool_calls) = &choice.message.tool_calls {
-            println!("\nTool calls:");
-            for tool_call in tool_calls {
-                println!(
-                    "  Calling {}: {:?}",
-                    tool_call.function.name, tool_call.function.arguments
-                );
-
-                match tool_registry
-                    .execute(
-                        &tool_call.function.name,
-                        tool_call.function.arguments.clone(),
-                    )
-                    .await
-                {
-                    Ok(result) => {
-                        println!("  Result: {}", result);
-                        messages.push(choice.message.clone());
-                        messages.push(ChatMessage::tool_response(
-                            tool_call.id.clone(),
-                            result.to_string(),
-                        ));
-                    }
-                    Err(e) => {
-                        error!("Tool execution failed: {}", e);
-                        messages.push(choice.message.clone());
-                        messages.push(ChatMessage::tool_response(
-                            tool_call.id.clone(),
-                            format!("Error: {}", e),
-                        ));
-                    }
-                }
-            }
-
+        if dispatch_tool_calls(tool_registry, &mut messages, choice).await {
             continue;
         }
 
@@ -249,7 +258,7 @@ async fn single_chat(
 }
 
 async fn interactive_chat(
-    provider: &OllamaProvider,
+    provider: &dyn ModelProvider,
     tool_registry: &ToolRegistry,
     model: &str,
     enable_tools: bool,
@@ -292,8 +301,7 @@ async fn interactive_chat(
                 ChatRequest::new(model, messages.clone()).with_temperature(temperature);
 
             if enable_tools {
-                let tool_definitions = tool_registry.get_definitions();
-                request = request.with_tools(tool_definitions);
+                request = request.with_tools(tool_registry.get_definitions());
             }
 
             let response = provider.chat(request).await?;
@@ -303,40 +311,7 @@ async fn interactive_chat(
                 println!("Assistant: {}", content);
             }
 
-            if let Some(tool_calls) = &choice.message.tool_calls {
-                println!("\n[Tool calls]");
-                for tool_call in tool_calls {
-                    println!(
-                        "  Calling {}: {:?}",
-                        tool_call.function.name, tool_call.function.arguments
-                    );
-
-                    match tool_registry
-                        .execute(
-                            &tool_call.function.name,
-                            tool_call.function.arguments.clone(),
-                        )
-                        .await
-                    {
-                        Ok(result) => {
-                            println!("  -> {}", result);
-                            messages.push(choice.message.clone());
-                            messages.push(ChatMessage::tool_response(
-                                tool_call.id.clone(),
-                                result.to_string(),
-                            ));
-                        }
-                        Err(e) => {
-                            error!("Tool execution failed: {}", e);
-                            messages.push(choice.message.clone());
-                            messages.push(ChatMessage::tool_response(
-                                tool_call.id.clone(),
-                                format!("Error: {}", e),
-                            ));
-                        }
-                    }
-                }
-                println!();
+            if dispatch_tool_calls(tool_registry, &mut messages, choice).await {
                 continue;
             }
 
@@ -348,7 +323,9 @@ async fn interactive_chat(
     Ok(())
 }
 
-async fn list_models(provider: &OllamaProvider) -> Result<(), Box<dyn std::error::Error>> {
+async fn list_models(
+    provider: &dyn ModelProvider,
+) -> Result<(), Box<dyn std::error::Error>> {
     println!("Available models:");
     let models = provider.list_models().await?;
 
@@ -386,16 +363,18 @@ fn list_tools(tool_registry: &ToolRegistry) {
     }
 }
 
-async fn health_check(provider: &OllamaProvider) -> Result<(), Box<dyn std::error::Error>> {
+async fn health_check(
+    provider: &dyn ModelProvider,
+) -> Result<(), Box<dyn std::error::Error>> {
     println!("Performing health check...");
 
     match provider.health_check().await {
         Ok(()) => {
-            println!("✓ Health check passed. Ollama is running and accessible.");
+            println!("\u{2713} Health check passed. Ollama is running and accessible.");
             info!("Health check successful");
         }
         Err(e) => {
-            println!("✗ Health check failed: {}", e);
+            println!("\u{2717} Health check failed: {}", e);
             error!("Health check failed: {}", e);
             return Err(e.into());
         }
@@ -411,12 +390,10 @@ async fn run_agent(
     verbose: bool,
     tools: bool,
     workspace_root: &std::path::Path,
+    provider: Arc<dyn ModelProvider>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     use harness::agent::{AgentConfig, AgentContext, AgentLoop};
-    use std::sync::Arc;
 
-    let config = OllamaConfig::default();
-    let provider = Arc::new(OllamaProvider::new(config)?);
     let entity_store = initialize_workspace(workspace_root).await;
 
     let agent_config = AgentConfig {
@@ -440,7 +417,7 @@ async fn run_agent(
     }
 
     let mut agent = if tools {
-        let tool_registry = create_tool_registry(workspace_root);
+        let tool_registry = harness::tools::create_tool_registry(workspace_root);
         AgentLoop::with_tools(agent_config, entity_store, provider, tool_registry)
     } else {
         AgentLoop::with_llm(agent_config, entity_store, provider)
@@ -478,13 +455,11 @@ async fn run_agent(
 async fn run_mcp_server(
     model: &str,
     max_iterations: usize,
+    provider: Arc<dyn ModelProvider>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     use harness::mcp::NannaMcpServer;
     use harness::task::TaskManager;
-    use std::sync::Arc;
 
-    let config = OllamaConfig::default();
-    let provider = Arc::new(OllamaProvider::new(config)?);
     let task_manager = Arc::new(TaskManager::default());
 
     info!(

--- a/harness/tests/tools_unit_tests.rs
+++ b/harness/tests/tools_unit_tests.rs
@@ -1,0 +1,578 @@
+//! Unit tests for harness tool implementations.
+//!
+//! ## What is being tested and why
+//!
+//! `tools.rs` is the widest public surface the agent touches at runtime: every
+//! file read/write, directory listing, text search, arithmetic calculation, and
+//! git-status inspection goes through one of the tools registered here.  Two
+//! classes of behaviour are critical yet had no isolated coverage:
+//!
+//! 1. **Path-security** – `ReadFileTool`, `WriteFileTool`, `ListDirTool`, and
+//!    `SearchTool` all reject paths that escape the workspace root (directory
+//!    traversal).  The integration tests exercise the happy path end-to-end but
+//!    never deliberately craft `../../etc/passwd`-style inputs.
+//!
+//! 2. **Argument validation / sad paths** – Every tool returns a structured
+//!    `ToolError` on bad input; none of these branches were exercised in
+//!    isolation.
+//!
+//! ## Test style rationale
+//!
+//! Pure unit tests (no container, no Ollama, no git daemon) keep CI fast and
+//! reliable.  Each test is self-contained: it creates its own `TempDir` so
+//! tests can run in parallel without interfering.  Async tools are driven with
+//! `#[tokio::test]`.  Sync helpers (e.g. `CalculatorTool`) use plain `#[test]`.
+
+use harness::tools::{
+    CalculatorTool, EchoTool, ListDirTool, ReadFileTool, SearchTool, Tool, ToolRegistry,
+    WriteFileTool,
+};
+use serde_json::json;
+use std::fs;
+use tempfile::TempDir;
+
+// ---------------------------------------------------------------------------
+// Helper: create a sandboxed workspace with a known file layout
+// ---------------------------------------------------------------------------
+
+struct Workspace {
+    dir: TempDir,
+}
+
+impl Workspace {
+    fn new() -> Self {
+        let dir = TempDir::new().expect("tempdir");
+        // Populate a minimal file tree the tests can read / search
+        fs::write(dir.path().join("hello.txt"), "Hello, world!\n").unwrap();
+        fs::write(
+            dir.path().join("src.rs"),
+            "fn main() {\n    println!(\"hi\");\n}\n",
+        )
+        .unwrap();
+        fs::create_dir(dir.path().join("subdir")).unwrap();
+        fs::write(
+            dir.path().join("subdir").join("nested.txt"),
+            "nested content",
+        )
+        .unwrap();
+        Self { dir }
+    }
+
+    fn path_str(&self) -> &str {
+        self.dir.path().to_str().expect("utf-8 path")
+    }
+
+    fn read_tool(&self) -> ReadFileTool {
+        ReadFileTool::new(self.dir.path())
+    }
+
+    fn write_tool(&self) -> WriteFileTool {
+        WriteFileTool::new(self.dir.path())
+    }
+
+    fn list_tool(&self) -> ListDirTool {
+        ListDirTool::new(self.dir.path())
+    }
+
+    fn search_tool(&self) -> SearchTool {
+        SearchTool::new(self.dir.path())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ToolRegistry
+// ---------------------------------------------------------------------------
+
+#[test]
+fn registry_register_and_lookup() {
+    let mut registry = ToolRegistry::new();
+    registry.register(Box::new(EchoTool::new()));
+    assert!(registry.get_tool("echo").is_some());
+    assert!(registry.get_tool("nonexistent").is_none());
+}
+
+#[test]
+fn registry_list_tools_includes_registered() {
+    let mut registry = ToolRegistry::new();
+    registry.register(Box::new(EchoTool::new()));
+    registry.register(Box::new(CalculatorTool::new()));
+    let names = registry.list_tools();
+    assert!(names.contains(&"echo"));
+    assert!(names.contains(&"calculator"));
+}
+
+#[test]
+fn registry_get_definitions_matches_registered_tools() {
+    let mut registry = ToolRegistry::new();
+    registry.register(Box::new(EchoTool::new()));
+    let defs = registry.get_definitions();
+    assert_eq!(defs.len(), 1);
+    assert_eq!(defs[0].function.name, "echo");
+}
+
+// ---------------------------------------------------------------------------
+// EchoTool – simplest possible tool, useful as a sanity baseline
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn echo_returns_message() {
+    let tool = EchoTool::new();
+    let result = tool.execute(json!({"message": "ping"})).await.unwrap();
+    assert_eq!(result["message"], "ping");
+}
+
+#[tokio::test]
+async fn echo_missing_message_returns_error() {
+    let tool = EchoTool::new();
+    let err = tool.execute(json!({})).await.unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("message") || msg.contains("Invalid") || msg.contains("missing"),
+        "expected descriptive error, got: {msg}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// CalculatorTool – pure arithmetic, no I/O
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn calculator_addition() {
+    let tool = CalculatorTool::new();
+    let result = tool
+        .execute(json!({"expression": "2 + 3"}))
+        .await
+        .unwrap();
+    // The tool stores the numeric result under a "result" key
+    let val = result["result"].as_f64().unwrap();
+    assert!((val - 5.0).abs() < 1e-9);
+}
+
+#[tokio::test]
+async fn calculator_multiplication_and_division() {
+    let tool = CalculatorTool::new();
+
+    let r = tool
+        .execute(json!({"expression": "6 * 7"}))
+        .await
+        .unwrap();
+    assert!((r["result"].as_f64().unwrap() - 42.0).abs() < 1e-9);
+
+    let r = tool
+        .execute(json!({"expression": "10 / 4"}))
+        .await
+        .unwrap();
+    assert!((r["result"].as_f64().unwrap() - 2.5).abs() < 1e-9);
+}
+
+#[tokio::test]
+async fn calculator_subtraction_negative_result() {
+    let tool = CalculatorTool::new();
+    let result = tool
+        .execute(json!({"expression": "3 - 10"}))
+        .await
+        .unwrap();
+    assert!((result["result"].as_f64().unwrap() - (-7.0)).abs() < 1e-9);
+}
+
+#[tokio::test]
+async fn calculator_missing_expression_returns_error() {
+    let tool = CalculatorTool::new();
+    let err = tool.execute(json!({})).await.unwrap_err();
+    assert!(
+        err.to_string().contains("expression")
+            || err.to_string().contains("Invalid")
+            || err.to_string().contains("missing"),
+        "expected descriptive error, got: {err}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// ReadFileTool – happy path + path traversal rejection
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn read_file_happy_path() {
+    let ws = Workspace::new();
+    let tool = ws.read_tool();
+    let result = tool
+        .execute(json!({"path": "hello.txt"}))
+        .await
+        .unwrap();
+    let content = result["content"].as_str().unwrap();
+    assert!(content.contains("Hello, world!"));
+}
+
+#[tokio::test]
+async fn read_file_nested_path() {
+    let ws = Workspace::new();
+    let tool = ws.read_tool();
+    let result = tool
+        .execute(json!({"path": "subdir/nested.txt"}))
+        .await
+        .unwrap();
+    assert!(result["content"]
+        .as_str()
+        .unwrap()
+        .contains("nested content"));
+}
+
+#[tokio::test]
+async fn read_file_path_traversal_rejected() {
+    let ws = Workspace::new();
+    let tool = ws.read_tool();
+    // Classic traversal attempt escaping the workspace root
+    let err = tool
+        .execute(json!({"path": "../../etc/passwd"}))
+        .await
+        .unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("security") || msg.contains("traversal") || msg.contains("outside")
+            || msg.contains("allowed") || msg.contains("violation"),
+        "expected path-security error, got: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn read_file_absolute_path_outside_workspace_rejected() {
+    let ws = Workspace::new();
+    let tool = ws.read_tool();
+    // Absolute path to a well-known system file
+    let err = tool
+        .execute(json!({"path": "/etc/hostname"}))
+        .await
+        .unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("security") || msg.contains("traversal") || msg.contains("outside")
+            || msg.contains("allowed") || msg.contains("violation"),
+        "expected path-security error for absolute path, got: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn read_file_nonexistent_returns_error() {
+    let ws = Workspace::new();
+    let tool = ws.read_tool();
+    let err = tool
+        .execute(json!({"path": "does_not_exist.txt"}))
+        .await
+        .unwrap_err();
+    // Should be an IO error, not a panic
+    assert!(!err.to_string().is_empty());
+}
+
+#[tokio::test]
+async fn read_file_missing_path_argument_returns_error() {
+    let ws = Workspace::new();
+    let tool = ws.read_tool();
+    let err = tool.execute(json!({})).await.unwrap_err();
+    assert!(
+        err.to_string().contains("path") || err.to_string().contains("Invalid"),
+        "expected descriptive error about missing path, got: {err}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// WriteFileTool – happy path + path traversal rejection
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn write_file_creates_new_file() {
+    let ws = Workspace::new();
+    let tool = ws.write_tool();
+    tool.execute(json!({"path": "new_file.txt", "content": "created by test"}))
+        .await
+        .unwrap();
+    let on_disk = fs::read_to_string(ws.dir.path().join("new_file.txt")).unwrap();
+    assert_eq!(on_disk, "created by test");
+}
+
+#[tokio::test]
+async fn write_file_overwrites_existing_file() {
+    let ws = Workspace::new();
+    let tool = ws.write_tool();
+    tool.execute(json!({"path": "hello.txt", "content": "overwritten"}))
+        .await
+        .unwrap();
+    let on_disk = fs::read_to_string(ws.dir.path().join("hello.txt")).unwrap();
+    assert_eq!(on_disk, "overwritten");
+}
+
+#[tokio::test]
+async fn write_file_path_traversal_rejected() {
+    let ws = Workspace::new();
+    let tool = ws.write_tool();
+    let err = tool
+        .execute(json!({"path": "../../tmp/evil.txt", "content": "should not write"}))
+        .await
+        .unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("security") || msg.contains("traversal") || msg.contains("outside")
+            || msg.contains("allowed") || msg.contains("violation"),
+        "expected path-security error, got: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn write_file_absolute_path_outside_workspace_rejected() {
+    let ws = Workspace::new();
+    let tool = ws.write_tool();
+    let err = tool
+        .execute(json!({"path": "/tmp/evil_write_test_nanna.txt", "content": "bad"}))
+        .await
+        .unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("security") || msg.contains("traversal") || msg.contains("outside")
+            || msg.contains("allowed") || msg.contains("violation"),
+        "expected path-security error for absolute path, got: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn write_file_creates_parent_directories() {
+    let ws = Workspace::new();
+    let tool = ws.write_tool();
+    tool.execute(json!({"path": "a/b/c/deep.txt", "content": "deep"}))
+        .await
+        .unwrap();
+    let on_disk = fs::read_to_string(ws.dir.path().join("a/b/c/deep.txt")).unwrap();
+    assert_eq!(on_disk, "deep");
+}
+
+#[tokio::test]
+async fn write_file_missing_path_argument_returns_error() {
+    let ws = Workspace::new();
+    let tool = ws.write_tool();
+    let err = tool
+        .execute(json!({"content": "no path given"}))
+        .await
+        .unwrap_err();
+    assert!(
+        err.to_string().contains("path") || err.to_string().contains("Invalid"),
+        "expected descriptive error, got: {err}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// ListDirTool – happy path + path traversal rejection
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn list_dir_workspace_root() {
+    let ws = Workspace::new();
+    let tool = ws.list_tool();
+    // Listing "." or "" should show the top-level entries
+    let result = tool.execute(json!({"path": "."})).await.unwrap();
+    let entries = result["entries"].as_array().unwrap();
+    let names: Vec<&str> = entries
+        .iter()
+        .filter_map(|e| e["name"].as_str())
+        .collect();
+    assert!(
+        names.contains(&"hello.txt"),
+        "root listing should include hello.txt, got: {names:?}"
+    );
+    assert!(
+        names.contains(&"subdir"),
+        "root listing should include subdir, got: {names:?}"
+    );
+}
+
+#[tokio::test]
+async fn list_dir_subdirectory() {
+    let ws = Workspace::new();
+    let tool = ws.list_tool();
+    let result = tool.execute(json!({"path": "subdir"})).await.unwrap();
+    let entries = result["entries"].as_array().unwrap();
+    let names: Vec<&str> = entries
+        .iter()
+        .filter_map(|e| e["name"].as_str())
+        .collect();
+    assert!(
+        names.contains(&"nested.txt"),
+        "subdir listing should include nested.txt, got: {names:?}"
+    );
+}
+
+#[tokio::test]
+async fn list_dir_path_traversal_rejected() {
+    let ws = Workspace::new();
+    let tool = ws.list_tool();
+    let err = tool
+        .execute(json!({"path": "../../"}))
+        .await
+        .unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("security") || msg.contains("traversal") || msg.contains("outside")
+            || msg.contains("allowed") || msg.contains("violation"),
+        "expected path-security error, got: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn list_dir_nonexistent_returns_error() {
+    let ws = Workspace::new();
+    let tool = ws.list_tool();
+    let err = tool
+        .execute(json!({"path": "no_such_dir"}))
+        .await
+        .unwrap_err();
+    assert!(!err.to_string().is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// SearchTool – content search within the workspace
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn search_finds_matching_content() {
+    let ws = Workspace::new();
+    let tool = ws.search_tool();
+    let result = tool
+        .execute(json!({"query": "Hello", "path": "."}))
+        .await
+        .unwrap();
+    // Results should mention hello.txt since it contains "Hello, world!"
+    let output = serde_json::to_string(&result).unwrap();
+    assert!(
+        output.contains("hello.txt"),
+        "search for 'Hello' should match hello.txt, got: {output}"
+    );
+}
+
+#[tokio::test]
+async fn search_returns_empty_for_no_matches() {
+    let ws = Workspace::new();
+    let tool = ws.search_tool();
+    let result = tool
+        .execute(json!({"query": "zzz_nonexistent_string_xyz", "path": "."}))
+        .await
+        .unwrap();
+    let matches = result["matches"]
+        .as_array()
+        .map(|a| a.len())
+        .unwrap_or(0);
+    assert_eq!(matches, 0, "no matches expected for nonsense query");
+}
+
+#[tokio::test]
+async fn search_path_traversal_rejected() {
+    let ws = Workspace::new();
+    let tool = ws.search_tool();
+    let err = tool
+        .execute(json!({"query": "root", "path": "../../"}))
+        .await
+        .unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("security") || msg.contains("traversal") || msg.contains("outside")
+            || msg.contains("allowed") || msg.contains("violation"),
+        "expected path-security error for traversal search, got: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn search_missing_query_argument_returns_error() {
+    let ws = Workspace::new();
+    let tool = ws.search_tool();
+    let err = tool.execute(json!({"path": "."})).await.unwrap_err();
+    assert!(
+        err.to_string().contains("query") || err.to_string().contains("Invalid"),
+        "expected descriptive error for missing query, got: {err}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Tool definitions (JSON schema contract)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn tool_definitions_have_names_and_descriptions() {
+    let tools: Vec<Box<dyn Tool>> = vec![
+        Box::new(EchoTool::new()),
+        Box::new(CalculatorTool::new()),
+    ];
+    for tool in &tools {
+        let def = tool.definition();
+        assert!(
+            !def.function.name.is_empty(),
+            "tool '{}' definition name is empty",
+            tool.name()
+        );
+        assert!(
+            !def.function.description.is_empty(),
+            "tool '{}' definition description is empty",
+            tool.name()
+        );
+    }
+}
+
+#[test]
+fn workspace_scoped_tool_definitions_have_names_and_descriptions() {
+    let ws = Workspace::new();
+    let tools: Vec<Box<dyn Tool>> = vec![
+        Box::new(ws.read_tool()),
+        Box::new(ws.write_tool()),
+        Box::new(ws.list_tool()),
+        Box::new(ws.search_tool()),
+    ];
+    for tool in &tools {
+        let def = tool.definition();
+        assert!(
+            !def.function.name.is_empty(),
+            "tool '{}' definition name is empty",
+            tool.name()
+        );
+        assert!(
+            !def.function.description.is_empty(),
+            "tool '{}' definition description is empty",
+            tool.name()
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Invariant: tool name() must equal definition().function.name
+// ---------------------------------------------------------------------------
+
+#[test]
+fn tool_name_matches_definition_name() {
+    let ws = Workspace::new();
+    let tools: Vec<Box<dyn Tool>> = vec![
+        Box::new(EchoTool::new()),
+        Box::new(CalculatorTool::new()),
+        Box::new(ws.read_tool()),
+        Box::new(ws.write_tool()),
+        Box::new(ws.list_tool()),
+        Box::new(ws.search_tool()),
+    ];
+    for tool in &tools {
+        assert_eq!(
+            tool.name(),
+            tool.definition().function.name,
+            "tool name() and definition().function.name must match"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// create_tool_registry helper
+// ---------------------------------------------------------------------------
+
+#[test]
+fn create_tool_registry_contains_expected_tools() {
+    let ws = Workspace::new();
+    let registry = harness::tools::create_tool_registry(ws.dir.path());
+    // These are the core tools every non-container workspace should have
+    for name in &["read_file", "write_file", "list_dir", "search", "calculator"] {
+        assert!(
+            registry.get_tool(name).is_some(),
+            "expected tool '{name}' in default registry"
+        );
+    }
+}


### PR DESCRIPTION
## Architecture review findings

Reviewed the codebase against ARCHITECTURE.md, AGENTS.md, CONTRIBUTING.md, and TESTING.md.

---

## Issues fixed in this PR

### 1. Redundant `OllamaProvider` constructions

`main()` already constructed one `OllamaProvider`, but `run_agent()` and `run_mcp_server()` each ignored it and built their own independently via `OllamaConfig::default() + OllamaProvider::new()`. This meant two or three independent provider instances were alive simultaneously, and swapping the provider implementation would require touching multiple call sites.

**Fix:** `main()` creates one `Arc<dyn ModelProvider>` and passes it into `run_agent()` and `run_mcp_server()` as a parameter. The concrete `OllamaProvider` type is now mentioned only once in `main()`. Both `run_agent()` and `run_mcp_server()` already accepted `Arc<dyn ModelProvider>` in their downstream callers (`AgentLoop`, `NannaMcpServer`), so no other changes were needed.

### 2. Duplicated tool-call dispatch loop

`single_chat()` and `interactive_chat()` both contained a verbatim copy of the tool-execute → message-append loop. The only difference was a cosmetic label string (`"Tool calls:"` vs `"[Tool calls]"`). Any bug fix or protocol change to tool dispatch had to be applied in two places.

**Fix:** extracted a shared `dispatch_tool_calls(tool_registry, messages, choice) -> bool` helper. Both callers now delegate to it.

### 3. Trivial one-line `create_tool_registry` wrapper

`main.rs` defined a private function that only forwarded to `harness::tools::create_tool_registry` with no added logic.

**Fix:** inlined the two call sites.

---

## Issue flagged — not fixed here (requires architectural discussion per CONTRIBUTING.md)

Three large modules — `monitoring.rs` (~850 lines), `observability.rs` (~800 lines), `telemetry.rs` (~750 lines) — are exported from `harness/src/lib.rs` but are not referenced by the agent control flow, the MCP server, or any binary entrypoint. Together they account for roughly 2,400 lines of speculative infrastructure with many stub implementations (methods that return hardcoded values or `Ok(())` with a debug log).

This is not aligned with the documented architecture: ARCHITECTURE.md shows a clean Harness → Model flow with no monitoring/telemetry layer in scope. Per CONTRIBUTING.md, architectural changes require a GitHub Issue and approval before implementation. This should be filed as a separate issue before any removal.

---

## Previously in this PR: tool unit tests

`harness/src/tools.rs` — the tool layer the agent uses for every filesystem operation — had zero isolated unit tests. The path-traversal rejection logic (the security-critical code paths that prevent an agent from reading `/etc/passwd` or writing outside the workspace) was not exercised by any test in CI.

| Invariant | Tests |
|-----------|-------|
| Path traversal (`../../`) is rejected by read/write/list/search | `read_file_path_traversal_rejected`, `write_file_path_traversal_rejected`, `list_dir_path_traversal_rejected`, `search_path_traversal_rejected` |
| Absolute paths outside the workspace are rejected | `read_file_absolute_path_outside_workspace_rejected`, `write_file_absolute_path_outside_workspace_rejected` |
| Missing required arguments produce a structured error | `*_missing_*_argument_returns_error` tests |
| Tool `name()` always matches `definition().function.name` | `tool_name_matches_definition_name` |
| Tool definitions always have non-empty name and description | `tool_definitions_have_names_and_descriptions` |
| `CalculatorTool` computes correct arithmetic | `calculator_*` tests |
| `WriteFileTool` creates missing parent directories | `write_file_creates_parent_directories` |
| `create_tool_registry` includes all core tools | `create_tool_registry_contains_expected_tools` |

## Test plan

- [ ] `cargo build --bin harness` compiles cleanly
- [ ] `cargo nextest run --workspace --lib` passes (includes new tool unit tests)
- [ ] `harness health` still works end-to-end
- [ ] `harness agent --prompt "..." --tools` still works end-to-end
- [ ] `harness chat --prompt "..."` still works end-to-end