### PR TITLE
refactor(harness/entities): generify callers + add list_by_kind/invalidate_stale hooks (#193 Phase A)

### DIFF
--- a/harness/src/agent/eval.rs
+++ b/harness/src/agent/eval.rs
@@ -657,9 +657,9 @@ impl AgentEvaluator {
     }
 
     /// Evaluate RAG relevance
-    async fn evaluate_rag_relevance(
+    async fn evaluate_rag_relevance<S: EntityStore + Send>(
         &self,
-        agent: &AgentLoop,
+        agent: &AgentLoop<S>,
         scenario: &EvaluationScenario,
     ) -> EvaluationResult<f64> {
         // Query entities using the scenario's prompt

--- a/harness/src/agent/mod.rs
+++ b/harness/src/agent/mod.rs
@@ -269,11 +269,17 @@ fn extract_result_summary(history: &[ChatMessage]) -> String {
         .to_string()
 }
 
-pub struct AgentLoop {
+/// Agent control loop.
+///
+/// Generic over the backing entity store so that downstream callers can plug
+/// in either the default [`InMemoryEntityStore`] or future persistent
+/// backends (see issue #193). The default type parameter keeps the common
+/// call sites unchanged.
+pub struct AgentLoop<S: EntityStore + Send = InMemoryEntityStore> {
     state: AgentState,
     config: AgentConfig,
     iterations: usize,
-    entity_store: InMemoryEntityStore,
+    entity_store: S,
     performed_actions: usize,
     llm_provider: Option<Arc<dyn ModelProvider>>,
     plan_cache: Option<String>,
@@ -283,8 +289,8 @@ pub struct AgentLoop {
     state_history: Vec<AgentState>,
 }
 
-impl AgentLoop {
-    /// Create a new agent loop with default entity store
+impl AgentLoop<InMemoryEntityStore> {
+    /// Create a new agent loop with the default in-memory entity store.
     pub fn new(config: AgentConfig) -> Self {
         Self {
             state: AgentState::EnrichingEntities,
@@ -300,9 +306,11 @@ impl AgentLoop {
             state_history: Vec::new(),
         }
     }
+}
 
+impl<S: EntityStore + Send> AgentLoop<S> {
     /// Create a new agent loop with a provided entity store
-    pub fn with_entity_store(config: AgentConfig, entity_store: InMemoryEntityStore) -> Self {
+    pub fn with_entity_store(config: AgentConfig, entity_store: S) -> Self {
         Self {
             state: AgentState::EnrichingEntities,
             config,
@@ -321,7 +329,7 @@ impl AgentLoop {
     /// Create a new agent loop with entity store and LLM provider
     pub fn with_llm(
         config: AgentConfig,
-        entity_store: InMemoryEntityStore,
+        entity_store: S,
         llm_provider: Arc<dyn ModelProvider>,
     ) -> Self {
         Self {
@@ -342,7 +350,7 @@ impl AgentLoop {
     /// Create a new agent loop with entity store, LLM provider, and tool registry
     pub fn with_tools(
         config: AgentConfig,
-        entity_store: InMemoryEntityStore,
+        entity_store: S,
         llm_provider: Arc<dyn ModelProvider>,
         tool_registry: ToolRegistry,
     ) -> Self {
@@ -375,12 +383,12 @@ impl AgentLoop {
     }
 
     /// Get reference to entity store
-    pub fn entity_store(&self) -> &InMemoryEntityStore {
+    pub fn entity_store(&self) -> &S {
         &self.entity_store
     }
 
     /// Get mutable reference to entity store
-    pub fn entity_store_mut(&mut self) -> &mut InMemoryEntityStore {
+    pub fn entity_store_mut(&mut self) -> &mut S {
         &mut self.entity_store
     }
 
@@ -666,7 +674,7 @@ impl AgentLoop {
         }
 
         if let Some(provider) = &self.llm_provider {
-            use crate::entities::{EntityQuery, EntityStore};
+            use crate::entities::EntityQuery;
 
             let entity_count = self
                 .entity_store
@@ -713,7 +721,7 @@ impl AgentLoop {
     /// request has been fully satisfied.
     async fn check_task_completion(&self, context: &AgentContext) -> AgentResult<bool> {
         if let Some(provider) = &self.llm_provider {
-            use crate::entities::{EntityQuery, EntityStore};
+            use crate::entities::EntityQuery;
 
             let entities = self
                 .entity_store
@@ -777,7 +785,7 @@ impl AgentLoop {
     /// query for more context (true) or proceed to plan (false).
     async fn entity_modification_decision(&self, context: &AgentContext) -> AgentResult<bool> {
         if let Some(provider) = &self.llm_provider {
-            use crate::entities::{EntityQuery, EntityStore};
+            use crate::entities::EntityQuery;
 
             let plan = self.plan_cache.as_deref().unwrap_or("No plan yet");
             let entity_count = self
@@ -890,7 +898,7 @@ impl AgentLoop {
     /// the Performing state instead.
     #[deprecated(note = "Use with_tools constructor for LLM-driven performing")]
     async fn perform_entity_modification_mvp(&mut self, context: &AgentContext) -> AgentResult<()> {
-        use crate::entities::{git::types::GitRepository, EntityStore};
+        use crate::entities::git::types::GitRepository;
 
         self.performed_actions += 1;
 

--- a/harness/src/entities/ast/mod.rs
+++ b/harness/src/entities/ast/mod.rs
@@ -9,9 +9,12 @@ pub mod types;
 
 pub use types::*;
 
-use crate::entities::{EntityStore, InMemoryEntityStore};
+use crate::entities::EntityStore;
 use std::path::Path;
 use thiserror::Error;
+
+#[cfg(test)]
+use crate::entities::InMemoryEntityStore;
 
 #[derive(Error, Debug)]
 pub enum ScanError {
@@ -76,21 +79,21 @@ impl WorkspaceScanner {
         name.starts_with('.')
     }
 
-    pub async fn scan_workspace(
+    pub async fn scan_workspace<S: EntityStore + Send + ?Sized>(
         &self,
         root: &Path,
-        store: &mut InMemoryEntityStore,
+        store: &mut S,
     ) -> ScanResult<usize> {
         let mut count = 0;
         self.scan_directory(root, root, store, &mut count).await?;
         Ok(count)
     }
 
-    fn scan_directory<'a>(
+    fn scan_directory<'a, S: EntityStore + Send + ?Sized>(
         &'a self,
         dir: &'a Path,
         root: &'a Path,
-        store: &'a mut InMemoryEntityStore,
+        store: &'a mut S,
         count: &'a mut usize,
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ScanResult<()>> + Send + 'a>> {
         Box::pin(async move {

--- a/harness/src/entities/mod.rs
+++ b/harness/src/entities/mod.rs
@@ -22,6 +22,7 @@ pub mod test;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::path::Path;
 use thiserror::Error;
 use uuid::Uuid;
 
@@ -329,6 +330,38 @@ pub trait EntityStore: Send + Sync {
         to: &str,
         relationship_type: RelationshipType,
     ) -> EntityResult<()>;
+
+    /// List all entity IDs for a given entity kind.
+    ///
+    /// The default implementation runs a full `query` constrained to the
+    /// requested kind and projects the IDs out of the results. Backends that
+    /// can answer this more cheaply (e.g. indexed SQL) should override it.
+    ///
+    /// This hook is introduced to prepare for the persistent-store work in
+    /// issue #193 (Phase A). It has no behavior change for the in-memory
+    /// store.
+    async fn list_by_kind(&self, kind: EntityType) -> EntityResult<Vec<EntityId>> {
+        let query = EntityQuery {
+            entity_types: vec![kind],
+            ..EntityQuery::default()
+        };
+        let results = self.query(&query).await?;
+        Ok(results.into_iter().map(|r| r.entity_id).collect())
+    }
+
+    /// Invalidate stale entries against the given workspace root.
+    ///
+    /// Persistent backends override this to drop entries whose backing
+    /// on-disk state has changed (file mtime advanced, HEAD commit moved,
+    /// etc.). The in-memory store has no persistence to invalidate, so the
+    /// default returns `Ok(0)`.
+    ///
+    /// Returns the number of entries that were invalidated/removed. Added
+    /// as part of issue #193 Phase A so that callers can be generified
+    /// against the trait ahead of the persistent-store implementation.
+    async fn invalidate_stale(&mut self, _workspace_root: &Path) -> EntityResult<usize> {
+        Ok(0)
+    }
 }
 
 /// In-memory entity store implementation (for testing and development)
@@ -509,5 +542,98 @@ mod tests {
         // Note: Full tests will be added when concrete entity types are implemented
         let store = InMemoryEntityStore::new();
         assert_eq!(store.entities.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_list_by_kind_returns_matching_ids() {
+        use crate::entities::context::types::ContextEntity;
+        use crate::entities::git::types::GitRepository;
+
+        let mut store = InMemoryEntityStore::new();
+
+        let git_entity =
+            Box::new(GitRepository::new(String::new(), "main".to_string())) as Box<dyn Entity>;
+        let git_id = store.store(git_entity).await.unwrap();
+
+        let context_entity = Box::new(ContextEntity::new(
+            "task".to_string(),
+            vec![],
+            vec![],
+            String::new(),
+            "model".to_string(),
+        )) as Box<dyn Entity>;
+        let context_id = store.store(context_entity).await.unwrap();
+
+        let git_ids = store.list_by_kind(EntityType::Git).await.unwrap();
+        assert_eq!(git_ids, vec![git_id.clone()]);
+
+        let context_ids = store.list_by_kind(EntityType::Context).await.unwrap();
+        assert_eq!(context_ids, vec![context_id.clone()]);
+
+        let ast_ids = store.list_by_kind(EntityType::Ast).await.unwrap();
+        assert!(ast_ids.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_invalidate_stale_default_is_noop() {
+        use crate::entities::git::types::GitRepository;
+
+        let mut store = InMemoryEntityStore::new();
+        let git_entity =
+            Box::new(GitRepository::new(String::new(), "main".to_string())) as Box<dyn Entity>;
+        store.store(git_entity).await.unwrap();
+
+        // The in-memory store uses the default impl, which is a no-op.
+        let invalidated = store
+            .invalidate_stale(std::path::Path::new("/nonexistent"))
+            .await
+            .unwrap();
+        assert_eq!(invalidated, 0);
+
+        // Entity should still be present.
+        let remaining = store.query(&EntityQuery::default()).await.unwrap();
+        assert_eq!(remaining.len(), 1);
+    }
+
+    /// Generic helper that exercises the `EntityStore` trait contract.
+    ///
+    /// Added as part of issue #193 Phase A so that future backends (e.g. the
+    /// planned `PersistentEntityStore`) can be validated against the same
+    /// sequence of operations as `InMemoryEntityStore`.
+    async fn exercise_store<S: EntityStore + ?Sized>(store: &mut S) {
+        use crate::entities::git::types::GitRepository;
+
+        // Store two entities.
+        let a = Box::new(GitRepository::new(String::new(), "main".to_string())) as Box<dyn Entity>;
+        let a_id = store.store(a).await.unwrap();
+
+        let b = Box::new(GitRepository::new(String::new(), "dev".to_string())) as Box<dyn Entity>;
+        let b_id = store.store(b).await.unwrap();
+
+        assert!(store.exists(&a_id).await);
+        assert!(store.exists(&b_id).await);
+
+        // list_by_kind should enumerate both Git entities.
+        let git_ids = store.list_by_kind(EntityType::Git).await.unwrap();
+        assert_eq!(git_ids.len(), 2);
+
+        // Delete one and verify.
+        store.delete(&a_id).await.unwrap();
+        assert!(!store.exists(&a_id).await);
+
+        let remaining = store.list_by_kind(EntityType::Git).await.unwrap();
+        assert_eq!(remaining, vec![b_id.clone()]);
+
+        // invalidate_stale should be callable through the trait.
+        let _ = store
+            .invalidate_stale(std::path::Path::new("/tmp"))
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_exercise_store_with_in_memory() {
+        let mut store = InMemoryEntityStore::new();
+        exercise_store(&mut store).await;
     }
 }

--- a/harness/src/main.rs
+++ b/harness/src/main.rs
@@ -7,6 +7,11 @@ use model::prelude::*;
 use std::io::{self, Write};
 use tracing::{error, info};
 
+// NOTE: `main.rs` binds the workspace entity store to `InMemoryEntityStore`
+// concretely today, but the downstream callers accept any `EntityStore` via
+// generics (see `AgentLoop<S>` and `interactive_chat`). Issue #193 Phase B
+// will introduce `PersistentEntityStore` and swap the binding here.
+
 #[derive(Parser)]
 #[command(name = "harness")]
 #[command(about = "A CLI tool for interacting with language models")]
@@ -248,13 +253,13 @@ async fn single_chat(
     Ok(())
 }
 
-async fn interactive_chat(
+async fn interactive_chat<S: EntityStore + Send>(
     provider: &OllamaProvider,
     tool_registry: &ToolRegistry,
     model: &str,
     enable_tools: bool,
     temperature: f32,
-    entity_store: InMemoryEntityStore,
+    entity_store: S,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let entity_count = entity_store
         .query(&harness::entities::EntityQuery::default())


### PR DESCRIPTION
## Summary

Phase A of the persistent entity store work (issue #193). This PR is a **mechanical refactor with no behavior change**; it exists to unblock the Phase B skeleton without dragging SQL/rusqlite changes into review.

- Add two default-implemented hooks to the `EntityStore` trait:
  - `async fn list_by_kind(&self, kind: EntityType) -> EntityResult<Vec<EntityId>>` — default impl projects `query(EntityQuery { entity_types: vec![kind], .. })`.
  - `async fn invalidate_stale(&mut self, workspace_root: &Path) -> EntityResult<usize>` — default `Ok(0)` so `InMemoryEntityStore` is a no-op.
- Make `AgentLoop` generic over `S: EntityStore + Send` with a default of `InMemoryEntityStore`, so existing callers compile unchanged. `AgentLoop::new` stays on the `InMemoryEntityStore` impl; `with_entity_store`, `with_llm`, `with_tools` are generic.
- Generify `WorkspaceScanner::scan_workspace` and `main::interactive_chat` / `agent::eval::evaluate_rag_relevance` so they no longer concretely depend on `InMemoryEntityStore`.
- Add tests for `list_by_kind`, `invalidate_stale` (no-op contract), and a generic `exercise_store<S: EntityStore>` helper invoked against `InMemoryEntityStore` to keep the trait contract honest for future backends.

## Feedback loop (green)

- `cargo fmt --all -- --check` — clean
- `cargo clippy -p harness --all-targets --all-features -- -D warnings` — clean
- `cargo test -p harness` — 288 lib + 98 integration tests pass (386 total, no regressions); 3 new tests added cover the trait additions.

## Explicit non-goals (deferred to later phases)

- **Phase B**: add `rusqlite` / `directories` / `fs4` / `blake3` deps; `PersistentEntityStore` skeleton with schema DDL + metadata R/W + `open_or_create`.
- **Phase C**: SQL-backed CRUD (`store` / `update` / `delete` / `query`) with write-through from the in-memory hot path.
- **Phase D**: invalidation logic (file mtime + git HEAD/porcelain hash) + `tracing` events.
- **Phase E**: wire into `main.rs`: `--entity-cache <path>` / `--no-entity-cache` CLI flags, `NANNA_ENTITY_CACHE` env, swap `initialize_workspace` binding.
- **Phase F**: `schema_version = 1` + wipe-on-mismatch (no migrations yet).

## REQUIRED design decision before Phase B can land

The `Entity` trait currently exposes `fn to_json(&self) -> EntityResult<String>` but has **no** `from_json` / `Deserialize` counterpart, and `Box<dyn Entity>` cannot be reconstructed from a BLOB without a registry or enum wrapper. This blocks hydration of the persistent store.

Three options, each with different blast radius on existing code:

- **(a) Enum wrapper**: introduce `enum EntityPayload { Git(GitRepository), Ast(FileEntity), ... }` with `#[serde(tag = "kind")]`. Pro: purely declarative, single source of truth. Con: every new concrete entity type must be added to the enum — closed world.
- **(b) `inventory`-style registry**: `Kind → fn(serde_json::Value) -> Box<dyn Entity>` deserializers registered at module-init. Pro: keeps `Box<dyn Entity>` as the currency, open world. Con: requires `inventory` or `linkme` dep and `ctor`-style registration; harder to trace.
- **(c) Typed sub-stores keyed by kind**: one concretely-typed store per `EntityType` (`GitStore`, `AstStore`, ...), avoids erasure entirely. Pro: no serde gymnastics. Con: biggest refactor — `EntityStore` as a facade over sub-stores, all call sites touching the trait today need to pick a kind up front.

**Please pick one before Phase B starts.** My lean is (a) for scope/simplicity unless the "learned patterns" work (see review) needs open-world entity types, in which case (b).

Refs #193

https://claude.ai/code/session_01EWkGgVyjb3196n8qompeGL