### PR TITLE
feat(harness/agent): project prompt loader + language/framework detectors (#194 Phase A+B)

### DIFF
--- a/harness/src/agent/mod.rs
+++ b/harness/src/agent/mod.rs
@@ -15,6 +15,8 @@
 pub mod decision;
 pub mod eval;
 pub mod eval_case;
+pub mod project_detect;
+pub mod project_prompt;
 pub mod prompts;
 pub mod rag;
 

--- a/harness/src/agent/project_detect.rs
+++ b/harness/src/agent/project_detect.rs
@@ -1,0 +1,670 @@
+//! Language, framework, and CI-expectation detectors for the workspace root.
+//!
+//! Each detector is a pure function that reads a single file (or directory)
+//! under `workspace_root` and emits zero or more [`Signal`]s. [`detect`]
+//! composes them into a [`DetectedProfile`] that downstream phases will feed
+//! into the system-prompt assembler (issue #194, Phase B).
+//!
+//! # Relationship to the existing hardcoded system prompt
+//!
+//! This module only produces data. It does **not** modify the two current
+//! hardcoded system-prompt call sites:
+//!
+//! - `harness/src/main.rs:425`
+//! - `harness/src/task.rs:369`
+//!
+//! Those are rewritten in Phase D. Phase B (this module) is deliberately
+//! limited to detector logic + tests so it can land in parallel with the
+//! Phase A loader.
+//!
+//! # Design notes
+//!
+//! - All detectors tolerate missing or malformed files and return an empty
+//!   [`Vec<Signal>`] in those cases. Parse errors are silently dropped: a
+//!   project with a broken `Cargo.toml` should still produce an agent prompt.
+//! - Detectors do not walk outside `workspace_root` except for the
+//!   single-level glob in [`detect_github_workflows`].
+//! - The enums are deliberately closed - new languages or frameworks require
+//!   a code change (and a test) so typos cannot sneak in via config.
+
+use regex::Regex;
+use serde::Deserialize;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Detected languages in a workspace.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum Language {
+    Rust,
+    Node,
+    Python,
+    Go,
+    Nix,
+}
+
+/// Detected testing / tooling frameworks.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum Framework {
+    Cargo,
+    Nextest,
+    Tokio,
+    Proptest,
+    Criterion,
+    Jest,
+    Vitest,
+    Mocha,
+    Playwright,
+    Pytest,
+    Poetry,
+    Uv,
+    Ruff,
+    Mypy,
+    Tox,
+    Flake,
+}
+
+/// Aggregated detection result for the whole workspace.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct DetectedProfile {
+    pub languages: Vec<Language>,
+    pub frameworks: Vec<Framework>,
+    pub ci_expectations: Vec<String>,
+}
+
+/// A single detector observation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Signal {
+    Language(Language),
+    Framework(Framework),
+    /// Free-form CI or tooling expectation, e.g. "use `cargo nextest run`".
+    CiExpectation(String),
+}
+
+/// Run every detector against `workspace_root` and compose a
+/// [`DetectedProfile`]. Duplicate signals are de-duplicated while preserving
+/// first-seen order.
+pub fn detect(workspace_root: &Path) -> DetectedProfile {
+    let mut signals = Vec::new();
+    signals.extend(detect_cargo_toml(workspace_root));
+    signals.extend(detect_package_json(workspace_root));
+    signals.extend(detect_pyproject_toml(workspace_root));
+    signals.extend(detect_requirements_txt(workspace_root));
+    signals.extend(detect_go_mod(workspace_root));
+    signals.extend(detect_flake_nix(workspace_root));
+    signals.extend(detect_github_workflows(workspace_root));
+
+    let mut profile = DetectedProfile::default();
+    for signal in signals {
+        match signal {
+            Signal::Language(l) => {
+                if !profile.languages.contains(&l) {
+                    profile.languages.push(l);
+                }
+            }
+            Signal::Framework(f) => {
+                if !profile.frameworks.contains(&f) {
+                    profile.frameworks.push(f);
+                }
+            }
+            Signal::CiExpectation(s) => {
+                if !profile.ci_expectations.contains(&s) {
+                    profile.ci_expectations.push(s);
+                }
+            }
+        }
+    }
+    profile
+}
+
+/// Read `workspace_root/Cargo.toml` if present and emit Rust + detected
+/// dev-dependency frameworks.
+pub fn detect_cargo_toml(workspace_root: &Path) -> Vec<Signal> {
+    let path = workspace_root.join("Cargo.toml");
+    let Ok(contents) = fs::read_to_string(&path) else {
+        return Vec::new();
+    };
+    let Ok(parsed) = toml::from_str::<CargoManifest>(&contents) else {
+        // Tolerate malformed manifests - still at least flag Rust.
+        return vec![
+            Signal::Language(Language::Rust),
+            Signal::Framework(Framework::Cargo),
+        ];
+    };
+
+    let mut out = vec![
+        Signal::Language(Language::Rust),
+        Signal::Framework(Framework::Cargo),
+    ];
+
+    for (name, _) in parsed.dev_dependencies.iter() {
+        match name.as_str() {
+            "nextest" | "cargo-nextest" => out.push(Signal::Framework(Framework::Nextest)),
+            "tokio" => out.push(Signal::Framework(Framework::Tokio)),
+            "proptest" => out.push(Signal::Framework(Framework::Proptest)),
+            "criterion" => out.push(Signal::Framework(Framework::Criterion)),
+            _ => {}
+        }
+    }
+    // tokio often appears in regular [dependencies] too for async projects.
+    for (name, _) in parsed.dependencies.iter() {
+        if name == "tokio" {
+            out.push(Signal::Framework(Framework::Tokio));
+        }
+    }
+
+    out
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct CargoManifest {
+    #[serde(default, rename = "dev-dependencies")]
+    dev_dependencies: toml::Table,
+    #[serde(default)]
+    dependencies: toml::Table,
+}
+
+/// Read `workspace_root/package.json` if present and emit Node + JS
+/// test-framework signals from `devDependencies` and `scripts`.
+pub fn detect_package_json(workspace_root: &Path) -> Vec<Signal> {
+    let path = workspace_root.join("package.json");
+    let Ok(contents) = fs::read_to_string(&path) else {
+        return Vec::new();
+    };
+    let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&contents) else {
+        return vec![Signal::Language(Language::Node)];
+    };
+
+    let mut out = vec![Signal::Language(Language::Node)];
+
+    let mut names: Vec<String> = Vec::new();
+    if let Some(dd) = parsed.get("devDependencies").and_then(|v| v.as_object()) {
+        names.extend(dd.keys().cloned());
+    }
+    if let Some(d) = parsed.get("dependencies").and_then(|v| v.as_object()) {
+        names.extend(d.keys().cloned());
+    }
+    let scripts_blob = parsed
+        .get("scripts")
+        .and_then(|v| v.as_object())
+        .map(|obj| {
+            obj.values()
+                .filter_map(|v| v.as_str())
+                .collect::<Vec<_>>()
+                .join(" ")
+        })
+        .unwrap_or_default();
+
+    let push_if = |condition: bool, fw: Framework, out: &mut Vec<Signal>| {
+        if condition {
+            out.push(Signal::Framework(fw));
+        }
+    };
+
+    let has = |needle: &str| {
+        names.iter().any(|n| n == needle) || scripts_blob.split_whitespace().any(|w| w == needle)
+    };
+
+    push_if(has("jest"), Framework::Jest, &mut out);
+    push_if(has("vitest"), Framework::Vitest, &mut out);
+    push_if(has("mocha"), Framework::Mocha, &mut out);
+    push_if(
+        has("playwright") || names.iter().any(|n| n == "@playwright/test"),
+        Framework::Playwright,
+        &mut out,
+    );
+
+    out
+}
+
+/// Read `workspace_root/pyproject.toml` and emit Python + Python-tooling
+/// framework signals based on `[tool.*]` tables.
+pub fn detect_pyproject_toml(workspace_root: &Path) -> Vec<Signal> {
+    let path = workspace_root.join("pyproject.toml");
+    let Ok(contents) = fs::read_to_string(&path) else {
+        return Vec::new();
+    };
+    let Ok(parsed) = toml::from_str::<toml::Value>(&contents) else {
+        return vec![Signal::Language(Language::Python)];
+    };
+
+    let mut out = vec![Signal::Language(Language::Python)];
+    let tool = parsed.get("tool").and_then(|v| v.as_table());
+
+    if let Some(tool) = tool {
+        if tool
+            .get("pytest")
+            .and_then(|v| v.as_table())
+            .and_then(|t| t.get("ini_options"))
+            .is_some()
+            || tool.contains_key("pytest")
+        {
+            out.push(Signal::Framework(Framework::Pytest));
+        }
+        if tool.contains_key("poetry") {
+            out.push(Signal::Framework(Framework::Poetry));
+        }
+        if tool.contains_key("uv") {
+            out.push(Signal::Framework(Framework::Uv));
+        }
+        if tool.contains_key("ruff") {
+            out.push(Signal::Framework(Framework::Ruff));
+        }
+        if tool.contains_key("mypy") {
+            out.push(Signal::Framework(Framework::Mypy));
+        }
+    }
+
+    out
+}
+
+/// Read `workspace_root/requirements.txt` and regex-scan for pytest / tox
+/// entries.
+pub fn detect_requirements_txt(workspace_root: &Path) -> Vec<Signal> {
+    let path = workspace_root.join("requirements.txt");
+    let Ok(contents) = fs::read_to_string(&path) else {
+        return Vec::new();
+    };
+
+    let mut out = vec![Signal::Language(Language::Python)];
+
+    // Match package name at line start (allowing leading whitespace) followed
+    // by end-of-name punctuation. Case-insensitive.
+    let pytest_re = Regex::new(r"(?im)^\s*pytest(\s*$|[\[=<>!~])").unwrap();
+    let tox_re = Regex::new(r"(?im)^\s*tox(\s*$|[\[=<>!~])").unwrap();
+
+    if pytest_re.is_match(&contents) {
+        out.push(Signal::Framework(Framework::Pytest));
+    }
+    if tox_re.is_match(&contents) {
+        out.push(Signal::Framework(Framework::Tox));
+    }
+
+    out
+}
+
+/// Detect Go via `go.mod`. Requires a `go <version>` directive.
+pub fn detect_go_mod(workspace_root: &Path) -> Vec<Signal> {
+    let path = workspace_root.join("go.mod");
+    let Ok(contents) = fs::read_to_string(&path) else {
+        return Vec::new();
+    };
+    let re = Regex::new(r"(?m)^go\s+\d+\.\d+").unwrap();
+    if re.is_match(&contents) {
+        vec![Signal::Language(Language::Go)]
+    } else {
+        Vec::new()
+    }
+}
+
+/// Detect Nix flakes by file existence.
+pub fn detect_flake_nix(workspace_root: &Path) -> Vec<Signal> {
+    let path = workspace_root.join("flake.nix");
+    if path.is_file() {
+        vec![
+            Signal::Language(Language::Nix),
+            Signal::Framework(Framework::Flake),
+            Signal::CiExpectation(
+                "use `nix develop --command ...` for hermetic builds".to_string(),
+            ),
+        ]
+    } else {
+        Vec::new()
+    }
+}
+
+/// Walk `.github/workflows/*.yml` (and `.yaml`) and regex-scan `run:` lines
+/// for CI expectations that the agent should respect.
+pub fn detect_github_workflows(workspace_root: &Path) -> Vec<Signal> {
+    let dir = workspace_root.join(".github").join("workflows");
+    let Ok(entries) = fs::read_dir(&dir) else {
+        return Vec::new();
+    };
+
+    let mut paths: Vec<PathBuf> = entries
+        .filter_map(|r| r.ok())
+        .map(|e| e.path())
+        .filter(|p| {
+            p.is_file()
+                && matches!(
+                    p.extension().and_then(|e| e.to_str()),
+                    Some("yml") | Some("yaml")
+                )
+        })
+        .collect();
+    paths.sort();
+
+    // Match a YAML run-step: lines like `- run: cargo fmt` or `run: |` blocks.
+    let run_re = Regex::new(r"(?m)^\s*-?\s*run:\s*(.*)$").unwrap();
+
+    let mut out = Vec::new();
+    let seen = |needle: &str, expectation: &str, out: &mut Vec<Signal>| {
+        let exp = expectation.to_string();
+        if !out
+            .iter()
+            .any(|s| matches!(s, Signal::CiExpectation(e) if e == &exp))
+        {
+            out.push(Signal::CiExpectation(exp));
+        }
+        let _ = needle;
+    };
+
+    for path in paths {
+        let Ok(contents) = fs::read_to_string(&path) else {
+            continue;
+        };
+        // Collect each `run:` tail plus any indented continuation for `run: |`.
+        // For simplicity we scan the entire file body against each needle; the
+        // YAML structure is only used to skip obvious non-run lines.
+        let mut run_bodies = String::new();
+        for cap in run_re.captures_iter(&contents) {
+            run_bodies.push_str(cap.get(1).map_or("", |m| m.as_str()));
+            run_bodies.push('\n');
+        }
+        // Also include the whole file so multi-line `run: |` blocks are caught
+        // (cheap and safe - false positives here would only be other YAML
+        // strings that literally mention these commands).
+        let haystack = format!("{run_bodies}\n{contents}");
+
+        if haystack.contains("cargo fmt") {
+            seen("cargo fmt", "CI runs `cargo fmt -- --check`", &mut out);
+        }
+        if haystack.contains("cargo clippy") {
+            seen(
+                "cargo clippy",
+                "CI runs `cargo clippy -- -D warnings`",
+                &mut out,
+            );
+        }
+        if haystack.contains("cargo deny") {
+            seen("cargo deny", "CI runs `cargo deny check`", &mut out);
+        }
+        if haystack.contains("nextest") {
+            seen("nextest", "CI runs tests via `cargo nextest`", &mut out);
+        }
+    }
+
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    fn write(dir: &Path, rel: &str, contents: &str) {
+        let path = dir.join(rel);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(path, contents).unwrap();
+    }
+
+    #[test]
+    fn cargo_toml_rust_plus_frameworks() {
+        let dir = tempdir().unwrap();
+        write(
+            dir.path(),
+            "Cargo.toml",
+            r#"
+[package]
+name = "x"
+version = "0.1.0"
+
+[dependencies]
+tokio = "1"
+
+[dev-dependencies]
+nextest = "0.9"
+proptest = "1"
+criterion = "0.5"
+"#,
+        );
+        let signals = detect_cargo_toml(dir.path());
+        assert!(signals.contains(&Signal::Language(Language::Rust)));
+        assert!(signals.contains(&Signal::Framework(Framework::Cargo)));
+        assert!(signals.contains(&Signal::Framework(Framework::Nextest)));
+        assert!(signals.contains(&Signal::Framework(Framework::Tokio)));
+        assert!(signals.contains(&Signal::Framework(Framework::Proptest)));
+        assert!(signals.contains(&Signal::Framework(Framework::Criterion)));
+    }
+
+    #[test]
+    fn cargo_toml_missing_returns_empty() {
+        let dir = tempdir().unwrap();
+        assert!(detect_cargo_toml(dir.path()).is_empty());
+    }
+
+    #[test]
+    fn cargo_toml_malformed_still_flags_rust() {
+        let dir = tempdir().unwrap();
+        write(dir.path(), "Cargo.toml", "this is = = not toml");
+        let signals = detect_cargo_toml(dir.path());
+        assert!(signals.contains(&Signal::Language(Language::Rust)));
+    }
+
+    #[test]
+    fn package_json_node_plus_frameworks() {
+        let dir = tempdir().unwrap();
+        write(
+            dir.path(),
+            "package.json",
+            r#"{
+  "name": "x",
+  "devDependencies": {
+    "jest": "^29",
+    "@playwright/test": "^1"
+  },
+  "scripts": {
+    "test": "vitest run",
+    "e2e": "playwright test"
+  }
+}"#,
+        );
+        let signals = detect_package_json(dir.path());
+        assert!(signals.contains(&Signal::Language(Language::Node)));
+        assert!(signals.contains(&Signal::Framework(Framework::Jest)));
+        assert!(signals.contains(&Signal::Framework(Framework::Vitest)));
+        assert!(signals.contains(&Signal::Framework(Framework::Playwright)));
+        assert!(!signals.contains(&Signal::Framework(Framework::Mocha)));
+    }
+
+    #[test]
+    fn package_json_missing_returns_empty() {
+        let dir = tempdir().unwrap();
+        assert!(detect_package_json(dir.path()).is_empty());
+    }
+
+    #[test]
+    fn pyproject_toml_tool_tables() {
+        let dir = tempdir().unwrap();
+        write(
+            dir.path(),
+            "pyproject.toml",
+            r#"
+[tool.poetry]
+name = "x"
+
+[tool.pytest.ini_options]
+minversion = "7"
+
+[tool.ruff]
+line-length = 100
+
+[tool.mypy]
+strict = true
+
+[tool.uv]
+"#,
+        );
+        let signals = detect_pyproject_toml(dir.path());
+        assert!(signals.contains(&Signal::Language(Language::Python)));
+        assert!(signals.contains(&Signal::Framework(Framework::Pytest)));
+        assert!(signals.contains(&Signal::Framework(Framework::Poetry)));
+        assert!(signals.contains(&Signal::Framework(Framework::Ruff)));
+        assert!(signals.contains(&Signal::Framework(Framework::Mypy)));
+        assert!(signals.contains(&Signal::Framework(Framework::Uv)));
+    }
+
+    #[test]
+    fn requirements_txt_scans_pytest_and_tox() {
+        let dir = tempdir().unwrap();
+        write(
+            dir.path(),
+            "requirements.txt",
+            "requests==2.31.0\npytest>=7.0\ntox\n",
+        );
+        let signals = detect_requirements_txt(dir.path());
+        assert!(signals.contains(&Signal::Language(Language::Python)));
+        assert!(signals.contains(&Signal::Framework(Framework::Pytest)));
+        assert!(signals.contains(&Signal::Framework(Framework::Tox)));
+    }
+
+    #[test]
+    fn requirements_txt_no_matching_deps() {
+        let dir = tempdir().unwrap();
+        write(dir.path(), "requirements.txt", "requests==2.31.0\n");
+        let signals = detect_requirements_txt(dir.path());
+        assert!(signals.contains(&Signal::Language(Language::Python)));
+        assert!(!signals.contains(&Signal::Framework(Framework::Pytest)));
+    }
+
+    #[test]
+    fn go_mod_version_detected() {
+        let dir = tempdir().unwrap();
+        write(dir.path(), "go.mod", "module x\n\ngo 1.22\n");
+        let signals = detect_go_mod(dir.path());
+        assert!(signals.contains(&Signal::Language(Language::Go)));
+    }
+
+    #[test]
+    fn go_mod_missing_version_not_detected() {
+        let dir = tempdir().unwrap();
+        write(dir.path(), "go.mod", "module x\n");
+        assert!(detect_go_mod(dir.path()).is_empty());
+    }
+
+    #[test]
+    fn flake_nix_present_emits_expectation() {
+        let dir = tempdir().unwrap();
+        write(dir.path(), "flake.nix", "{ outputs = _: {}; }");
+        let signals = detect_flake_nix(dir.path());
+        assert!(signals.contains(&Signal::Language(Language::Nix)));
+        assert!(signals.contains(&Signal::Framework(Framework::Flake)));
+        assert!(signals.iter().any(|s| matches!(
+            s,
+            Signal::CiExpectation(msg) if msg.contains("nix develop")
+        )));
+    }
+
+    #[test]
+    fn flake_nix_missing_emits_nothing() {
+        let dir = tempdir().unwrap();
+        assert!(detect_flake_nix(dir.path()).is_empty());
+    }
+
+    #[test]
+    fn github_workflows_finds_cargo_commands() {
+        let dir = tempdir().unwrap();
+        write(
+            dir.path(),
+            ".github/workflows/ci.yml",
+            r#"
+name: ci
+on: [push]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: cargo fmt --all -- --check
+      - run: cargo clippy --all-targets -- -D warnings
+      - run: cargo deny check
+      - run: cargo nextest run
+"#,
+        );
+        let signals = detect_github_workflows(dir.path());
+        assert!(signals
+            .iter()
+            .any(|s| matches!(s, Signal::CiExpectation(m) if m.contains("cargo fmt"))));
+        assert!(signals
+            .iter()
+            .any(|s| matches!(s, Signal::CiExpectation(m) if m.contains("clippy"))));
+        assert!(signals
+            .iter()
+            .any(|s| matches!(s, Signal::CiExpectation(m) if m.contains("deny"))));
+        assert!(signals
+            .iter()
+            .any(|s| matches!(s, Signal::CiExpectation(m) if m.contains("nextest"))));
+    }
+
+    #[test]
+    fn github_workflows_directory_absent() {
+        let dir = tempdir().unwrap();
+        assert!(detect_github_workflows(dir.path()).is_empty());
+    }
+
+    #[test]
+    fn composite_rust_nix_ci_profile() {
+        let dir = tempdir().unwrap();
+        write(
+            dir.path(),
+            "Cargo.toml",
+            r#"
+[package]
+name = "x"
+version = "0.1.0"
+
+[dev-dependencies]
+nextest = "0.9"
+tokio = "1"
+"#,
+        );
+        write(dir.path(), "flake.nix", "{ outputs = _: {}; }");
+        write(
+            dir.path(),
+            ".github/workflows/ci.yml",
+            "jobs:\n  t:\n    steps:\n      - run: cargo fmt -- --check\n      - run: cargo nextest run\n",
+        );
+
+        let profile = detect(dir.path());
+
+        assert!(profile.languages.contains(&Language::Rust));
+        assert!(profile.languages.contains(&Language::Nix));
+        assert!(profile.frameworks.contains(&Framework::Cargo));
+        assert!(profile.frameworks.contains(&Framework::Nextest));
+        assert!(profile.frameworks.contains(&Framework::Tokio));
+        assert!(profile.frameworks.contains(&Framework::Flake));
+
+        // CI expectations should cover both the nix-develop hint and the
+        // cargo-fmt / nextest lines from workflows.
+        assert!(profile
+            .ci_expectations
+            .iter()
+            .any(|m| m.contains("nix develop")));
+        assert!(profile
+            .ci_expectations
+            .iter()
+            .any(|m| m.contains("cargo fmt")));
+        assert!(profile
+            .ci_expectations
+            .iter()
+            .any(|m| m.contains("nextest")));
+
+        // Deduplication: each language / framework appears exactly once.
+        let rust_count = profile
+            .languages
+            .iter()
+            .filter(|l| **l == Language::Rust)
+            .count();
+        assert_eq!(rust_count, 1);
+    }
+
+    #[test]
+    fn empty_workspace_yields_empty_profile() {
+        let dir = tempdir().unwrap();
+        let profile = detect(dir.path());
+        assert!(profile.languages.is_empty());
+        assert!(profile.frameworks.is_empty());
+        assert!(profile.ci_expectations.is_empty());
+    }
+}

--- a/harness/src/agent/project_prompt.rs
+++ b/harness/src/agent/project_prompt.rs
@@ -1,0 +1,333 @@
+//! Per-project prompt configuration loader.
+//!
+//! Reads an optional `.nanna/prompt.md` file at the workspace root and parses
+//! it into a [`ProjectPromptDoc`] consisting of optional TOML front-matter plus
+//! a Markdown body. This is the first of several phases implementing
+//! domain-specific system prompts (see issue #194, Phase A).
+//!
+//! # Relationship to the existing hardcoded system prompt
+//!
+//! The current hardcoded system prompt lives in two call sites that will be
+//! rewritten in Phase D of the issue-194 roll-out:
+//!
+//! - `harness/src/main.rs:425` (`AgentConfig { system_prompt: ... }` in the
+//!   CLI entry point)
+//! - `harness/src/task.rs:369` (same string in the task-dispatch path)
+//!
+//! Phase A (this module) only introduces the loader - neither call site is
+//! modified here. Phases C (assembler) and D (wiring) will replace those
+//! hardcoded strings with the layered, detector-augmented assembly produced
+//! from a [`ProjectPromptDoc`].
+//!
+//! # File format
+//!
+//! ```text
+//! +++
+//! language_override = "rust"
+//! frameworks = ["tokio", "nextest"]
+//! max_tokens = 1200
+//! +++
+//!
+//! # Project guidance
+//! Use `nix develop --command cargo nextest run` for tests.
+//! ```
+//!
+//! Front-matter is optional. When absent, the entire file is treated as the
+//! body and `frontmatter` is [`Default`]. Unknown keys in the front-matter
+//! are rejected (`#[serde(deny_unknown_fields)]`) so typos surface early.
+
+use serde::Deserialize;
+use std::fs;
+use std::io;
+use std::path::Path;
+
+/// Maximum allowed size of `.nanna/prompt.md` on disk, in bytes.
+pub const MAX_PROMPT_FILE_BYTES: u64 = 64 * 1024;
+
+/// Relative path of the per-project prompt file within a workspace.
+pub const PROMPT_FILE_REL_PATH: &str = ".nanna/prompt.md";
+
+/// Parsed representation of `.nanna/prompt.md`.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct ProjectPromptDoc {
+    /// Structured hints from the TOML front-matter.
+    pub frontmatter: ProjectPromptFrontMatter,
+    /// Markdown body (everything after the closing `+++` delimiter, or the
+    /// whole file if no front-matter is present).
+    pub body: String,
+}
+
+/// Structured front-matter hints.
+///
+/// Unknown keys are rejected at parse time to catch typos early. Extending
+/// the schema therefore requires adding a field here.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Deserialize)]
+#[serde(deny_unknown_fields, default)]
+pub struct ProjectPromptFrontMatter {
+    /// Force a language and skip auto-detection in Phase B.
+    pub language_override: Option<String>,
+    /// Additional framework hints to merge with detected frameworks.
+    pub frameworks: Vec<String>,
+    /// Optional soft cap on assembled prompt tokens (consumed in Phase C).
+    pub max_tokens: Option<usize>,
+}
+
+/// Load and parse `.nanna/prompt.md` from `workspace_root`, if it exists.
+///
+/// Returns `Ok(None)` when the file is absent - a fresh checkout should not
+/// produce warnings. All other errors (oversize file, control chars in body,
+/// malformed TOML front-matter, unknown front-matter keys) are surfaced as
+/// [`io::Error`] with a descriptive message.
+pub fn load(workspace_root: &Path) -> io::Result<Option<ProjectPromptDoc>> {
+    let path = workspace_root.join(PROMPT_FILE_REL_PATH);
+
+    let metadata = match fs::metadata(&path) {
+        Ok(m) => m,
+        Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => return Err(e),
+    };
+
+    if metadata.len() > MAX_PROMPT_FILE_BYTES {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "{} exceeds maximum size of {} bytes (actual: {})",
+                path.display(),
+                MAX_PROMPT_FILE_BYTES,
+                metadata.len()
+            ),
+        ));
+    }
+
+    let raw = fs::read_to_string(&path)?;
+    parse(&raw).map(Some)
+}
+
+/// Parse a raw prompt-file string into a [`ProjectPromptDoc`].
+///
+/// Exposed for unit tests; callers should prefer [`load`].
+fn parse(raw: &str) -> io::Result<ProjectPromptDoc> {
+    let (frontmatter_str, body) = split_frontmatter(raw);
+
+    let frontmatter = match frontmatter_str {
+        Some(fm) => toml::from_str::<ProjectPromptFrontMatter>(fm).map_err(|e| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("failed to parse TOML front-matter: {e}"),
+            )
+        })?,
+        None => ProjectPromptFrontMatter::default(),
+    };
+
+    reject_disallowed_control_chars(body)?;
+
+    Ok(ProjectPromptDoc {
+        frontmatter,
+        body: body.to_string(),
+    })
+}
+
+/// If `raw` starts with a `+++` fenced block, return `(Some(inner), rest)`;
+/// otherwise `(None, raw)`.
+///
+/// The opening fence must be at byte offset 0 and the closing fence must be
+/// on its own line. Unterminated front-matter is treated as "no front-matter"
+/// so a stray `+++` at the top of an otherwise-valid markdown file doesn't
+/// eat the body.
+fn split_frontmatter(raw: &str) -> (Option<&str>, &str) {
+    let Some(after_open) = raw.strip_prefix("+++\n") else {
+        return (None, raw);
+    };
+
+    // Look for a line consisting solely of `+++` (optionally followed by \n).
+    let mut search_start = 0usize;
+    while let Some(pos) = after_open[search_start..].find("+++") {
+        let absolute = search_start + pos;
+        // The fence must start at beginning-of-line: either offset 0 or
+        // preceded by '\n'.
+        let at_line_start = absolute == 0 || after_open.as_bytes()[absolute - 1] == b'\n';
+        // The fence must be followed by EOL or EOF.
+        let end = absolute + 3;
+        let followed_by_eol = match after_open.as_bytes().get(end) {
+            None => true,
+            Some(&b'\n') => true,
+            Some(&b'\r') => matches!(after_open.as_bytes().get(end + 1), Some(&b'\n')),
+            _ => false,
+        };
+
+        if at_line_start && followed_by_eol {
+            let inner = &after_open[..absolute];
+            // Trim the trailing newline that belongs to the "+++" line above.
+            let inner = inner.strip_suffix('\n').unwrap_or(inner);
+            // Skip past the closing fence and its line terminator.
+            let mut body_start = end;
+            if after_open.as_bytes().get(body_start) == Some(&b'\r') {
+                body_start += 1;
+            }
+            if after_open.as_bytes().get(body_start) == Some(&b'\n') {
+                body_start += 1;
+            }
+            let body = &after_open[body_start..];
+            return (Some(inner), body);
+        }
+
+        search_start = absolute + 3;
+    }
+
+    (None, raw)
+}
+
+/// Reject ASCII control characters that have no legitimate use in a prompt
+/// body: `\x00-\x08`, `\x0B`, `\x0C`, `\x0E-\x1F`. Tab (`\x09`), LF (`\x0A`)
+/// and CR (`\x0D`) are allowed.
+fn reject_disallowed_control_chars(body: &str) -> io::Result<()> {
+    for (idx, ch) in body.char_indices() {
+        let c = ch as u32;
+        let disallowed = (c <= 0x08) || c == 0x0B || c == 0x0C || (0x0E..=0x1F).contains(&c);
+        if disallowed {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "prompt body contains disallowed control character U+{c:04X} at byte offset {idx}"
+                ),
+            ));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    fn write_prompt(dir: &Path, contents: &[u8]) {
+        let nanna = dir.join(".nanna");
+        fs::create_dir_all(&nanna).unwrap();
+        fs::write(nanna.join("prompt.md"), contents).unwrap();
+    }
+
+    #[test]
+    fn missing_file_returns_ok_none() {
+        let dir = tempdir().unwrap();
+        let result = load(dir.path()).expect("load must not error on missing file");
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn file_without_frontmatter_has_default_frontmatter() {
+        let dir = tempdir().unwrap();
+        let body = "# Project guidance\n\nUse nextest.\n";
+        write_prompt(dir.path(), body.as_bytes());
+
+        let doc = load(dir.path()).unwrap().expect("should return Some");
+        assert_eq!(doc.frontmatter, ProjectPromptFrontMatter::default());
+        assert_eq!(doc.body, body);
+    }
+
+    #[test]
+    fn file_with_frontmatter_parses_fields() {
+        let dir = tempdir().unwrap();
+        let contents = "+++\nlanguage_override = \"rust\"\nframeworks = [\"tokio\", \"nextest\"]\nmax_tokens = 1200\n+++\n# Body\nHello.\n";
+        write_prompt(dir.path(), contents.as_bytes());
+
+        let doc = load(dir.path()).unwrap().unwrap();
+        assert_eq!(doc.frontmatter.language_override.as_deref(), Some("rust"));
+        assert_eq!(doc.frontmatter.frameworks, vec!["tokio", "nextest"]);
+        assert_eq!(doc.frontmatter.max_tokens, Some(1200));
+        assert_eq!(doc.body, "# Body\nHello.\n");
+    }
+
+    #[test]
+    fn frontmatter_only_no_body() {
+        let dir = tempdir().unwrap();
+        let contents = "+++\nmax_tokens = 42\n+++\n";
+        write_prompt(dir.path(), contents.as_bytes());
+
+        let doc = load(dir.path()).unwrap().unwrap();
+        assert_eq!(doc.frontmatter.max_tokens, Some(42));
+        assert_eq!(doc.body, "");
+    }
+
+    #[test]
+    fn oversize_file_is_rejected() {
+        let dir = tempdir().unwrap();
+        // Write (MAX + 1) bytes.
+        let big = vec![b'a'; (MAX_PROMPT_FILE_BYTES as usize) + 1];
+        write_prompt(dir.path(), &big);
+
+        let err = load(dir.path()).expect_err("oversize file must error");
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+        assert!(
+            err.to_string().contains("exceeds maximum size"),
+            "unexpected message: {err}"
+        );
+    }
+
+    #[test]
+    fn disallowed_control_char_is_rejected() {
+        let dir = tempdir().unwrap();
+        // U+0007 (BEL) is in the \x00-\x08 disallowed range.
+        let contents = b"# Heading\nline with bell \x07 here\n";
+        write_prompt(dir.path(), contents);
+
+        let err = load(dir.path()).expect_err("control char must error");
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+        assert!(
+            err.to_string().contains("control character"),
+            "unexpected message: {err}"
+        );
+    }
+
+    #[test]
+    fn tab_lf_cr_are_allowed_in_body() {
+        let dir = tempdir().unwrap();
+        let contents = "line1\n\tindented\r\nline3\n";
+        write_prompt(dir.path(), contents.as_bytes());
+
+        let doc = load(dir.path()).unwrap().unwrap();
+        assert_eq!(doc.body, contents);
+    }
+
+    #[test]
+    fn invalid_toml_frontmatter_errors_descriptively() {
+        let dir = tempdir().unwrap();
+        let contents = "+++\nthis is = = not toml\n+++\nbody\n";
+        write_prompt(dir.path(), contents.as_bytes());
+
+        let err = load(dir.path()).expect_err("invalid TOML must error");
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+        let msg = err.to_string();
+        assert!(
+            msg.contains("TOML front-matter"),
+            "expected descriptive message, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn unknown_frontmatter_key_is_rejected() {
+        // We opted for `deny_unknown_fields` so typos surface early. Documented
+        // in the module-level rustdoc.
+        let dir = tempdir().unwrap();
+        let contents = "+++\nlanguage_overridden = \"rust\"\n+++\nbody\n";
+        write_prompt(dir.path(), contents.as_bytes());
+
+        let err = load(dir.path()).expect_err("unknown key must error");
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn unterminated_frontmatter_is_treated_as_body() {
+        // A file that begins with `+++\n` but never closes the fence should
+        // fall back to "no front-matter" so a stray `+++` at the top of a
+        // markdown document doesn't consume the rest of the file.
+        let dir = tempdir().unwrap();
+        let contents = "+++\nno closing fence here\n";
+        write_prompt(dir.path(), contents.as_bytes());
+
+        let doc = load(dir.path()).unwrap().unwrap();
+        assert_eq!(doc.frontmatter, ProjectPromptFrontMatter::default());
+        assert_eq!(doc.body, contents);
+    }
+}


### PR DESCRIPTION
## Summary

Lands Phases A and B of the issue #194 roll-out for domain-specific system prompts. This PR is intentionally scoped to data-producing modules only; no call sites are modified.

**Phase A - loader** (`harness/src/agent/project_prompt.rs`):
- `ProjectPromptDoc` / `ProjectPromptFrontMatter` types.
- `load(workspace_root) -> io::Result<Option<ProjectPromptDoc>>`:
  - returns `Ok(None)` when `.nanna/prompt.md` is absent (fresh checkouts stay quiet),
  - rejects files over 64 KiB,
  - rejects body control chars in `\x00-\x08`, `\x0B`, `\x0C`, `\x0E-\x1F` (tab / LF / CR allowed),
  - splits a `+++`-fenced TOML front-matter block from the Markdown body (unterminated fences fall back to "no front-matter"),
  - parses the front-matter via the existing workspace `toml` dep with `#[serde(deny_unknown_fields)]` so typos error out.

**Phase B - detectors** (`harness/src/agent/project_detect.rs`):
- `Language` / `Framework` enums, `DetectedProfile`, `Signal`.
- Pure-function detectors, each tolerant of missing / malformed inputs:
  - `detect_cargo_toml` (Rust + `[dev-dependencies]`: nextest, tokio, proptest, criterion; plus tokio from `[dependencies]`),
  - `detect_package_json` (Node + devDeps/deps/scripts scanned for jest, vitest, mocha, playwright / `@playwright/test`),
  - `detect_pyproject_toml` (Python + `[tool.pytest.ini_options]`, poetry, uv, ruff, mypy),
  - `detect_requirements_txt` (regex scan for pytest, tox),
  - `detect_go_mod` (matches `^go \d+\.\d+`),
  - `detect_flake_nix` (emits the `nix develop --command ...` CI hint),
  - `detect_github_workflows` (scans `run:` occurrences in `.github/workflows/*.{yml,yaml}` for `cargo fmt`, `cargo clippy`, `cargo deny`, `nextest`).
- `detect()` composes them into a deduplicated `DetectedProfile`.

Both new modules carry module-level rustdoc pointing at the two current hardcoded-prompt call sites (`harness/src/main.rs:425` and `harness/src/task.rs:369`) so future readers know where Phase D will wire this in.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy -p harness --all-targets -- -D warnings` clean
- [x] `cargo test -p harness --lib` passes (311 total; 26 new unit tests: 10 loader + 16 detector, all using `tempfile` fixtures, no `insta`)

## Explicit non-goals (follow-up phases)

- **Phase C - assembler** (`prompt_assembly.rs`): layered base + auto + user + entity composition, token-budget guard.
- **Phase C - entity reference interpolation** (`{{entity.*}}`): see note below; needs entity-selector API design work.
- **Phase D - wiring**: replace the hardcoded strings at `harness/src/main.rs:425` and `harness/src/task.rs:369`, thread `workspace_root` + `&dyn EntityStore` into `AgentConfig::system_prompt`, add `--show-system-prompt` / `--dry-run` CLI flags.
- **Phase E - session caching**: reuse a single assembled prompt across turns in `AgentLoop`; criterion bench.
- **Phase F - docs + goldens**: AGENTS.md / ARCHITECTURE.md / CONTRIBUTING.md updates and `insta` snapshot tests.

## Review call-out: entity-selector API gap

The dev plan (`/tmp/dev-plans/issue-194.md` section 4) proposes selectors like `entity.type.Git.count` and `entity.path.Cargo.toml.summary`. As the plan review (`/tmp/plan-reviews/issue-194.md`) notes, these do not map to the current `EntityStore` API (`store/exists/update/delete/query/*_relationship`): there is no `count_by_type`, no path index, and `QueryResult` exposes `snippet` rather than `summary`. Phase C will need to either (a) add concrete `EntityStore` helpers or (b) build a resolver over `EntityQuery` (e.g. `entity.type.Git.count` -> `query(EntityQuery { entity_types: vec![Git], ..default() }).len()`). This is called out here so it is addressed before Phase C starts - it is not an implementation detail internal to that phase.

Refs #194

https://claude.ai/code/session_01EWkGgVyjb3196n8qompeGL