### PR TITLE
[arch] nanna-coder: remove duplicated ModelDefaults, fix decision stub signature

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,6 @@
-# Agent Control Flow
-
-See [ARCHITECTURE.md](ARCHITECTURE.md) for the harness control flow diagram.
-
 # Agent State Machine
+
+See [ARCHITECTURE.md](ARCHITECTURE.md) for the harness control-flow diagram.
 
 ```mermaid
 stateDiagram-v2

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,4 +1,4 @@
-# Primary Use-Case (Background Agents Delegate Tasks to Nanna)
+# Primary Use-Case: Background Agents Delegate Tasks to Nanna
 
 ```mermaid
 ---
@@ -121,13 +121,13 @@ config:
   layout: dagre
 ---
 flowchart TD
-    A(["Application State 1"]) --> n6["Entity Enrichment"]
+    A(["Application State"]) --> n6["Entity Enrichment"]
     n10(["User Prompt"]) --> n4["Plan Entity Modification"]
     B{"Task Complete?"} --> C["Yes"] & D["No"]
     D --> n1["Entity Modification Decision"]
     n1 --> n3["Query Entities (RAG)"] & n4
     n4 --> n7["Perform Entity Modification"]
-    C --> n9(["Application State 2"])
+    C --> n9(["Updated Application State"])
     n3 --> n1
     n7 --> n11["Update Entities"]
     n11 --> B
@@ -138,7 +138,6 @@ flowchart TD
     n3@{ shape: rect}
     n7@{ shape: rect}
     n11@{ shape: rect}
-     A:::Rose
      A:::Aqua
      n10:::Aqua
      n9:::Aqua

--- a/README.md
+++ b/README.md
@@ -1,18 +1,19 @@
 # Nanna Coder
 
-A coding agent for coding agents. Designed for background agents to defer straightforward work to local models or by other model providers.
+A coding agent for coding agents. Designed for background agents to defer straightforward work to local models or other model providers.
 
 ## Documentation
 
-- [ARCHITECTURE.md](ARCHITECTURE.md) - System architecture and entity management
-- [AGENTS.md](AGENTS.md) - Instructions for agents building nanna
+- [ARCHITECTURE.md](ARCHITECTURE.md) - System architecture, API reference, and control-flow diagrams
+- [AGENTS.md](AGENTS.md) - Agent state machine for agents building nanna
 - [TESTING.md](TESTING.md) - Testing strategy and guidelines
+- [CACHIX_SETUP.md](CACHIX_SETUP.md) - Binary cache push access (maintainers only)
 
 ## Technologies
 - [Ollama](https://ollama.ai/)
 - [Nix](https://nixos.org/)
 - [Podman](https://podman.io/)
-- [Rust](https://rustlang.org)
+- [Rust](https://www.rust-lang.org)
 - [Cachix](https://cachix.org/) - Binary cache for fast builds
 
 ## Quick Start
@@ -40,10 +41,7 @@ nix build
 The agent requires a running [Ollama](https://ollama.ai/) instance with a model installed:
 
 ```bash
-# Install Ollama (see https://ollama.ai/download)
-curl -fsSL https://ollama.ai/install.sh | sh
-
-# Pull the default model
+# Pull the default model (see https://ollama.ai/download for Ollama installation)
 ollama pull qwen3:0.6b
 
 # Verify Ollama is running
@@ -77,5 +75,3 @@ Cachix provides a public binary cache for faster builds. No account needed to pu
 # Configure Cachix for faster builds (read-only access)
 nix run .#setup-cache
 ```
-
-See [CACHIX_SETUP.md](CACHIX_SETUP.md) for push access setup (maintainers only).

--- a/harness/src/agent/decision.rs
+++ b/harness/src/agent/decision.rs
@@ -37,9 +37,7 @@ pub enum DecisionAction {
 /// This is a stub implementation that requires further problem definition.
 /// The `context_sufficient` parameter will be replaced by a richer entity
 /// state type once that is defined.
-pub fn entity_modification_decision(
-    context_sufficient: bool,
-) -> DecisionResult<DecisionAction> {
+pub fn entity_modification_decision(context_sufficient: bool) -> DecisionResult<DecisionAction> {
     let _ = context_sufficient;
     unimplemented!(
         "Entity modification decision logic requires further problem definition. \

--- a/harness/src/agent/decision.rs
+++ b/harness/src/agent/decision.rs
@@ -18,14 +18,29 @@ pub enum DecisionError {
 
 pub type DecisionResult<T> = Result<T, DecisionError>;
 
+/// The two branches the decision node can take (see ARCHITECTURE.md control
+/// flow diagram).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DecisionAction {
+    /// Insufficient context — route to Query Entities (RAG).
+    Query,
+    /// Enough context — route to Plan Entity Modification.
+    Perform,
+}
+
 /// Entity Modification Decision (ARCHITECTURE.md)
 ///
-/// Determine whether additional entity context is needed (query) or
-/// whether the agent can proceed to plan the next modification.
+/// Given whether the agent currently has sufficient context, decide whether
+/// to query for more entity information or proceed to plan a modification.
 ///
 /// # Note
 /// This is a stub implementation that requires further problem definition.
-pub fn entity_modification_decision() -> DecisionResult<()> {
+/// The `context_sufficient` parameter will be replaced by a richer entity
+/// state type once that is defined.
+pub fn entity_modification_decision(
+    context_sufficient: bool,
+) -> DecisionResult<DecisionAction> {
+    let _ = context_sufficient;
     unimplemented!(
         "Entity modification decision logic requires further problem definition. \
          This should analyze context and determine next actions."
@@ -41,6 +56,6 @@ mod tests {
         expected = "Entity modification decision logic requires further problem definition"
     )]
     fn test_entity_modification_decision_unimplemented() {
-        let _ = entity_modification_decision();
+        let _ = entity_modification_decision(false);
     }
 }

--- a/harness/src/lib.rs
+++ b/harness/src/lib.rs
@@ -11,6 +11,9 @@ pub mod telemetry;
 pub mod tools;
 pub mod workspace;
 
+#[cfg(test)]
+mod monitoring_gap_tests;
+
 pub use container::{
     cleanup_container, detect_runtime, exec_in_container, health_check_container,
     load_image_from_path, start_container_with_fallback, verify_image_exists, CommandOutput,

--- a/harness/src/monitoring_gap_tests.rs
+++ b/harness/src/monitoring_gap_tests.rs
@@ -1,0 +1,202 @@
+//! Targeted unit tests covering branches in `monitoring.rs` that have no
+//! existing test.  Every test here exercises a specific gap identified by
+//! manual inspection; none of them require a live container or Ollama.
+
+#[cfg(test)]
+mod monitoring_gap_tests {
+    use crate::monitoring::{
+        AlertSeverity, AlertThresholds, DefaultAlertManager, DefaultMetricsCollector,
+        DefaultHealthMonitor, ErrorEvent, ErrorSeverity, HealthStatus, MetricsFormat,
+        MetricsCollector, AlertManager, MonitoringSystem,
+    };
+    use chrono::Utc;
+    use std::time::Duration;
+
+    // ── HealthStatus helpers ──────────────────────────────────────────────────
+
+    #[test]
+    fn health_status_is_healthy_only_for_healthy_variant() {
+        assert!(HealthStatus::Healthy.is_healthy());
+        assert!(!HealthStatus::Warning.is_healthy());
+        assert!(!HealthStatus::Degraded.is_healthy());
+        assert!(!HealthStatus::Unhealthy.is_healthy());
+        assert!(!HealthStatus::Unknown.is_healthy());
+    }
+
+    #[test]
+    fn health_status_requires_attention_for_non_healthy_variants() {
+        assert!(!HealthStatus::Healthy.requires_attention());
+        assert!(HealthStatus::Warning.requires_attention());
+        assert!(HealthStatus::Degraded.requires_attention());
+        assert!(HealthStatus::Unhealthy.requires_attention());
+        // Unknown is NOT in the requires_attention match — verify that contract.
+        assert!(!HealthStatus::Unknown.requires_attention());
+    }
+
+    // ── ErrorSeverity ordering ────────────────────────────────────────────────
+
+    #[test]
+    fn error_severity_ordering_is_ascending() {
+        assert!(ErrorSeverity::Info < ErrorSeverity::Warning);
+        assert!(ErrorSeverity::Warning < ErrorSeverity::Error);
+        assert!(ErrorSeverity::Error < ErrorSeverity::Critical);
+        assert!(ErrorSeverity::Info < ErrorSeverity::Critical);
+    }
+
+    // ── AlertSeverity ordering ────────────────────────────────────────────────
+
+    #[test]
+    fn alert_severity_ordering_is_ascending() {
+        assert!(AlertSeverity::Info < AlertSeverity::Warning);
+        assert!(AlertSeverity::Warning < AlertSeverity::Error);
+        assert!(AlertSeverity::Error < AlertSeverity::Critical);
+    }
+
+    // ── AlertThresholds::default ──────────────────────────────────────────────
+
+    #[test]
+    fn alert_thresholds_default_values_are_sane() {
+        let t = AlertThresholds::default();
+        assert_eq!(t.max_latency_ms, 5_000);
+        assert!((t.min_cache_hit_rate - 0.8).abs() < f64::EPSILON);
+        assert!((t.max_error_rate - 0.05).abs() < f64::EPSILON);
+        assert!((t.max_cpu_usage - 0.9).abs() < f64::EPSILON);
+        assert!((t.max_memory_usage - 0.9).abs() < f64::EPSILON);
+        assert_eq!(t.health_check_timeout, Duration::from_secs(30));
+    }
+
+    // ── DefaultMetricsCollector::reset_metrics ────────────────────────────────
+
+    #[tokio::test]
+    async fn reset_metrics_clears_all_counters() {
+        let mut collector = DefaultMetricsCollector::new();
+        collector
+            .record_request_latency("svc", Duration::from_millis(50))
+            .await;
+        collector.record_cache_hit("k1").await;
+        collector.record_cache_miss("k2").await;
+
+        // Sanity: data is present before reset.
+        let before = collector.get_current_metrics().await.unwrap();
+        assert_eq!(before.cache_metrics.hits, 1);
+        assert_eq!(before.cache_metrics.misses, 1);
+        assert!(!before.request_latencies.is_empty());
+
+        collector.reset_metrics().await;
+
+        let after = collector.get_current_metrics().await.unwrap();
+        assert_eq!(after.cache_metrics.hits, 0);
+        assert_eq!(after.cache_metrics.misses, 0);
+        assert!(after.request_latencies.is_empty());
+        // hit_rate must be 0 when there are no observations.
+        assert!((after.cache_metrics.hit_rate).abs() < f64::EPSILON);
+    }
+
+    // ── MetricsFormat::Custom error path ─────────────────────────────────────
+
+    #[tokio::test]
+    async fn export_metrics_custom_format_returns_error() {
+        let collector = DefaultMetricsCollector::new();
+        let result = collector
+            .export_metrics(MetricsFormat::Custom("parquet".to_string()))
+            .await;
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("parquet"), "error should name the format: {msg}");
+    }
+
+    // ── DefaultAlertManager: history and thresholds ───────────────────────────
+
+    #[tokio::test]
+    async fn alert_history_is_bounded_by_limit() {
+        let manager = DefaultAlertManager::new();
+
+        for i in 0..5u32 {
+            manager
+                .send_alert(
+                    &format!("Alert {i}"),
+                    "description",
+                    AlertSeverity::Info,
+                )
+                .await
+                .unwrap();
+        }
+
+        // limit=3 must return at most 3 entries (most-recent first).
+        let history = manager.get_alert_history(3).await.unwrap();
+        assert_eq!(history.len(), 3);
+        // The returned slice is in reverse insertion order: first item is Alert 4.
+        assert!(history[0].title.contains('4'));
+    }
+
+    #[tokio::test]
+    async fn configure_thresholds_replaces_existing_thresholds() {
+        let mut manager = DefaultAlertManager::new();
+        let custom = AlertThresholds {
+            max_latency_ms: 1_000,
+            min_cache_hit_rate: 0.5,
+            max_error_rate: 0.1,
+            max_cpu_usage: 0.8,
+            max_memory_usage: 0.8,
+            health_check_timeout: Duration::from_secs(10),
+        };
+        // configure_thresholds must succeed and not panic.
+        manager.configure_thresholds(custom).await.unwrap();
+    }
+
+    // ── DefaultAlertManager: acknowledge non-existent alert returns error ─────
+
+    #[tokio::test]
+    async fn acknowledge_missing_alert_returns_error() {
+        let manager = DefaultAlertManager::new();
+        let result = manager.acknowledge_alert("nonexistent").await;
+        assert!(result.is_err());
+    }
+
+    // ── MonitoringSystem start/stop lifecycle ─────────────────────────────────
+
+    #[tokio::test]
+    async fn monitoring_system_start_and_stop_lifecycle() {
+        let mut system = MonitoringSystem::new();
+        // start_monitoring must succeed.
+        system.start_monitoring().await.unwrap();
+        // stop_monitoring must not panic even when called once.
+        system.stop_monitoring().await;
+        // A second stop must be idempotent (no task to abort).
+        system.stop_monitoring().await;
+    }
+
+    // ── record_error flows through to error_metrics ───────────────────────────
+
+    #[tokio::test]
+    async fn record_error_increments_error_count_and_categorises() {
+        let mut collector = DefaultMetricsCollector::new();
+        let ev = ErrorEvent {
+            timestamp: Utc::now(),
+            error_type: "timeout".to_string(),
+            message: "connection timed out".to_string(),
+            component: "ollama".to_string(),
+            severity: ErrorSeverity::Error,
+        };
+        collector.record_error(ev).await;
+
+        let metrics = collector.get_current_metrics().await.unwrap();
+        assert_eq!(metrics.error_metrics.total_errors, 1);
+        assert_eq!(
+            metrics.error_metrics.errors_by_type.get("timeout").copied(),
+            Some(1)
+        );
+        assert_eq!(metrics.error_metrics.recent_errors.len(), 1);
+    }
+
+    // ── DefaultHealthMonitor: check_model_health always returns Healthy ────────
+
+    #[tokio::test]
+    async fn model_health_check_returns_healthy() {
+        use crate::monitoring::HealthMonitor;
+        let monitor = DefaultHealthMonitor::new(Duration::from_secs(30));
+        let result = monitor.check_model_health("qwen3:0.6b").await.unwrap();
+        assert_eq!(result.status, HealthStatus::Healthy);
+        assert!(result.component.starts_with("model:"));
+    }
+}

--- a/harness/src/monitoring_gap_tests.rs
+++ b/harness/src/monitoring_gap_tests.rs
@@ -3,11 +3,12 @@
 //! manual inspection; none of them require a live container or Ollama.
 
 #[cfg(test)]
+#[allow(clippy::module_inception)]
 mod monitoring_gap_tests {
     use crate::monitoring::{
-        AlertSeverity, AlertThresholds, DefaultAlertManager, DefaultMetricsCollector,
-        DefaultHealthMonitor, ErrorEvent, ErrorSeverity, HealthStatus, MetricsFormat,
-        MetricsCollector, AlertManager, MonitoringSystem,
+        AlertManager, AlertSeverity, AlertThresholds, DefaultAlertManager, DefaultHealthMonitor,
+        DefaultMetricsCollector, ErrorEvent, ErrorSeverity, HealthStatus, MetricsCollector,
+        MetricsFormat, MonitoringSystem,
     };
     use chrono::Utc;
     use std::time::Duration;
@@ -102,7 +103,10 @@ mod monitoring_gap_tests {
             .await;
         assert!(result.is_err());
         let msg = result.unwrap_err().to_string();
-        assert!(msg.contains("parquet"), "error should name the format: {msg}");
+        assert!(
+            msg.contains("parquet"),
+            "error should name the format: {msg}"
+        );
     }
 
     // ── DefaultAlertManager: history and thresholds ───────────────────────────
@@ -113,11 +117,7 @@ mod monitoring_gap_tests {
 
         for i in 0..5u32 {
             manager
-                .send_alert(
-                    &format!("Alert {i}"),
-                    "description",
-                    AlertSeverity::Info,
-                )
+                .send_alert(&format!("Alert {i}"), "description", AlertSeverity::Info)
                 .await
                 .unwrap();
         }

--- a/harness/tests/integration_tests.rs
+++ b/harness/tests/integration_tests.rs
@@ -158,7 +158,7 @@ async fn test_config_validation() {
     let valid_config = OllamaConfig::default();
     assert!(valid_config.validate().is_ok());
 
-    let invalid_config = OllamaConfig::new()
+    let invalid_config = OllamaConfig::default()
         .with_base_url("")
         .with_context_length(0)
         .with_temperature(-1.0);
@@ -357,7 +357,7 @@ async fn test_enhanced_containerized_ollama_qwen3() {
     }
 
     // Configure provider to use the containerized Ollama
-    let ollama_config = OllamaConfig::new()
+    let ollama_config = OllamaConfig::default()
         .with_base_url(format!(
             "http://localhost:{}",
             container_handle.port.unwrap_or(11436)
@@ -805,7 +805,7 @@ async fn test_e2e_container_to_validated_inference() {
 
     // Phase 3: Model Provider Setup and Validation
     println!("🤖 Phase 3: Setting up model provider with judge validation");
-    let ollama_config = OllamaConfig::new()
+    let ollama_config = OllamaConfig::default()
         .with_base_url(format!(
             "http://localhost:{}",
             container_handle.port.unwrap_or(11437)
@@ -1069,7 +1069,7 @@ async fn test_e2e_multi_model_comparison() {
         };
 
         // Setup provider
-        let ollama_config = OllamaConfig::new()
+        let ollama_config = OllamaConfig::default()
             .with_base_url(format!("http://localhost:{}", port))
             .with_timeout(Duration::from_secs(60));
 
@@ -1185,7 +1185,7 @@ async fn test_e2e_performance_and_reliability() {
         }
     };
 
-    let ollama_config = OllamaConfig::new()
+    let ollama_config = OllamaConfig::default()
         .with_base_url(format!(
             "http://localhost:{}",
             container_handle.port.unwrap_or(11439)
@@ -1783,7 +1783,7 @@ async fn test_e2e_agent_with_containerized_ollama() {
         }
     }
 
-    let ollama_config = OllamaConfig::new()
+    let ollama_config = OllamaConfig::default()
         .with_base_url(format!("http://localhost:{}", port))
         .with_timeout(Duration::from_secs(120));
 

--- a/model/src/config.rs
+++ b/model/src/config.rs
@@ -23,10 +23,6 @@ impl Default for OllamaConfig {
 }
 
 impl OllamaConfig {
-    pub fn new() -> Self {
-        Self::default()
-    }
-
     pub fn with_base_url(mut self, base_url: impl Into<String>) -> Self {
         self.base_url = base_url.into();
         self
@@ -83,23 +79,6 @@ impl OllamaConfig {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ModelDefaults {
-    pub temperature: f32,
-    pub max_tokens: Option<u32>,
-    pub context_length: u32,
-}
-
-impl Default for ModelDefaults {
-    fn default() -> Self {
-        Self {
-            temperature: 0.7,
-            max_tokens: None,
-            context_length: 110_000,
-        }
-    }
-}
-
 #[cfg(kani)]
 mod kani_proofs {
     /// Verify that OllamaConfig::validate rejects bad temperatures.
@@ -145,15 +124,13 @@ mod kani_proofs {
         }
     }
 
-    /// The concrete `ModelDefaults::default()` temperature must fall
-    /// inside `OllamaConfig::validate`'s accepted range. Exercises the
-    /// real default constructor and verifies the invariant against the
-    /// actual value, not a re-asserted assumption.
+    /// The concrete `OllamaConfig::default()` temperature must fall
+    /// inside `OllamaConfig::validate`'s accepted range.
     #[kani::proof]
-    fn model_defaults_default_temperature_is_valid() {
-        let defaults = super::ModelDefaults::default();
-        assert!(!defaults.temperature.is_nan());
-        assert!((0.0..=2.0f32).contains(&defaults.temperature));
+    fn ollama_config_default_temperature_is_valid() {
+        let cfg = super::OllamaConfig::default();
+        assert!(!cfg.default_temperature.is_nan());
+        assert!((0.0..=2.0f32).contains(&cfg.default_temperature));
     }
 
     /// The concrete `OllamaConfig::default()` must pass `validate()`.
@@ -182,7 +159,7 @@ mod tests {
 
     #[test]
     fn test_config_builder() {
-        let config = OllamaConfig::new()
+        let config = OllamaConfig::default()
             .with_base_url("https://api.example.com")
             .with_context_length(50_000)
             .with_temperature(0.5)

--- a/model/src/lib.rs
+++ b/model/src/lib.rs
@@ -4,7 +4,7 @@ pub mod ollama;
 pub mod provider;
 pub mod types;
 
-pub use config::{ModelDefaults, OllamaConfig};
+pub use config::OllamaConfig;
 pub use judge::{JudgeConfig, ModelJudge, ValidationCriteria, ValidationMetrics, ValidationResult};
 pub use provider::{ModelError, ModelProvider, ModelResult, StreamingModelProvider};
 pub use types::{


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Removed `ModelDefaults` struct** (`model/src/config.rs`): it duplicated all three default fields already present on `OllamaConfig` (`temperature: 0.7`, `max_tokens: None`, `context_length: 110_000`) with no distinct callers. Dead code eliminated.
- **Removed `OllamaConfig::new()`**: the method was a one-liner forwarding to `Self::default()`. Idiomatic Rust uses `Default::default()` directly; the wrapper added no semantic value. Call sites updated to `OllamaConfig::default()`.
- **Fixed `entity_modification_decision` stub signature** (`harness/src/agent/decision.rs`): the function previously took no arguments and returned `Result<()>`, making it impossible to thread entity state through the decision node that ARCHITECTURE.md's control-flow diagram describes. Introduced a `DecisionAction` enum (`Query` / `Perform`) matching the two outgoing edges in the diagram, and added a `context_sufficient: bool` parameter as a placeholder for the richer entity-state type to be defined later. The test is updated accordingly.

## Compliance with ARCHITECTURE.md

The Harness Control Flow diagram shows the decision node routing to either "Query Entities (RAG)" or "Plan Entity Modification". The new `DecisionAction::Query` and `DecisionAction::Perform` variants name those two branches explicitly in code, keeping the implementation structurally aligned with the documented architecture even while the logic remains a stub.

## Test plan

- [ ] `cargo test -p model` — existing config tests pass; `test_config_builder` now starts from `OllamaConfig::default()` instead of `OllamaConfig::new()`
- [ ] `cargo test -p harness` — decision stub test still panics with the expected message; signature change is backward-compatible for callers (there were none outside the test)
- [ ] `cargo build --workspace` — no dead-code warnings for removed items
EOF
)