### PR TITLE
feat(entities/env): ContainerConfigEntity + DeploymentManifest first slice (#25 partial)

### DIFF
--- a/harness/src/entities/env/bridge.rs
+++ b/harness/src/entities/env/bridge.rs
@@ -1,0 +1,148 @@
+//! Bridge between `container::ContainerConfig` and `ContainerConfigEntity`.
+//!
+//! Converts the loosely-typed container config used by the runtime layer
+//! into a typed, serde-friendly entity.
+//!
+//! Follow-ups (tracked in PR body, not carried in this slice):
+//! - `cfg.test_image`, `cfg.container_name`, `cfg.model_to_pull`,
+//!   `cfg.additional_args` are not yet represented on the entity.
+
+use super::security::SecurityContext;
+use super::types::{ContainerConfigEntity, EnvVarRef, EnvVarSource, PortMapping, RuntimeConfig};
+
+/// Convert a [`crate::container::ContainerConfig`] into a
+/// [`ContainerConfigEntity`].
+///
+/// Mapping (explicit):
+/// - `cfg.base_image` -> `entity.image`
+/// - `cfg.port_mapping` -> `entity.runtime.ports` (0 or 1 entry)
+/// - `cfg.env_vars` -> `entity.env_refs` as [`EnvVarSource::Literal`] entries
+/// - `cfg.startup_timeout` (seconds) -> `entity.runtime.startup_timeout_secs`
+/// - `cfg.health_check_timeout` (seconds) -> `entity.runtime.health_check_timeout_secs`
+/// - `cpu_limit` / `memory_limit_mb` -> `None` (not in source)
+/// - `volumes` -> `vec![]` (not in source)
+/// - `security` -> [`SecurityContext::default()`] (restrictive)
+///
+/// Callers that need plaintext env values treated as secrets must rewrite
+/// the resulting [`EnvVarRef`] entries to use [`EnvVarSource::SecretRef`];
+/// this bridge makes no such inference.
+pub fn from_container_config(cfg: &crate::container::ContainerConfig) -> ContainerConfigEntity {
+    let ports = match cfg.port_mapping {
+        Some((host, container)) => vec![PortMapping { host, container }],
+        None => Vec::new(),
+    };
+
+    let env_refs = cfg
+        .env_vars
+        .iter()
+        .map(|(name, value)| EnvVarRef {
+            name: name.clone(),
+            source: EnvVarSource::literal(value.clone()),
+        })
+        .collect();
+
+    let runtime = RuntimeConfig {
+        cpu_limit: None,
+        memory_limit_mb: None,
+        ports,
+        volumes: Vec::new(),
+        startup_timeout_secs: Some(cfg.startup_timeout.as_secs()),
+        health_check_timeout_secs: Some(cfg.health_check_timeout.as_secs()),
+    };
+
+    let mut entity = ContainerConfigEntity::new(cfg.base_image.clone());
+    entity.runtime = runtime;
+    entity.security = SecurityContext::default();
+    entity.env_refs = env_refs;
+    entity
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::container::ContainerConfig;
+    use crate::entities::env::security::CapabilitySet;
+    use std::time::Duration;
+
+    fn sample_config() -> ContainerConfig {
+        ContainerConfig {
+            base_image: "alpine:3.19".to_string(),
+            test_image: None,
+            container_name: "svc".to_string(),
+            port_mapping: Some((8080, 80)),
+            model_to_pull: None,
+            startup_timeout: Duration::from_secs(30),
+            health_check_timeout: Duration::from_secs(5),
+            env_vars: vec![
+                ("LOG_LEVEL".to_string(), "info".to_string()),
+                ("DB_URL".to_string(), "postgres://...".to_string()),
+            ],
+            additional_args: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn test_from_container_config_populates_image_and_ports() {
+        let cfg = sample_config();
+        let entity = from_container_config(&cfg);
+
+        assert_eq!(entity.image, "alpine:3.19");
+        assert_eq!(entity.runtime.ports.len(), 1);
+        assert_eq!(
+            entity.runtime.ports[0],
+            PortMapping {
+                host: 8080,
+                container: 80,
+            }
+        );
+
+        // No source for cpu / memory / volumes — must be unset/empty.
+        assert_eq!(entity.runtime.cpu_limit, None);
+        assert_eq!(entity.runtime.memory_limit_mb, None);
+        assert!(entity.runtime.volumes.is_empty());
+
+        // With no port_mapping, ports must be empty.
+        let mut cfg_no_ports = sample_config();
+        cfg_no_ports.port_mapping = None;
+        let entity_no_ports = from_container_config(&cfg_no_ports);
+        assert!(entity_no_ports.runtime.ports.is_empty());
+    }
+
+    #[test]
+    fn test_from_container_config_security_defaults_restrictive() {
+        let cfg = sample_config();
+        let entity = from_container_config(&cfg);
+
+        assert!(entity.security.read_only_root_fs);
+        assert!(entity.security.run_as_non_root);
+        assert_eq!(entity.security.capabilities, CapabilitySet::None);
+        assert!(entity.security.allowed_paths.is_empty());
+    }
+
+    #[test]
+    fn test_from_container_config_env_vars_literal() {
+        let cfg = sample_config();
+        let entity = from_container_config(&cfg);
+
+        assert_eq!(entity.env_refs.len(), 2);
+        assert_eq!(entity.env_refs[0].name, "LOG_LEVEL");
+        match &entity.env_refs[0].source {
+            EnvVarSource::Literal { value } => assert_eq!(value, "info"),
+            other => panic!("expected Literal, got {:?}", other),
+        }
+        assert_eq!(entity.env_refs[1].name, "DB_URL");
+        match &entity.env_refs[1].source {
+            EnvVarSource::Literal { value } => assert_eq!(value, "postgres://..."),
+            other => panic!("expected Literal, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_from_container_config_timeouts_mapped() {
+        let cfg = sample_config();
+        let entity = from_container_config(&cfg);
+
+        assert_eq!(entity.runtime.startup_timeout_secs, Some(30));
+        assert_eq!(entity.runtime.health_check_timeout_secs, Some(5));
+    }
+}

--- a/harness/src/entities/env/deployment.rs
+++ b/harness/src/entities/env/deployment.rs
@@ -1,0 +1,323 @@
+//! Deployment manifest entity and approval workflow
+//!
+//! Defines [`DeploymentManifest`] together with its target, impact, and
+//! approval types. Release deployments require an explicit approval record;
+//! dev and sandbox deployments do not.
+
+use crate::entities::{Entity, EntityMetadata, EntityResult, EntityType};
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+/// A deployment of a [`super::types::ContainerConfigEntity`] to a target
+/// environment.
+///
+/// The `container` field holds the id of the `ContainerConfigEntity` being
+/// deployed (string id, matching [`crate::entities::EntityId`]).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DeploymentManifest {
+    #[serde(flatten)]
+    pub metadata: EntityMetadata,
+
+    /// Target environment for this deployment.
+    pub target: DeploymentTarget,
+
+    /// Service name (e.g. `"harness-api"`).
+    pub service_name: String,
+
+    /// Desired replica count.
+    pub replicas: u32,
+
+    /// Id of the `ContainerConfigEntity` being deployed.
+    pub container: String,
+}
+
+impl DeploymentManifest {
+    /// Create a new deployment manifest.
+    pub fn new(
+        target: DeploymentTarget,
+        service_name: String,
+        replicas: u32,
+        container: String,
+    ) -> Self {
+        Self {
+            metadata: EntityMetadata::new(EntityType::Env),
+            target,
+            service_name,
+            replicas,
+            container,
+        }
+    }
+
+    /// Whether this deployment requires an approval record before it can
+    /// proceed.
+    pub fn requires_approval(&self) -> bool {
+        match self.target {
+            DeploymentTarget::Dev | DeploymentTarget::Sandbox => false,
+            DeploymentTarget::Release { approval_required } => approval_required,
+        }
+    }
+
+    /// Validate this manifest against an optional approval record.
+    ///
+    /// - If approval is not required, `approval` is ignored and `Ok(())` is
+    ///   returned.
+    /// - If approval is required and `approval` is `None`, returns
+    ///   [`EnvError::ApprovalRequired`].
+    /// - If approval is provided but any checklist item is unverified,
+    ///   returns [`EnvError::InvalidConfig`].
+    pub fn validate_with_approval(
+        &self,
+        approval: Option<&DeploymentApproval>,
+    ) -> Result<(), EnvError> {
+        if !self.requires_approval() {
+            return Ok(());
+        }
+
+        let approval = approval.ok_or(EnvError::ApprovalRequired)?;
+
+        if let Some(unverified) = approval.checklist.iter().find(|item| !item.verified) {
+            return Err(EnvError::InvalidConfig(format!(
+                "approval checklist item not verified: {}",
+                unverified.requirement
+            )));
+        }
+
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl Entity for DeploymentManifest {
+    fn metadata(&self) -> &EntityMetadata {
+        &self.metadata
+    }
+
+    fn metadata_mut(&mut self) -> &mut EntityMetadata {
+        &mut self.metadata
+    }
+
+    fn to_json(&self) -> EntityResult<String> {
+        serde_json::to_string(self)
+            .map_err(|e| crate::entities::EntityError::SerializationError(e.to_string()))
+    }
+}
+
+/// Target environment for a deployment.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum DeploymentTarget {
+    /// Developer workstation / inner-loop.
+    Dev,
+
+    /// Shared sandbox environment. Still isolated from production.
+    Sandbox,
+
+    /// Production release target. May require approval.
+    Release { approval_required: bool },
+}
+
+/// Coarse impact classification. Ordered so that higher impact is greater.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ImpactLevel {
+    /// Affects only developer environments.
+    DevOnly,
+    /// Affects only sandbox, which is isolated from production.
+    SandboxIsolated,
+    /// Touches production traffic or data.
+    ProductionCritical,
+}
+
+/// Record of an approval for a deployment.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DeploymentApproval {
+    /// Id of the [`DeploymentManifest`] being approved.
+    pub deployment_id: String,
+
+    /// Approver identity.
+    pub approver: String,
+
+    /// When the approval was recorded.
+    pub timestamp: DateTime<Utc>,
+
+    /// Checklist of items the approver attested to.
+    pub checklist: Vec<ApprovalItem>,
+}
+
+/// One item in an approval checklist.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ApprovalItem {
+    /// Human-readable requirement (e.g. `"runbook updated"`).
+    pub requirement: String,
+
+    /// Whether the requirement was verified.
+    pub verified: bool,
+
+    /// Optional evidence (URL, ticket id, etc.).
+    pub evidence: Option<String>,
+}
+
+/// Errors raised by env-entity validation.
+#[derive(Debug, Error)]
+pub enum EnvError {
+    /// Deployment requires approval but none was supplied.
+    #[error("deployment approval required")]
+    ApprovalRequired,
+
+    /// Manifest or related record was rejected.
+    #[error("invalid configuration: {0}")]
+    InvalidConfig(String),
+
+    /// Referenced entity could not be found.
+    #[error("not found: {0}")]
+    NotFound(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn manifest(target: DeploymentTarget) -> DeploymentManifest {
+        DeploymentManifest::new(target, "svc".to_string(), 1, "container-id".to_string())
+    }
+
+    #[test]
+    fn test_deployment_target_dev_no_approval() {
+        let m = manifest(DeploymentTarget::Dev);
+        assert!(!m.requires_approval());
+    }
+
+    #[test]
+    fn test_deployment_target_sandbox_no_approval() {
+        let m = manifest(DeploymentTarget::Sandbox);
+        assert!(!m.requires_approval());
+    }
+
+    #[test]
+    fn test_deployment_target_release_approval_required() {
+        let m = manifest(DeploymentTarget::Release {
+            approval_required: true,
+        });
+        assert!(m.requires_approval());
+
+        let m2 = manifest(DeploymentTarget::Release {
+            approval_required: false,
+        });
+        assert!(!m2.requires_approval());
+    }
+
+    #[test]
+    fn test_validate_dev_without_approval_ok() {
+        let m = manifest(DeploymentTarget::Dev);
+        assert!(m.validate_with_approval(None).is_ok());
+    }
+
+    #[test]
+    fn test_validate_release_without_approval_errors() {
+        let m = manifest(DeploymentTarget::Release {
+            approval_required: true,
+        });
+        match m.validate_with_approval(None) {
+            Err(EnvError::ApprovalRequired) => {}
+            other => panic!("expected ApprovalRequired, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_validate_release_with_approval_ok() {
+        let m = manifest(DeploymentTarget::Release {
+            approval_required: true,
+        });
+        let approval = DeploymentApproval {
+            deployment_id: m.metadata.id.clone(),
+            approver: "alice".to_string(),
+            timestamp: Utc::now(),
+            checklist: vec![ApprovalItem {
+                requirement: "runbook updated".to_string(),
+                verified: true,
+                evidence: Some("https://example.com/runbook".to_string()),
+            }],
+        };
+        assert!(m.validate_with_approval(Some(&approval)).is_ok());
+
+        // An unverified checklist item rejects the approval.
+        let bad = DeploymentApproval {
+            deployment_id: m.metadata.id.clone(),
+            approver: "bob".to_string(),
+            timestamp: Utc::now(),
+            checklist: vec![ApprovalItem {
+                requirement: "smoke tests".to_string(),
+                verified: false,
+                evidence: None,
+            }],
+        };
+        match m.validate_with_approval(Some(&bad)) {
+            Err(EnvError::InvalidConfig(msg)) => assert!(msg.contains("smoke tests")),
+            other => panic!("expected InvalidConfig, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_approval_item_verified_evidence_populated() {
+        let item = ApprovalItem {
+            requirement: "change ticket".to_string(),
+            verified: true,
+            evidence: Some("CHG-42".to_string()),
+        };
+        assert!(item.verified);
+        assert_eq!(item.evidence.as_deref(), Some("CHG-42"));
+
+        let json = serde_json::to_string(&item).expect("serialize");
+        let decoded: ApprovalItem = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(decoded.requirement, item.requirement);
+        assert_eq!(decoded.verified, item.verified);
+        assert_eq!(decoded.evidence, item.evidence);
+    }
+
+    #[test]
+    fn test_impact_level_ordering() {
+        assert!(ImpactLevel::DevOnly < ImpactLevel::SandboxIsolated);
+        assert!(ImpactLevel::SandboxIsolated < ImpactLevel::ProductionCritical);
+        assert!(ImpactLevel::DevOnly < ImpactLevel::ProductionCritical);
+
+        let mut levels = vec![
+            ImpactLevel::ProductionCritical,
+            ImpactLevel::DevOnly,
+            ImpactLevel::SandboxIsolated,
+        ];
+        levels.sort();
+        assert_eq!(
+            levels,
+            vec![
+                ImpactLevel::DevOnly,
+                ImpactLevel::SandboxIsolated,
+                ImpactLevel::ProductionCritical,
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_deployment_manifest_implements_entity() {
+        let m = manifest(DeploymentTarget::Sandbox);
+        assert_eq!(m.metadata().entity_type, EntityType::Env);
+        assert_eq!(m.entity_type(), EntityType::Env);
+        assert!(m.to_json().is_ok());
+
+        let boxed: Box<dyn Entity> = Box::new(m);
+        assert_eq!(boxed.entity_type(), EntityType::Env);
+    }
+
+    #[test]
+    fn test_env_error_display() {
+        let approval = EnvError::ApprovalRequired;
+        assert_eq!(approval.to_string(), "deployment approval required");
+
+        let invalid = EnvError::InvalidConfig("bad shape".to_string());
+        assert_eq!(invalid.to_string(), "invalid configuration: bad shape");
+
+        let nf = EnvError::NotFound("entity-123".to_string());
+        assert_eq!(nf.to_string(), "not found: entity-123");
+    }
+}

--- a/harness/src/entities/env/mod.rs
+++ b/harness/src/entities/env/mod.rs
@@ -8,6 +8,12 @@
 // Placeholder for environment entity implementation
 // Full implementation tracked in issue #25
 
+pub mod bridge;
+pub mod deployment;
+pub mod security;
 pub mod types;
 
+pub use bridge::*;
+pub use deployment::*;
+pub use security::*;
 pub use types::*;

--- a/harness/src/entities/env/security.rs
+++ b/harness/src/entities/env/security.rs
@@ -1,0 +1,142 @@
+//! Security context for container configuration entities
+//!
+//! Defines the restrictive-by-default security posture applied to
+//! [`crate::entities::env::types::ContainerConfigEntity`] values.
+//!
+//! The default is intentionally locked down: read-only root filesystem,
+//! non-root UID, no extra capabilities, no additional allowed paths.
+//! Callers MUST explicitly opt in to relax this posture.
+
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+/// Security posture for a container.
+///
+/// [`Default`] returns a restrictive configuration:
+/// - `read_only_root_fs: true`
+/// - `run_as_non_root: true`
+/// - `capabilities: CapabilitySet::None`
+/// - `allowed_paths: vec![]`
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SecurityContext {
+    /// Mount the container root filesystem read-only.
+    pub read_only_root_fs: bool,
+
+    /// Require a non-root UID inside the container.
+    pub run_as_non_root: bool,
+
+    /// Linux capabilities granted to the container. Defaults to
+    /// [`CapabilitySet::None`].
+    pub capabilities: CapabilitySet,
+
+    /// Paths the container is permitted to access beyond the default
+    /// read-only root filesystem. Empty by default.
+    pub allowed_paths: Vec<PathBuf>,
+}
+
+impl Default for SecurityContext {
+    fn default() -> Self {
+        Self {
+            read_only_root_fs: true,
+            run_as_non_root: true,
+            capabilities: CapabilitySet::None,
+            allowed_paths: Vec::new(),
+        }
+    }
+}
+
+/// Set of Linux capabilities granted to a container.
+///
+/// `None` grants no capabilities. `Minimal` documents a curated minimal
+/// set (e.g. `NetBindService` for privileged ports). `Custom` carries any
+/// caller-specified list — callers are responsible for justifying the use
+/// in review.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", content = "caps", rename_all = "snake_case")]
+pub enum CapabilitySet {
+    /// No capabilities granted.
+    None,
+
+    /// Minimal, vetted capability set.
+    Minimal(Vec<Capability>),
+
+    /// Caller-specified capability set.
+    Custom(Vec<Capability>),
+}
+
+/// Closed enum of Linux capabilities recognized by the entity layer.
+///
+/// This intentionally does NOT include a `Custom(String)` variant —
+/// capabilities outside this list require a code change and review.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Capability {
+    /// `CAP_NET_BIND_SERVICE` — bind to privileged ports (<1024).
+    NetBindService,
+    /// `CAP_CHOWN` — change file ownership.
+    Chown,
+    /// `CAP_DAC_OVERRIDE` — bypass file permission checks.
+    DacOverride,
+    /// `CAP_SYS_ADMIN` — wide-ranging admin operations (avoid).
+    SysAdmin,
+    /// `CAP_NET_RAW` — use raw sockets.
+    NetRaw,
+    /// `CAP_SETUID` — set process UID.
+    SetUid,
+    /// `CAP_SETGID` — set process GID.
+    SetGid,
+    /// `CAP_SYS_TIME` — set system clock.
+    SysTime,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_security_context_default_is_restrictive() {
+        let sc = SecurityContext::default();
+        assert!(sc.read_only_root_fs, "read_only_root_fs must default true");
+        assert!(sc.run_as_non_root, "run_as_non_root must default true");
+        assert_eq!(
+            sc.capabilities,
+            CapabilitySet::None,
+            "capabilities must default to None"
+        );
+        assert!(
+            sc.allowed_paths.is_empty(),
+            "allowed_paths must default empty"
+        );
+    }
+
+    #[test]
+    fn test_capability_set_none() {
+        let cs = CapabilitySet::None;
+        let json = serde_json::to_string(&cs).expect("serialize");
+        let decoded: CapabilitySet = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(decoded, cs);
+    }
+
+    #[test]
+    fn test_capability_set_minimal() {
+        let cs = CapabilitySet::Minimal(vec![Capability::NetBindService, Capability::Chown]);
+        let json = serde_json::to_string(&cs).expect("serialize");
+        let decoded: CapabilitySet = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(decoded, cs);
+    }
+
+    #[test]
+    fn test_capability_set_custom() {
+        let cs = CapabilitySet::Custom(vec![
+            Capability::SysAdmin,
+            Capability::NetRaw,
+            Capability::SetUid,
+            Capability::SetGid,
+            Capability::DacOverride,
+            Capability::SysTime,
+        ]);
+        let json = serde_json::to_string(&cs).expect("serialize");
+        let decoded: CapabilitySet = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(decoded, cs);
+    }
+}

--- a/harness/src/entities/env/types.rs
+++ b/harness/src/entities/env/types.rs
@@ -6,6 +6,9 @@
 use crate::entities::{Entity, EntityMetadata, EntityResult, EntityType};
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+use super::security::SecurityContext;
 
 /// Environment/deployment entity (placeholder)
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -42,5 +45,232 @@ impl EnvEntity {
 impl Default for EnvEntity {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ContainerConfigEntity and supporting types (issue #25 first slice)
+// ---------------------------------------------------------------------------
+
+/// Container configuration entity
+///
+/// A typed, serde-friendly representation of a container configuration.
+/// Built to replace ad-hoc `container::ContainerConfig` bags with a queryable
+/// entity carrying an explicit `SecurityContext` and references (never
+/// plaintext) to secrets.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ContainerConfigEntity {
+    #[serde(flatten)]
+    pub metadata: EntityMetadata,
+
+    /// Container image reference (e.g. `"ollama/ollama:latest"`).
+    pub image: String,
+
+    /// Runtime resource and networking configuration.
+    pub runtime: RuntimeConfig,
+
+    /// Security posture for this container. Defaults to a restrictive
+    /// configuration; callers must opt in to elevated capabilities.
+    pub security: SecurityContext,
+
+    /// Environment variable references. Secrets MUST be referenced via
+    /// [`EnvVarSource::SecretRef`]; plaintext values are restricted to
+    /// [`EnvVarSource::Literal`] and MUST NOT be used for secret material.
+    pub env_refs: Vec<EnvVarRef>,
+}
+
+impl ContainerConfigEntity {
+    /// Create a new ContainerConfigEntity with a restrictive default
+    /// security context and empty runtime/env configuration.
+    pub fn new(image: String) -> Self {
+        Self {
+            metadata: EntityMetadata::new(EntityType::Env),
+            image,
+            runtime: RuntimeConfig::default(),
+            security: SecurityContext::default(),
+            env_refs: Vec::new(),
+        }
+    }
+}
+
+#[async_trait]
+impl Entity for ContainerConfigEntity {
+    fn metadata(&self) -> &EntityMetadata {
+        &self.metadata
+    }
+
+    fn metadata_mut(&mut self) -> &mut EntityMetadata {
+        &mut self.metadata
+    }
+
+    fn to_json(&self) -> EntityResult<String> {
+        serde_json::to_string(self)
+            .map_err(|e| crate::entities::EntityError::SerializationError(e.to_string()))
+    }
+}
+
+/// Runtime configuration for a container (resources, networking, volumes).
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct RuntimeConfig {
+    /// Optional CPU limit (number of cores, integer for now).
+    pub cpu_limit: Option<u32>,
+
+    /// Optional memory limit in megabytes.
+    pub memory_limit_mb: Option<u64>,
+
+    /// Port mappings (host -> container).
+    pub ports: Vec<PortMapping>,
+
+    /// Volume mounts.
+    pub volumes: Vec<VolumeMount>,
+
+    /// Optional container startup timeout (seconds).
+    pub startup_timeout_secs: Option<u64>,
+
+    /// Optional health-check timeout (seconds).
+    pub health_check_timeout_secs: Option<u64>,
+}
+
+/// Host-to-container port mapping.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PortMapping {
+    pub host: u16,
+    pub container: u16,
+}
+
+/// Volume mount.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct VolumeMount {
+    pub host_path: PathBuf,
+    pub container_path: PathBuf,
+    pub read_only: bool,
+}
+
+/// Environment variable reference — the variable name and its source.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EnvVarRef {
+    pub name: String,
+    pub source: EnvVarSource,
+}
+
+/// Source for an environment variable value.
+///
+/// `Literal` values are stored inline and MUST NOT carry secret material.
+/// `SecretRef` stores only a `vault` identifier and a `key`; the actual
+/// secret value is resolved at runtime by a secret backend and is never
+/// serialized.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum EnvVarSource {
+    /// Inline, non-secret value.
+    Literal { value: String },
+
+    /// Reference to a secret in an external vault. Only the locator is
+    /// persisted; the value is never stored or serialized here.
+    SecretRef { vault: String, key: String },
+}
+
+impl EnvVarSource {
+    /// Construct a [`EnvVarSource::Literal`] from a value.
+    pub fn literal(value: impl Into<String>) -> Self {
+        EnvVarSource::Literal {
+            value: value.into(),
+        }
+    }
+
+    /// Construct a [`EnvVarSource::SecretRef`] from a vault and key.
+    pub fn secret_ref(vault: impl Into<String>, key: impl Into<String>) -> Self {
+        EnvVarSource::SecretRef {
+            vault: vault.into(),
+            key: key.into(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod new_types_tests {
+    use super::*;
+    use crate::entities::env::security::{Capability, CapabilitySet};
+
+    #[test]
+    fn test_container_config_entity_serde_roundtrip() {
+        let mut entity = ContainerConfigEntity::new("alpine:3.19".to_string());
+        entity.runtime.cpu_limit = Some(2);
+        entity.runtime.memory_limit_mb = Some(512);
+        entity.runtime.ports.push(PortMapping {
+            host: 8080,
+            container: 80,
+        });
+        entity.runtime.volumes.push(VolumeMount {
+            host_path: PathBuf::from("/host"),
+            container_path: PathBuf::from("/container"),
+            read_only: true,
+        });
+        entity.runtime.startup_timeout_secs = Some(30);
+        entity.runtime.health_check_timeout_secs = Some(10);
+        entity.env_refs.push(EnvVarRef {
+            name: "LOG_LEVEL".to_string(),
+            source: EnvVarSource::literal("info"),
+        });
+        entity.env_refs.push(EnvVarRef {
+            name: "DB_PASSWORD".to_string(),
+            source: EnvVarSource::secret_ref("primary", "db_password"),
+        });
+        entity.security.capabilities = CapabilitySet::Minimal(vec![Capability::NetBindService]);
+
+        let json = entity.to_json().expect("serialize");
+        let decoded: ContainerConfigEntity = serde_json::from_str(&json).expect("deserialize");
+
+        assert_eq!(decoded.image, entity.image);
+        assert_eq!(decoded.runtime.cpu_limit, Some(2));
+        assert_eq!(decoded.runtime.memory_limit_mb, Some(512));
+        assert_eq!(decoded.runtime.ports, entity.runtime.ports);
+        assert_eq!(decoded.runtime.volumes, entity.runtime.volumes);
+        assert_eq!(decoded.runtime.startup_timeout_secs, Some(30));
+        assert_eq!(decoded.runtime.health_check_timeout_secs, Some(10));
+        assert_eq!(decoded.env_refs, entity.env_refs);
+        assert!(decoded.security.read_only_root_fs);
+        assert!(decoded.security.run_as_non_root);
+        match decoded.security.capabilities {
+            CapabilitySet::Minimal(caps) => {
+                assert_eq!(caps, vec![Capability::NetBindService]);
+            }
+            other => panic!("expected Minimal, got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_container_config_entity_implements_entity() {
+        let entity = ContainerConfigEntity::new("alpine:3.19".to_string());
+        assert_eq!(entity.metadata().entity_type, EntityType::Env);
+        assert_eq!(entity.entity_type(), EntityType::Env);
+        assert!(entity.to_json().is_ok());
+
+        // Usable as a trait object.
+        let boxed: Box<dyn Entity> = Box::new(entity);
+        assert_eq!(boxed.entity_type(), EntityType::Env);
+    }
+
+    #[test]
+    fn test_env_var_source_secret_never_inlines_value() {
+        let secret = EnvVarSource::secret_ref("primary", "api_token");
+        let encoded = serde_json::to_string(&secret).expect("serialize SecretRef");
+
+        // Confirm only the locator fields are present — no `value` key and
+        // no plaintext token material.
+        assert!(encoded.contains("\"vault\""));
+        assert!(encoded.contains("\"key\""));
+        assert!(encoded.contains("primary"));
+        assert!(encoded.contains("api_token"));
+        assert!(
+            !encoded.to_lowercase().contains("value"),
+            "SecretRef must not serialize a `value` field: {}",
+            encoded
+        );
+        assert!(
+            !encoded.to_lowercase().contains("literal"),
+            "SecretRef must not serialize as a Literal variant: {}",
+            encoded
+        );
     }
 }


### PR DESCRIPTION
Part of #25 "Entity Type: Environment & Deployment Entities (env-entities)".

## Summary

First slice of the env/deployment entity work. Typed, serde-friendly entities with a safety-first design: restrictive security defaults, secret-ref-only env vars, and required approval for production manifests.

### Added
- `harness/src/entities/env/types.rs` — appended `ContainerConfigEntity`, `RuntimeConfig`, `PortMapping`, `VolumeMount`, `EnvVarRef`, `EnvVarSource` (`Literal | SecretRef` — SecretRef only persists `vault`+`key`, never plaintext).
- `harness/src/entities/env/security.rs` — `SecurityContext` with `impl Default` returning restrictive (`read_only_root_fs: true`, `run_as_non_root: true`, `CapabilitySet::None`), plus `CapabilitySet` and closed `Capability` enum.
- `harness/src/entities/env/deployment.rs` — `DeploymentManifest` + `DeploymentTarget` (`Dev | Sandbox | Release`), `ImpactLevel`, `DeploymentApproval`, `ApprovalItem`, `EnvError`. `validate_with_approval` returns `EnvError::ApprovalRequired` for `Release` without an approval record.
- `harness/src/entities/env/bridge.rs` — `from_container_config(&crate::container::ContainerConfig) -> ContainerConfigEntity`. Maps base_image/port/env_vars/startup_timeout/health_check_timeout; restrictive `SecurityContext` default.
- `harness/src/entities/env/mod.rs` — wires the new submodules.

### Preserved
- Existing `EnvEntity` placeholder retained (consumed by `harness/src/agent/eval.rs`). New types live alongside, nothing was renamed.
- No new runtime deps in `harness/Cargo.toml`.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p harness --all-targets --all-features -- -D warnings`
- [x] `cargo test -p harness --lib entities::env::`
- [x] `cargo nextest` — swarm env had no nextest; CI will run it.

## Bridge field mapping (explicit)

| `container::ContainerConfig` field | `ContainerConfigEntity` location |
|---|---|
| `base_image` | `image` |
| `port_mapping: Option<(u16,u16)>` | `runtime.ports[0]` (empty vec if None) |
| `env_vars: Vec<(String,String)>` | `env_refs` as `EnvVarSource::Literal` |
| `startup_timeout: Duration` | `runtime.startup_timeout_secs` |
| `health_check_timeout: Duration` | `runtime.health_check_timeout_secs` |
| `security` | `SecurityContext::default()` (restrictive) |
| `test_image`, `container_name`, `model_to_pull`, `additional_args` | **not carried in this slice** — follow-up |
| `volumes` / `cpu_limit` / `memory_limit_mb` | **not in source type** — None/empty |

## Follow-ups

- `ContainerOperations` trait + real podman/docker lifecycle (wraps `container::start_container_with_fallback`).
- Carry over `test_image` / `container_name` / `model_to_pull` / `additional_args` from `ContainerConfig`.
- `BuildConfig` + `BuildManager` (Nix / Docker / Custom build tools).
- `BuildArtifact` + `ValidationReport`.
- `RollbackPlan` execution engine.
- `HarnessDevRelation`, `DevSandboxRelation`, `SandboxReleasePromotion` typed relationships.
- `DeploymentController::deploy()` / `rollback()` / `request_approval()` with HITL prompting.
- bollard for Docker API (avoid string-argv).
- k8s-openapi for manifest emission.
- Audit log writing to `entities::context`.
- Proptest: arbitrary `SecurityContext` always satisfies `read_only_root_fs || run_as_non_root`.
- Wire `container::start_container_with_fallback` to emit `ContainerConfigEntity` lifecycle events.

## Notes for reviewers

- Branch has 2 commits due to API-based per-file push path (`bridge.rs` + `mod.rs` were the only files that ended up needing a new commit — others were already identical to a prior partial push). Recommend squash-merge.
- Commits are unsigned (signing server was returning HTTP 400 throughout the session).

---

- job-id: `claude-cron-20260423T192050Z-03678285`
- oldest-issue-id: `one_track#2`

Closes #25 (partial)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RueT9k7KwCLy9Z1R5NE2Kh)_