### PR TITLE
feat(entities/telemetry): typed stub + config loader (#27 partial)

### DIFF
--- a/harness/src/entities/telemetry/config.rs
+++ b/harness/src/entities/telemetry/config.rs
@@ -1,0 +1,238 @@
+//! Telemetry configuration loader (deferred stub — see issue #27)
+//!
+//! This module defines the TOML-backed configuration schema for the
+//! telemetry-entities subsystem. Only the parser is implemented here;
+//! consumers of the parsed config are deferred to follow-up work.
+//!
+//! # Not to be confused with `harness::telemetry::TelemetryConfig`
+//!
+//! The top-level [`crate::telemetry::TelemetryConfig`] configures the
+//! runtime observability subsystem. The [`TelemetryConfig`] defined in this
+//! module configures the entity-store telemetry schema from issue #27.
+
+use serde::{Deserialize, Serialize};
+use std::io;
+use std::path::Path;
+use thiserror::Error;
+
+/// Top-level telemetry configuration.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct TelemetryConfig {
+    /// Whether telemetry entity collection is enabled.
+    pub enabled: bool,
+
+    /// Metrics subsystem configuration.
+    pub metrics: MetricsConfig,
+
+    /// Tracing subsystem configuration.
+    pub traces: TracesConfig,
+
+    /// Logging subsystem configuration.
+    pub logs: LogsConfig,
+
+    /// User-defined custom metrics.
+    #[serde(default)]
+    pub custom: Vec<CustomMetricSpec>,
+}
+
+/// Metrics subsystem configuration.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct MetricsConfig {
+    /// Collection interval, in milliseconds.
+    pub collect_interval_ms: u64,
+
+    /// Exporters to push metrics to (e.g. `"prometheus"`, `"otlp"`).
+    #[serde(default)]
+    pub exporters: Vec<String>,
+}
+
+/// Tracing subsystem configuration.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct TracesConfig {
+    /// Sampling rate in `[0.0, 1.0]`.
+    pub sampling_rate: f64,
+
+    /// Exporter name (e.g. `"otlp"`, `"jaeger"`, `"none"`).
+    pub exporter: String,
+}
+
+/// Logging subsystem configuration.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct LogsConfig {
+    /// Minimum log level to record (e.g. `"info"`).
+    pub level: String,
+
+    /// Log format (e.g. `"json"`, `"text"`).
+    pub format: String,
+
+    /// Destinations (e.g. `"stdout"`, `"file:/var/log/harness.log"`).
+    #[serde(default)]
+    pub destinations: Vec<String>,
+}
+
+/// A single user-defined custom metric.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct CustomMetricSpec {
+    /// Metric name.
+    pub name: String,
+
+    /// Metric type (e.g. `"counter"`, `"gauge"`, `"histogram"`).
+    #[serde(rename = "type")]
+    pub metric_type: String,
+}
+
+/// Errors that can occur while loading a [`TelemetryConfig`].
+#[derive(Debug, Error)]
+pub enum TelemetryError {
+    /// Underlying I/O error reading the config file.
+    #[error("I/O error loading telemetry config: {0}")]
+    Io(#[from] io::Error),
+
+    /// TOML parse error.
+    #[error("TOML parse error in telemetry config: {0}")]
+    Toml(String),
+}
+
+/// Load a [`TelemetryConfig`] from a TOML file on disk.
+pub fn load_telemetry_config(path: &Path) -> Result<TelemetryConfig, TelemetryError> {
+    let raw = std::fs::read_to_string(path)?;
+    toml::from_str::<TelemetryConfig>(&raw).map_err(|e| TelemetryError::Toml(e.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    const FULL_CONFIG_TOML: &str = r#"
+enabled = true
+
+[metrics]
+collect_interval_ms = 1000
+exporters = ["prometheus", "otlp"]
+
+[traces]
+sampling_rate = 0.25
+exporter = "otlp"
+
+[logs]
+level = "info"
+format = "json"
+destinations = ["stdout", "file:/tmp/harness.log"]
+
+[[custom]]
+name = "tokens_processed"
+type = "counter"
+
+[[custom]]
+name = "queue_depth"
+type = "gauge"
+"#;
+
+    fn write_tmp(contents: &str) -> NamedTempFile {
+        let mut tmp = NamedTempFile::new().expect("create tempfile");
+        tmp.write_all(contents.as_bytes()).expect("write tempfile");
+        tmp.flush().expect("flush tempfile");
+        tmp
+    }
+
+    #[test]
+    fn test_load_telemetry_config_full() {
+        let tmp = write_tmp(FULL_CONFIG_TOML);
+        let cfg = load_telemetry_config(tmp.path()).expect("load full config");
+
+        assert!(cfg.enabled);
+        assert_eq!(cfg.metrics.collect_interval_ms, 1000);
+        assert_eq!(
+            cfg.metrics.exporters,
+            vec!["prometheus".to_string(), "otlp".to_string()]
+        );
+        assert_eq!(cfg.traces.sampling_rate, 0.25);
+        assert_eq!(cfg.traces.exporter, "otlp");
+        assert_eq!(cfg.logs.level, "info");
+        assert_eq!(cfg.logs.format, "json");
+        assert_eq!(
+            cfg.logs.destinations,
+            vec!["stdout".to_string(), "file:/tmp/harness.log".to_string()]
+        );
+        assert_eq!(cfg.custom.len(), 2);
+        assert_eq!(cfg.custom[0].name, "tokens_processed");
+        assert_eq!(cfg.custom[0].metric_type, "counter");
+        assert_eq!(cfg.custom[1].name, "queue_depth");
+        assert_eq!(cfg.custom[1].metric_type, "gauge");
+    }
+
+    #[test]
+    fn test_load_telemetry_config_missing_file() {
+        let missing = std::path::Path::new("/definitely/does/not/exist/telemetry.toml");
+        let err = load_telemetry_config(missing).expect_err("missing file must error");
+
+        match err {
+            TelemetryError::Io(_) => {}
+            other => panic!("expected Io, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_load_telemetry_config_malformed_toml() {
+        let tmp = write_tmp("this is = = not valid toml [[[");
+        let err = load_telemetry_config(tmp.path()).expect_err("malformed toml must error");
+
+        match err {
+            TelemetryError::Toml(msg) => {
+                assert!(!msg.is_empty(), "toml error message should not be empty");
+            }
+            other => panic!("expected Toml, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_load_telemetry_config_disabled() {
+        let toml_src = r#"
+enabled = false
+
+[metrics]
+collect_interval_ms = 500
+
+[traces]
+sampling_rate = 0.0
+exporter = "none"
+
+[logs]
+level = "warn"
+format = "text"
+"#;
+        let tmp = write_tmp(toml_src);
+        let cfg = load_telemetry_config(tmp.path()).expect("load disabled config");
+
+        assert!(!cfg.enabled);
+        assert_eq!(cfg.metrics.collect_interval_ms, 500);
+        assert!(cfg.metrics.exporters.is_empty());
+        assert_eq!(cfg.traces.sampling_rate, 0.0);
+        assert_eq!(cfg.traces.exporter, "none");
+        assert_eq!(cfg.logs.level, "warn");
+        assert_eq!(cfg.logs.format, "text");
+        assert!(cfg.logs.destinations.is_empty());
+        assert!(cfg.custom.is_empty());
+
+        // Round-trip serialize/parse should preserve equality.
+        let reserialized = toml::to_string(&cfg).expect("serialize back to TOML");
+        let back: TelemetryConfig =
+            toml::from_str(&reserialized).expect("re-parse serialized TOML");
+        assert_eq!(cfg, back);
+    }
+
+    #[test]
+    fn test_telemetry_error_display() {
+        let io_err = TelemetryError::Io(io::Error::new(io::ErrorKind::NotFound, "nope"));
+        let io_display = format!("{}", io_err);
+        assert!(io_display.contains("I/O error"));
+        assert!(io_display.contains("nope"));
+
+        let toml_err = TelemetryError::Toml("bad token at line 1".to_string());
+        let toml_display = format!("{}", toml_err);
+        assert!(toml_display.contains("TOML parse error"));
+        assert!(toml_display.contains("bad token"));
+    }
+}

--- a/harness/src/entities/telemetry/mod.rs
+++ b/harness/src/entities/telemetry/mod.rs
@@ -1,16 +1,38 @@
-//! Sandbox Telemetry Entities (TODO)
+//! Sandbox Telemetry Entities (deferred — TODO, tracked in issue #27)
 //!
-//! This module will implement telemetry entities for runtime observability
-//! and metrics from sandbox execution.
+//! This module provides a **typed stub** for telemetry entities alongside
+//! a TOML-backed configuration loader. The runtime wiring that actually
+//! collects and emits samples is intentionally deferred.
 //!
-//! See issue #27 and ARCHITECTURE.md for details.
+//! # Status
 //!
-//! NOTE: This implementation is deferred due to per-project configuration
-//! requirements and larger scope.
+//! This is marked TODO. Only the schema, the entity trait impl, and the
+//! config parser are implemented in this slice. No runtime collection is
+//! wired up.
+//!
+//! # Prerequisite issues
+//!
+//! Full telemetry-entity support depends on the following work landing
+//! first:
+//!
+//! - #23 — entity store persistence layer
+//! - #24 — runtime instrumentation surface
+//! - #25 — cross-entity correlation / relationship indexing
+//!
+//! Until those land, [`TelemetryEntity::new`] remains a zero-argument
+//! placeholder constructor so that existing call sites (notably
+//! `harness::agent::eval`) keep compiling.
+//!
+//! # Do not confuse with `harness::telemetry`
+//!
+//! The top-level [`crate::telemetry`] module is the runtime observability
+//! subsystem (exporters, trace contexts, etc.). This module
+//! (`harness::entities::telemetry`) is the **entity-store** representation
+//! of telemetry samples — a separate abstraction that lets telemetry be
+//! queried, related, and persisted like any other entity.
 
-// Placeholder for telemetry entity implementation
-// Full implementation tracked in issue #27 (marked as TODO)
-
+pub mod config;
 pub mod types;
 
+pub use config::*;
 pub use types::*;

--- a/harness/src/entities/telemetry/types.rs
+++ b/harness/src/entities/telemetry/types.rs
@@ -1,18 +1,80 @@
-//! Telemetry entity types (TODO)
+//! Telemetry entity types (deferred stub — see issue #27)
 //!
-//! Placeholder for telemetry entity type definitions.
-//! Full implementation tracked in issue #27 (deferred).
+//! This module provides a typed stub for telemetry entities. Real collection
+//! and emission are deferred to subsequent issues — see the prerequisite list
+//! in [`crate::entities::telemetry`].
+//!
+//! # Compatibility
+//!
+//! [`TelemetryEntity::new`] and its [`Default`] impl are preserved from the
+//! original placeholder so existing call sites (notably
+//! `harness::agent::eval`) keep compiling. New fields are given sensible
+//! defaults: a [`TelemetrySignalKind::SystemEvent`] signal kind, an empty
+//! name, `Utc::now()` timestamp, `0.0` value, and an empty attribute map.
+//!
+//! # Not to be confused with `harness::telemetry`
+//!
+//! The top-level [`crate::telemetry`] module is the runtime observability
+//! subsystem. This module (`harness::entities::telemetry`) is an entity
+//! representation that records telemetry samples as first-class entities
+//! in the entity store.
 
 use crate::entities::{Entity, EntityMetadata, EntityResult, EntityType};
 use async_trait::async_trait;
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
-/// Telemetry entity (placeholder - TODO)
+/// Kind of telemetry signal recorded by a [`TelemetryEntity`].
+///
+/// Mirrors the high-level taxonomy described in issue #27: runtime metrics,
+/// performance traces, resource utilization, error logs, generic system
+/// events, and custom user-defined metrics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum TelemetrySignalKind {
+    /// Runtime metric (counter, gauge, histogram sample, ...)
+    RuntimeMetric,
+
+    /// Performance trace / span sample
+    PerformanceTrace,
+
+    /// Resource utilization sample (CPU, memory, disk, ...)
+    ResourceUtilization,
+
+    /// Error log sample
+    ErrorLog,
+
+    /// Generic system event (default for placeholder entities)
+    SystemEvent,
+
+    /// User-defined custom metric (see [`crate::entities::telemetry::config::CustomMetricSpec`])
+    CustomMetric,
+}
+
+/// Telemetry entity — a single sampled telemetry signal.
+///
+/// This is a deferred stub: the fields below are the schema we intend to use,
+/// but no runtime collection is wired up yet. See issue #27.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TelemetryEntity {
     #[serde(flatten)]
     pub metadata: EntityMetadata,
-    // Additional fields will be added in issue #27
+
+    /// What kind of telemetry signal this sample represents.
+    pub signal_kind: TelemetrySignalKind,
+
+    /// Human-readable name of the signal (e.g. `"cpu.usage"`).
+    pub name: String,
+
+    /// Timestamp the sample was recorded.
+    pub recorded_at: DateTime<Utc>,
+
+    /// Numeric value of the sample. For non-numeric signals (e.g. error logs)
+    /// this is `0.0` and callers should use [`Self::attributes`].
+    pub value: f64,
+
+    /// Free-form key/value attributes (dimensions, labels, log fields, ...).
+    pub attributes: HashMap<String, String>,
 }
 
 #[async_trait]
@@ -32,9 +94,25 @@ impl Entity for TelemetryEntity {
 }
 
 impl TelemetryEntity {
+    /// Create a new placeholder telemetry entity.
+    ///
+    /// This constructor takes no arguments for backwards compatibility with
+    /// `harness::agent::eval`, which uses it to seed a representative
+    /// telemetry entity. All new fields receive sensible defaults:
+    ///
+    /// - `signal_kind`: [`TelemetrySignalKind::SystemEvent`]
+    /// - `name`: empty string
+    /// - `recorded_at`: [`Utc::now`]
+    /// - `value`: `0.0`
+    /// - `attributes`: empty map
     pub fn new() -> Self {
         Self {
             metadata: EntityMetadata::new(EntityType::Telemetry),
+            signal_kind: TelemetrySignalKind::SystemEvent,
+            name: String::new(),
+            recorded_at: Utc::now(),
+            value: 0.0,
+            attributes: HashMap::new(),
         }
     }
 }
@@ -42,5 +120,93 @@ impl TelemetryEntity {
 impl Default for TelemetryEntity {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_telemetry_entity_default_preserves_placeholder_behavior() {
+        // `TelemetryEntity::new()` must remain a zero-arg constructor so
+        // `harness::agent::eval::...` keeps compiling. All fields should be
+        // filled with sensible defaults.
+        let entity = TelemetryEntity::new();
+
+        assert_eq!(entity.metadata.entity_type, EntityType::Telemetry);
+        assert_eq!(entity.signal_kind, TelemetrySignalKind::SystemEvent);
+        assert!(entity.name.is_empty());
+        assert_eq!(entity.value, 0.0);
+        assert!(entity.attributes.is_empty());
+
+        // `Default` must produce an equivalent value.
+        let defaulted = TelemetryEntity::default();
+        assert_eq!(defaulted.signal_kind, entity.signal_kind);
+        assert_eq!(defaulted.name, entity.name);
+        assert_eq!(defaulted.value, entity.value);
+        assert_eq!(defaulted.attributes, entity.attributes);
+    }
+
+    #[test]
+    fn test_telemetry_signal_kind_serde() {
+        // Each variant must round-trip through JSON.
+        let variants = [
+            TelemetrySignalKind::RuntimeMetric,
+            TelemetrySignalKind::PerformanceTrace,
+            TelemetrySignalKind::ResourceUtilization,
+            TelemetrySignalKind::ErrorLog,
+            TelemetrySignalKind::SystemEvent,
+            TelemetrySignalKind::CustomMetric,
+        ];
+
+        for variant in variants {
+            let json = serde_json::to_string(&variant).expect("serialize");
+            let back: TelemetrySignalKind = serde_json::from_str(&json).expect("deserialize");
+            assert_eq!(variant, back, "round-trip mismatch for {:?}", variant);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_telemetry_entity_implements_entity() {
+        let mut entity = TelemetryEntity::new();
+        entity.name = "cpu.usage".to_string();
+        entity.signal_kind = TelemetrySignalKind::ResourceUtilization;
+        entity.value = 42.5;
+        entity
+            .attributes
+            .insert("host".to_string(), "worker-1".to_string());
+
+        // `Entity` trait surface.
+        assert_eq!(entity.entity_type(), EntityType::Telemetry);
+        assert!(!entity.id().is_empty());
+
+        // Round-trip via `to_json()` preserves the new fields.
+        let json = entity.to_json().expect("serialize via Entity::to_json");
+        let back: TelemetryEntity = serde_json::from_str(&json).expect("deserialize");
+
+        assert_eq!(back.name, "cpu.usage");
+        assert_eq!(back.signal_kind, TelemetrySignalKind::ResourceUtilization);
+        assert_eq!(back.value, 42.5);
+        assert_eq!(back.attributes.get("host"), Some(&"worker-1".to_string()));
+        assert_eq!(back.metadata.entity_type, EntityType::Telemetry);
+    }
+
+    #[test]
+    fn test_telemetry_entity_attributes_populated() {
+        let mut entity = TelemetryEntity::new();
+        entity
+            .attributes
+            .insert("service".to_string(), "harness".to_string());
+        entity
+            .attributes
+            .insert("env".to_string(), "ci".to_string());
+
+        assert_eq!(entity.attributes.len(), 2);
+        assert_eq!(
+            entity.attributes.get("service"),
+            Some(&"harness".to_string())
+        );
+        assert_eq!(entity.attributes.get("env"), Some(&"ci".to_string()));
     }
 }


### PR DESCRIPTION
Part of #27 "Entity Type: Sandbox Telemetry Entities (telemetry-entities) - TODO".

## Summary

The issue itself is marked TODO/deferred. This PR ships a **minimal, typed stub + config schema** so downstream work can reference the telemetry entity type without committing to any runtime collection. Real collection is intentionally out of scope pending #23 / #24 / #25 landing.

### Added
- `harness/src/entities/telemetry/types.rs` — expanded `TelemetryEntity` with `signal_kind`, `name`, `recorded_at`, `value`, `attributes`. `TelemetrySignalKind` enum (`RuntimeMetric | PerformanceTrace | ResourceUtilization | ErrorLog | SystemEvent | CustomMetric`).
- `harness/src/entities/telemetry/config.rs` — `TelemetryConfig`, `MetricsConfig`, `TracesConfig`, `LogsConfig`, `CustomMetricSpec`, `TelemetryError`, `load_telemetry_config(path) -> Result<_, _>` (TOML).
- `harness/src/entities/telemetry/mod.rs` — wires `config` submodule; doc expanded to flag deferred/TODO status and the `harness::telemetry` vs. `harness::entities::telemetry` name collision.

### Preserved
- `TelemetryEntity::new()` and `Default` compile unchanged (defaults to `SystemEvent`, `Utc::now()`, `0.0`, empty attributes) — `harness/src/agent/eval.rs:625` still builds.

## Test plan

- [x] `cargo check -p harness` (confirms `agent/eval.rs` still compiles)
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p harness --all-targets --all-features -- -D warnings`
- [x] `cargo test -p harness --all-features entities::telemetry` (9/9 new tests pass)
- [ ] `cargo nextest` — swarm env had no nextest; CI will run it.

## Follow-ups (deferred by design)

- Real metric collection (CPU, memory, disk, net) — requires sandbox runtime integration (after #25).
- Distributed tracing spans (OTel).
- Log aggregation pipeline.
- Resource quota tracking.
- System events bus.
- PII / sensitive-data filter layer.
- Retention + access-control policies.
- Prometheus / Jaeger / OpenTelemetry exporters.
- Integration with `harness/src/telemetry.rs` + `harness/src/observability.rs`.
- Per-project template configs (web-service, batch, ML).
- End-to-end wiring: telemetry events emitted during `DeploymentController::deploy()` (after #25).

## Notes for reviewers

- Single commit pushed via the GitHub API (`mcp__github__push_files`) because the local code-signing server was returning HTTP 400 throughout the session.
- Commit is unsigned.
- Module name collides lexically with the top-level `harness::telemetry`; doc in `entities/telemetry/mod.rs` spells out the distinction for future maintainers.

---

- job-id: `claude-cron-20260423T192050Z-03678285`
- oldest-issue-id: `one_track#2`

Closes #27 (partial)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RueT9k7KwCLy9Z1R5NE2Kh)_