### PR TITLE
arch: remove dead code and consolidate AgentLoop constructors

### DIFF
--- a/harness/src/agent/mod.rs
+++ b/harness/src/agent/mod.rs
@@ -295,19 +295,7 @@ pub struct AgentLoop<S: EntityStore + Send = InMemoryEntityStore> {
 impl AgentLoop<InMemoryEntityStore> {
     /// Create a new agent loop with the default in-memory entity store.
     pub fn new(config: AgentConfig) -> Self {
-        Self {
-            state: AgentState::EnrichingEntities,
-            config,
-            iterations: 0,
-            entity_store: InMemoryEntityStore::new(),
-            performed_actions: 0,
-            llm_provider: None,
-            plan_cache: None,
-            tool_registry: None,
-            conversation_history: Vec::new(),
-            progress_counter: None,
-            state_history: Vec::new(),
-        }
+        Self::with_entity_store(config, InMemoryEntityStore::new())
     }
 }
 
@@ -336,17 +324,8 @@ impl<S: EntityStore + Send> AgentLoop<S> {
         llm_provider: Arc<dyn ModelProvider>,
     ) -> Self {
         Self {
-            state: AgentState::EnrichingEntities,
-            config,
-            iterations: 0,
-            entity_store,
-            performed_actions: 0,
             llm_provider: Some(llm_provider),
-            plan_cache: None,
-            tool_registry: None,
-            conversation_history: Vec::new(),
-            progress_counter: None,
-            state_history: Vec::new(),
+            ..Self::with_entity_store(config, entity_store)
         }
     }
 
@@ -358,17 +337,8 @@ impl<S: EntityStore + Send> AgentLoop<S> {
         tool_registry: ToolRegistry,
     ) -> Self {
         Self {
-            state: AgentState::EnrichingEntities,
-            config,
-            iterations: 0,
-            entity_store,
-            performed_actions: 0,
-            llm_provider: Some(llm_provider),
-            plan_cache: None,
             tool_registry: Some(tool_registry),
-            conversation_history: Vec::new(),
-            progress_counter: None,
-            state_history: Vec::new(),
+            ..Self::with_llm(config, entity_store, llm_provider)
         }
     }
 

--- a/harness/src/entities/ast/types.rs
+++ b/harness/src/entities/ast/types.rs
@@ -154,9 +154,6 @@ impl FileEntity {
     }
 }
 
-#[deprecated(note = "Use FileEntity instead")]
-pub type AstEntity = FileEntity;
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/harness/src/monitoring.rs
+++ b/harness/src/monitoring.rs
@@ -518,9 +518,6 @@ struct InternalMetrics {
     errors: Vec<ErrorEvent>,
     /// Model metrics
     model_metrics: HashMap<String, ModelMetrics>,
-    /// System resource snapshots
-    #[allow(dead_code)]
-    system_snapshots: Vec<SystemResourceMetrics>,
 }
 
 impl Default for DefaultMetricsCollector {


### PR DESCRIPTION
## Summary

Three small, low-risk reductions aligned with the precepts in [ARCHITECTURE.md](./ARCHITECTURE.md), [AGENTS.md](./AGENTS.md), and [TESTING.md](./TESTING.md) ("Untested code is brittle. Harden it, don't bend it."):

- `harness/src/entities/ast/types.rs`: drop the deprecated `AstEntity` type alias for `FileEntity`. No remaining call sites in the workspace.
- `harness/src/monitoring.rs`: drop the dead `system_snapshots` field on `InternalMetrics`. Never written, never read; the supporting `SystemResourceMetrics` type stays in active use elsewhere.
- `harness/src/agent/mod.rs`: have `with_llm` and `with_tools` chain through `with_entity_store` via struct update syntax, so the `EnrichingEntities` initial state and zeroed counters live in one place. Pure refactor; the four constructor entry points remain identical.

Net: 3 insertions, 39 deletions across 3 files.

## Test plan

- [x] `cargo check --workspace --all-features` clean
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] `cargo test --workspace --lib --all-features` — same 2 pre-existing failures as `main` (`eval::swebench::tests::materialize_from_url_*`, unrelated to this change)
- [ ] CI green

---
_Generated by [Claude Code](https://claude.ai/code/session_01FzKpNrStguLtayd2ia2SKq)_