### PR TITLE
ci(eval): run happy-path cases against gemma4:e4b, fix #235

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,11 +147,7 @@ jobs:
       shell: bash
       run: |
         nix develop --command cargo nextest run --workspace --test '*' --all-features --test-threads=1
-        if curl -s --max-time 5 http://localhost:11434/api/tags > /dev/null 2>&1; then
-          nix develop --command cargo nextest run --workspace --test '*' --all-features --run-ignored ignored-only --test-threads=1
-        else
-          echo "Ollama not reachable on port 11434, skipping model integration tests"
-        fi
+        nix develop --command cargo nextest run --workspace --test '*' --all-features --run-ignored ignored-only --test-threads=1
 
     - name: Run lint checks
       if: matrix.test-type == 'lint'

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -52,10 +52,18 @@ jobs:
       run: |
         curl -fsSL https://ollama.com/install.sh | sh
         ollama serve &
+        READY=false
         for i in $(seq 1 60); do
-          ollama list > /dev/null 2>&1 && break
+          if ollama list > /dev/null 2>&1; then
+            READY=true
+            break
+          fi
           sleep 1
         done
+        if [ "$READY" != "true" ]; then
+          echo "::error::ollama daemon never became ready within 60s" >&2
+          exit 1
+        fi
         for attempt in 1 2 3; do
           if timeout 600 ollama pull "$MODEL"; then
             break

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -79,6 +79,19 @@ jobs:
         fi
         ollama list
 
+    # Test-image / model coverage notes:
+    #   * This workflow installs Ollama directly on the runner and pulls $MODEL,
+    #     so NANNA_EVAL_MODEL flows end-to-end into the happy-path runner.
+    #   * The harness integration tests in ci.yml's "integration-container" leg
+    #     reference a pre-baked qwen3 image (nanna-coder-test-ollama-qwen3:latest,
+    #     defined in nix/containers.nix). When that image is present locally the
+    #     ContainerConfig short-circuits model_to_pull (see container.rs ~line 321),
+    #     so those tests effectively run against qwen3 regardless of NANNA_EVAL_MODEL.
+    #     That mismatch is pre-existing and orthogonal to this workflow; aligning
+    #     test images with NANNA_EVAL_MODEL is tracked separately.
+    #   * --workspace --features eval-runner: cargo applies the feature only to
+    #     packages that declare it (the eval crate); other workspace members
+    #     compile without it. The flag is package-scoped, not workspace-wide.
     - name: Run eval suite
       id: eval
       env:

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -64,13 +64,19 @@ jobs:
           echo "::error::ollama daemon never became ready within 60s" >&2
           exit 1
         fi
+        PULLED=false
         for attempt in 1 2 3; do
           if timeout 600 ollama pull "$MODEL"; then
+            PULLED=true
             break
           fi
           echo "ollama pull attempt ${attempt} failed; retrying..."
           sleep 5
         done
+        if [ "$PULLED" != "true" ]; then
+          echo "::error::ollama pull failed for $MODEL after 3 attempts" >&2
+          exit 1
+        fi
         ollama list
 
     - name: Run eval suite

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -10,9 +10,10 @@ on:
       model:
         description: 'Model to use for evaluation'
         required: false
-        default: 'qwen3:0.6b'
+        default: 'gemma4:e4b'
         type: choice
         options:
+          - gemma4:e4b
           - qwen3:0.6b
           - llama3.1:8b
       case_filter:
@@ -51,17 +52,24 @@ jobs:
       run: |
         curl -fsSL https://ollama.com/install.sh | sh
         ollama serve &
-        # Wait for Ollama to be ready
-        for i in $(seq 1 30); do
+        for i in $(seq 1 60); do
           ollama list > /dev/null 2>&1 && break
           sleep 1
         done
-        ollama pull "$MODEL"
+        for attempt in 1 2 3; do
+          if timeout 600 ollama pull "$MODEL"; then
+            break
+          fi
+          echo "ollama pull attempt ${attempt} failed; retrying..."
+          sleep 5
+        done
+        ollama list
 
     - name: Run eval suite
       id: eval
       env:
         MODEL: ${{ inputs.model }}
+        NANNA_EVAL_MODEL: ${{ inputs.model }}
         CASE_FILTER: ${{ inputs.case_filter }}
       run: |
         echo "## Eval Results" > eval-results.md
@@ -84,20 +92,37 @@ jobs:
           --workspace --all-features \
           -E "$FILTER" \
           --no-fail-fast 2>&1 | tee eval-output.txt
-        EXIT_CODE=$?
+        UNIT_EXIT=$?
         set -e
 
         cat eval-output.txt >> eval-results.md
         echo '```' >> eval-results.md
 
-        if [ "$EXIT_CODE" -eq 0 ]; then
+        echo "" >> eval-results.md
+        echo "### Happy-path eval cases" >> eval-results.md
+        echo '```' >> eval-results.md
+
+        set +e
+        nix develop --command cargo nextest run \
+          --workspace --features eval-runner \
+          --run-ignored ignored-only \
+          -E 'test(eval_runner)' \
+          --test-threads=1 \
+          --no-fail-fast 2>&1 | tee happy-path-output.txt
+        HAPPY_EXIT=$?
+        set -e
+
+        cat happy-path-output.txt >> eval-results.md
+        echo '```' >> eval-results.md
+
+        if [ "$UNIT_EXIT" -eq 0 ] && [ "$HAPPY_EXIT" -eq 0 ]; then
           echo "outcome=success" >> "$GITHUB_OUTPUT"
           echo "" >> eval-results.md
           echo "**Status: PASSED**" >> eval-results.md
         else
           echo "outcome=failure" >> "$GITHUB_OUTPUT"
           echo "" >> eval-results.md
-          echo "**Status: FAILED** (see logs above)" >> eval-results.md
+          echo "**Status: FAILED** (unit_exit=${UNIT_EXIT} happy_exit=${HAPPY_EXIT})" >> eval-results.md
         fi
 
     - name: Write eval summary
@@ -120,4 +145,5 @@ jobs:
         path: |
           eval-results.md
           eval-output.txt
+          happy-path-output.txt
         if-no-files-found: warn

--- a/harness/tests/dev_container_integration.rs
+++ b/harness/tests/dev_container_integration.rs
@@ -20,7 +20,9 @@ use tokio::time::timeout;
 const MAX_ATTEMPTS: usize = 5;
 const MAX_TURNS: usize = 32;
 const TEST_TIMEOUT: Duration = Duration::from_secs(600);
-const E2E_MODEL: &str = "gemma4:e4b";
+fn e2e_model() -> String {
+    std::env::var("NANNA_EVAL_MODEL").unwrap_or_else(|_| "gemma4:e4b".to_string())
+}
 
 fn example_repo_path() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -131,7 +133,7 @@ async fn run_single_attempt(image_ref: &str) -> Result<(), String> {
         max_iterations: MAX_TURNS,
         verbose: true,
         system_prompt: "You are a coding assistant. Modify this Rust project to compute the first 10 prime numbers instead of Fibonacci numbers. Update src/lib.rs to implement a `primes(n: usize) -> Vec<u64>` function that returns the first n prime numbers. Update src/main.rs to call `primes(10)` and print the result. Update tests/fib_test.rs to test that primes(10) returns [2, 3, 5, 7, 11, 13, 17, 19, 23, 29]. Use run_command to run `cargo test` and `cargo run` to verify your changes work.".to_string(),
-        model_name: E2E_MODEL.to_string(),
+        model_name: e2e_model(),
     };
 
     let context = AgentContext {
@@ -222,7 +224,7 @@ async fn test_task_manager_submit_with_dev_container() {
                 .to_string(),
             repo_path,
             "HEAD".to_string(),
-            E2E_MODEL.to_string(),
+            e2e_model(),
             MAX_TURNS,
             provider,
         )

--- a/harness/tests/integration_tests.rs
+++ b/harness/tests/integration_tests.rs
@@ -27,7 +27,9 @@ use tokio::time::{sleep, timeout};
 // use futures::future; // Reserved for future concurrent test implementation
 
 // E2E test configuration
-const E2E_MODEL: &str = "gemma4:e4b";
+fn e2e_model() -> String {
+    std::env::var("NANNA_EVAL_MODEL").unwrap_or_else(|_| "gemma4:e4b".to_string())
+}
 const E2E_TIMEOUT: Duration = Duration::from_secs(300);
 const CONTAINER_STARTUP_WAIT: Duration = Duration::from_secs(30);
 const HEALTH_CHECK_TIMEOUT: Duration = Duration::from_secs(60);
@@ -765,7 +767,7 @@ async fn test_e2e_container_to_validated_inference() {
         test_image: Some("nanna-coder-test-ollama-qwen3:latest".to_string()),
         container_name: "e2e-test-container".to_string(),
         port_mapping: Some((11437, 11434)),
-        model_to_pull: Some(E2E_MODEL.to_string()),
+        model_to_pull: Some(e2e_model()),
         startup_timeout: CONTAINER_STARTUP_WAIT,
         health_check_timeout: HEALTH_CHECK_TIMEOUT,
         env_vars: vec![("OLLAMA_MODELS".to_string(), "/models".to_string())],
@@ -1166,7 +1168,7 @@ async fn test_e2e_performance_and_reliability() {
         test_image: Some("nanna-coder-test-ollama-qwen3:latest".to_string()),
         container_name: "e2e-performance-test".to_string(),
         port_mapping: Some((11439, 11434)),
-        model_to_pull: Some(E2E_MODEL.to_string()),
+        model_to_pull: Some(e2e_model()),
         startup_timeout: CONTAINER_STARTUP_WAIT,
         health_check_timeout: HEALTH_CHECK_TIMEOUT,
         env_vars: vec![
@@ -1244,7 +1246,7 @@ async fn test_e2e_performance_and_reliability() {
 
     for prompt in test_prompts {
         let messages = vec![ChatMessage::user(prompt)];
-        let request = ChatRequest::new(E2E_MODEL, messages).with_temperature(0.1);
+        let request = ChatRequest::new(e2e_model(), messages).with_temperature(0.1);
 
         match provider.chat(request).await {
             Ok(_) => successful_requests += 1,
@@ -1260,7 +1262,7 @@ async fn test_e2e_performance_and_reliability() {
     println!("💾 Performance Test 3: Resource efficiency validation");
     let memory_test_prompt = "Generate a detailed explanation of machine learning in 100 words";
     let memory_messages = vec![ChatMessage::user(memory_test_prompt)];
-    let memory_request = ChatRequest::new(E2E_MODEL, memory_messages)
+    let memory_request = ChatRequest::new(e2e_model(), memory_messages)
         .with_max_tokens(150)
         .with_temperature(0.3);
 
@@ -1757,7 +1759,7 @@ async fn test_e2e_agent_with_containerized_ollama() {
         test_image: Some("nanna-coder-test-ollama-qwen3:latest".to_string()),
         container_name: "e2e-agent-integration-test".to_string(),
         port_mapping: Some((11440, 11434)),
-        model_to_pull: Some(E2E_MODEL.to_string()),
+        model_to_pull: Some(e2e_model()),
         startup_timeout: CONTAINER_STARTUP_WAIT,
         health_check_timeout: HEALTH_CHECK_TIMEOUT,
         env_vars: vec![],
@@ -1802,7 +1804,7 @@ async fn test_e2e_agent_with_containerized_ollama() {
         max_iterations: 10,
         verbose: true,
         system_prompt: "You are a helpful assistant. Use the echo tool when asked to echo something. After using the tool, respond with a brief summary.".to_string(),
-        model_name: E2E_MODEL.to_string(),
+        model_name: e2e_model(),
     };
 
     let context = AgentContext {

--- a/harness/tests/nanna_self_dev_integration.rs
+++ b/harness/tests/nanna_self_dev_integration.rs
@@ -17,7 +17,9 @@ use tokio::time::timeout;
 const MAX_ATTEMPTS: usize = 5;
 const MAX_TURNS: usize = 32;
 const TEST_TIMEOUT: Duration = Duration::from_secs(600);
-const E2E_MODEL: &str = "gemma4:e4b";
+fn e2e_model() -> String {
+    std::env::var("NANNA_EVAL_MODEL").unwrap_or_else(|_| "gemma4:e4b".to_string())
+}
 const ORIGINAL_HELP_STRING: &str = "A CLI tool for interacting with language models";
 
 fn workspace_root() -> PathBuf {
@@ -138,7 +140,7 @@ async fn run_single_attempt(runtime: &ContainerRuntime, image_ref: &str) -> Resu
              After making changes, use run_command to verify with `cargo build --workspace` and \
              `cargo test --workspace` inside the container."
         ),
-        model_name: E2E_MODEL.to_string(),
+        model_name: e2e_model(),
     };
 
     let context = AgentContext {


### PR DESCRIPTION
## Summary

Three CI changes that, together, take the eval suite from "scaffolding only" to "exercises the agent end-to-end on every workflow_dispatch":

1. **`.github/workflows/ci.yml`** — drop the broken Ollama probe in the `integration-container` matrix leg. The probe checked `localhost:11434`, but nothing in the job ever started Ollama there, so `--run-ignored ignored-only` was always silently skipped — every model-backed integration test passed CI without ever running. Fixes **#235**.

2. **`.github/workflows/eval.yml`** — add a "Run happy-path eval cases" step that invokes the new `run_eval` runner (from #271) via `cargo nextest run --features eval-runner --run-ignored ignored-only -E 'test(eval_runner)'`. Default model bumped to `gemma4:e4b`; both `gemma4:e4b` and `qwen3:0.6b` remain in the workflow_dispatch choice list. Workflow now exports `NANNA_EVAL_MODEL` alongside `MODEL`. Ollama startup hardened (60s wait, retry/timeout around `ollama pull`). Added `happy-path-output.txt` to the uploaded `eval-results` artefact.

3. **`harness/tests/{integration_tests,dev_container_integration,nanna_self_dev_integration}.rs`** — replace `const E2E_MODEL: &str = "gemma4:e4b"` with an `e2e_model()` helper reading `NANNA_EVAL_MODEL` (default `gemma4:e4b`), so the workflow's model choice flows into the E2E tests. Mirrors the salvageable parts of #236 without taking on that PR's competing runner design.

## Why this is a separate PR from #271

#271 adds the `eval-runner` feature and the `run_eval` function. This PR's happy-path workflow step depends on that feature existing. Splitting them keeps both diffs small and reviewable. **Do not merge this before #271.**

## Stacked on #271

This PR is opened against `claude/eval-runner-issue-89` (the branch behind #271). Once #271 lands, GitHub will auto-rebase against `main`. If you'd prefer it against `main` directly, that's also fine — the conflict surface is small (this branch carries one extra commit on top of #271's tree).

## Test plan

- [x] `cargo check --workspace --all-features --tests` clean
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo nextest run --workspace --all-features` — 610 passed, 17 skipped (the 17 are `#[ignore]` tests requiring Ollama)
- [ ] CI green
- [ ] Manual `Eval Suite` workflow_dispatch run against `gemma4:e4b` produces a green `eval-results` artefact with happy-path-001/002/003 pass marks
- [ ] Push a deliberately-failing ignored test on a throwaway branch and confirm CI fails (validates that #235's silent-skip is gone)

## Notes

- **`workflows` permission caveat**: the GitHub App used by this session may not have `workflows` permission. If the push of `.github/workflows/*` was blocked, the maintainer needs to apply the workflow diff manually. (My push succeeded today, so this caveat may not apply.)
- The pre-existing `cargo deny` advisory on `rand 0.8.5` is unrelated.
- Defers #236's container-orchestrated runner design and resource utilization (#92).

Closes #235.
Part of #84, #129.