### PR TITLE
[clarity] tighten PoC overview, CI/CD pipeline, dev-experience, and test-execution docs

### DIFF
--- a/docs/ci-cd-pipeline.md
+++ b/docs/ci-cd-pipeline.md
@@ -5,9 +5,10 @@ The CI pipeline lives in `.github/workflows/ci.yml`. For the cache strategy that
 ## Job graph
 
 ```
-test-matrix    (unit, integration, lint, security)
-build-matrix   (x86_64-linux, aarch64-linux, x86_64-darwin, aarch64-darwin)
-build-containers (harness, ollama, qwen3-container, llama3-container)
+prebuild-deps    (builds Rust toolchain + cargo deps once; populates Cachix; gates all matrix jobs)
+├── test-matrix    (unit, integration, lint, security)
+├── build-matrix   (x86_64-linux, aarch64-linux, x86_64-darwin, aarch64-darwin)
+└── build-containers (harness, ollama, qwen3-container, llama3-container)
 benchmark        (main only)
 cache-maintenance (main only)
 ci-summary       (always; aggregates status)
@@ -15,6 +16,10 @@ release          (on GitHub release events)
 ```
 
 The total matrix is roughly 30 parallel jobs.
+
+## `prebuild-deps`
+
+Runs first, before all matrix jobs. Builds the Rust toolchain and all cargo dependencies once, then pushes the results to the Cachix binary cache (`nanna-coder`) under the key `cachix-v1-deps-{flake.lock}-{Cargo.lock}`. Outputs a `cache-key` value consumed by every downstream job. Because this job gates `test-matrix`, `build-matrix`, and `build-containers`, a cache miss here adds one build step rather than repeating it across the full ~30-job matrix.
 
 ## `test-matrix`
 

--- a/docs/ci-cd-pipeline.md
+++ b/docs/ci-cd-pipeline.md
@@ -1,371 +1,137 @@
-# CI/CD Pipeline Documentation
+# CI/CD Pipeline
 
-## Overview
+The CI pipeline lives in `.github/workflows/ci.yml`. For the cache strategy that backs it, see [CACHE_STRATEGY.md](./CACHE_STRATEGY.md). For test scope and commands, see [../TESTING.md](../TESTING.md).
 
-The Nanna Coder project uses an advanced, parallel CI/CD pipeline that provides comprehensive testing, building, and deployment across multiple platforms and architectures.
-
-## Pipeline Architecture
-
-### Parallel Execution Strategy
-
-The pipeline is designed for maximum parallelization and efficiency:
+## Job graph
 
 ```
-┌─────────────────────────────────────────────────────────────┐
-│                    CI/CD Pipeline Matrix                    │
-├─────────────────────────────────────────────────────────────┤
-│ Test Matrix (Parallel)                                     │
-│ ├── Unit Tests (Linux, macOS, Windows × stable, beta)      │
-│ ├── Integration Tests (Linux × stable, beta)               │
-│ ├── Lint Checks (Linux, macOS, Windows × stable, beta)     │
-│ └── Security Checks (Linux × stable, beta)                 │
-├─────────────────────────────────────────────────────────────┤
-│ Build Matrix (Parallel)                                    │
-│ ├── x86_64-linux (Nix)                                     │
-│ ├── aarch64-linux (Nix cross-compilation)                  │
-│ ├── x86_64-darwin (Cargo)                                  │
-│ └── aarch64-darwin (Cargo cross-compilation)               │
-├─────────────────────────────────────────────────────────────┤
-│ Container Matrix (Parallel)                                │
-│ ├── Harness (x86_64, aarch64)                              │
-│ ├── Ollama (x86_64, aarch64)                               │
-│ ├── Qwen3 Container (x86_64)                               │
-│ └── Llama3 Container (x86_64)                              │
-├─────────────────────────────────────────────────────────────┤
-│ Performance & Maintenance                                  │
-│ ├── Benchmarks (main branch)                               │
-│ ├── Cache Maintenance                                      │
-│ └── CI Summary & Status Aggregation                        │
-└─────────────────────────────────────────────────────────────┘
+test-matrix    (unit, integration, lint, security)
+build-matrix   (x86_64-linux, aarch64-linux, x86_64-darwin, aarch64-darwin)
+build-containers (harness, ollama, qwen3-container, llama3-container)
+benchmark        (main only)
+cache-maintenance (main only)
+ci-summary       (always; aggregates status)
+release          (on GitHub release events)
 ```
 
-## Pipeline Jobs
+The total matrix is roughly 30 parallel jobs.
 
-### 1. Test Matrix (`test-matrix`)
+## `test-matrix`
 
-**Purpose**: Comprehensive testing across platforms and Rust versions
-**Strategy**: Parallel execution with fail-fast disabled
-**Matrix Dimensions**:
-- **Operating Systems**: Ubuntu, macOS, Windows
-- **Rust Versions**: stable, beta, nightly (limited)
-- **Test Types**: unit, integration, lint, security
+Runs across `{ubuntu, macos, windows} x {stable, beta, (nightly limited)} x {unit, integration, lint, security}`, fail-fast disabled.
 
-#### Test Types
+| Test type | Command | Platforms |
+|---|---|---|
+| unit | `cargo nextest run --workspace --lib` | all |
+| integration | `nix run .#container-test` | linux only (containers required) |
+| lint | `cargo clippy --workspace --all-targets -- -D warnings` and `cargo fmt --all -- --check` | all |
+| security | `cargo audit`, `cargo deny check`, `cargo tarpaulin` | linux only |
 
-##### Unit Tests
-- **Scope**: Library and binary unit tests
-- **Command**: `cargo nextest run --workspace --lib`
-- **Platforms**: All (Linux, macOS, Windows)
-- **Rust Versions**: stable, beta, nightly
+Per-platform notes:
 
-##### Integration Tests
-- **Scope**: Containerized integration testing
-- **Command**: `nix run .#container-test`
-- **Platforms**: Linux only (container support required)
-- **Features**:
-  - Pre-built test containers
-  - Model integration testing
-  - Health checks
+- **Linux** — Nix-based builds, full Cachix integration, all test types.
+- **macOS** — direct Rust toolchain, cargo-installed tools, no containers (integration skipped).
+- **Windows** — direct Rust toolchain, unit + lint only; security tooling has limited Windows support.
 
-##### Lint Checks
-- **Scope**: Code quality and formatting
-- **Commands**:
-  - `cargo clippy --workspace --all-targets -- -D warnings`
-  - `cargo fmt --all -- --check`
-- **Platforms**: All
-- **Standards**: Zero warnings policy
+Coverage results upload to Codecov with a Rust-version flag.
 
-##### Security Checks
-- **Scope**: Security audit and compliance
-- **Commands**:
-  - `cargo audit` (vulnerability scanning)
-  - `cargo deny check` (license compliance)
-  - `cargo tarpaulin` (code coverage)
-- **Platforms**: Linux only
-- **Coverage**: Uploaded to Codecov with Rust version flags
+## `build-matrix`
 
-#### Platform-Specific Configurations
+| Target | Builder | Notes |
+|---|---|---|
+| x86_64-linux | `nix build .#nanna-coder` | native |
+| aarch64-linux | nix cross-compile | falls back to native if cross fails |
+| x86_64-darwin | `cargo build --release` | native |
+| aarch64-darwin | `cargo build --target aarch64-apple-darwin --release` | cross |
 
-**Linux (Ubuntu)**:
-- Uses Nix for reproducible builds
-- Full Cachix binary cache integration
-- Container support for integration tests
-- All test types supported
+Artifacts are named `nanna-coder-{target}` and uploaded with warning-on-missing.
 
-**macOS**:
-- Uses direct Rust toolchain installation
-- Cargo-based tool installation
-- No container support (integration tests skipped)
-- Unit, lint, and partial security tests
+## `build-containers`
 
-**Windows**:
-- Uses direct Rust toolchain installation
-- Limited to unit and lint tests
-- Security tests skipped (tooling limitations)
+| Image | Architectures |
+|---|---|
+| harness | x86_64, aarch64 |
+| ollama | x86_64, aarch64 |
+| qwen3-container | x86_64 |
+| llama3-container | x86_64 |
 
-### 2. Build Matrix (`build-matrix`)
+Pushes to `ghcr.io` using the workflow's `GITHUB_TOKEN`. Tags: `latest{-arm64}`, `<sha>{-arm64}`. Push is skipped on pull requests.
 
-**Purpose**: Multi-platform binary compilation
-**Strategy**: Cross-platform with fallback support
-**Targets**: x86_64-linux, aarch64-linux, x86_64-darwin, aarch64-darwin
+## Performance jobs
 
-#### Build Strategies
+- **`benchmark`** — runs on pushes to `main`. Uses `cargo bench` with Criterion; results stored on GitHub Pages via `benchmark-action`. Regression alert threshold: 200%.
+- **`cache-maintenance`** — pushes to `main` only. Runs `cache-analytics`, pushes to Cachix, summarizes in the GitHub Step Summary.
 
-**Linux Targets** (Ubuntu runner):
-- **x86_64-linux**: Native Nix build (`nix build .#nanna-coder`)
-- **aarch64-linux**: Nix cross-compilation with fallback
+## Release pipeline
 
-**macOS Targets** (macOS runner):
-- **x86_64-darwin**: Native Cargo build (`cargo build --release`)
-- **aarch64-darwin**: Cargo cross-compilation (`--target aarch64-apple-darwin`)
+Triggered on GitHub release events. Builds `harness-{target}` for the four targets above and uploads them as release assets.
 
-#### Artifact Management
-- Platform-specific artifact preparation
-- Automatic fallback for failed cross-compilation
-- Structured artifact naming (`nanna-coder-{target}`)
-- Upload with warnings for missing files
+## `ci-summary`
 
-### 3. Container Matrix (`build-containers`)
+Always runs. Aggregates job statuses into a markdown table in the Step Summary, surfaces artifact links, and reports failures.
 
-**Purpose**: Multi-architecture container image builds
-**Strategy**: Parallel container builds with registry push
-**Images**: harness, ollama, qwen3-container, llama3-container
-**Architectures**: x86_64, aarch64 (model containers x86_64 only)
+## Caching
 
-#### Container Types
+See [CACHE_STRATEGY.md](./CACHE_STRATEGY.md) for keys, TTLs, and the push filter (`(-source$|nixpkgs\.tar\.gz$)`). Other caches in play:
 
-**Base Containers**:
-- **Harness**: Application runtime container
-- **Ollama**: Model inference server
+- Cargo dependency cache (per-runner).
+- Container layer cache (Docker / podman).
 
-**Model Containers**:
-- **Qwen3**: Pre-loaded with Qwen3 0.6B model
-- **Llama3**: Pre-loaded with Llama3 model
-- **Optimized**: x86_64 only (ARM64 planned)
+## Security gates
 
-#### Registry Management
-- **Registry**: GitHub Container Registry (ghcr.io)
-- **Tagging Strategy**:
-  - Latest: `latest{-arm64}`
-  - Commit: `{sha}{-arm64}`
-- **Push Policy**: Skip on pull requests
-- **Authentication**: GitHub token
+Supply chain:
 
-### 4. Performance Jobs
+- `cargo audit` — vulnerability scanning.
+- `cargo deny check` — license compliance.
+- Pinned dependencies (`Cargo.lock`, `flake.lock`).
 
-#### Benchmarks (`benchmark`)
-- **Trigger**: Main branch pushes only
-- **Framework**: Cargo bench with Criterion
-- **Storage**: GitHub Pages with benchmark-action
-- **Alerting**: 200% performance regression threshold
-- **Features**:
-  - Historical trend analysis
-  - Automatic PR comments on regression
-  - Performance comparison charts
+Containers:
 
-#### Cache Maintenance (`cache-maintenance`)
-- **Trigger**: Main branch pushes only
-- **Purpose**: Binary cache optimization
-- **Actions**:
-  - Push successful builds to Cachix
-  - Generate cache analytics
-  - Performance reporting
-- **Reporting**: GitHub Step Summary integration
+- Trivy scan with SARIF upload.
+- Multi-stage builds for minimal attack surface.
 
-### 5. Release Pipeline (`release`)
+Access:
 
-**Purpose**: Multi-platform release artifact generation
-**Trigger**: GitHub release events
-**Strategy**: Parallel platform builds with artifact upload
+- Minimal-permission `GITHUB_TOKEN` per job.
+- Branch protection requires the `ci-summary` check.
+- Secrets are repo-scoped; fork PRs cannot access them.
 
-#### Release Targets
-- **x86_64-linux**: Primary Linux target
-- **aarch64-linux**: ARM64 Linux support
-- **x86_64-darwin**: Intel macOS support
-- **aarch64-darwin**: Apple Silicon support
+## Performance targets
 
-#### Release Process
-1. **Parallel Build**: Each platform builds independently
-2. **Artifact Collection**: Platform-specific binaries
-3. **Asset Upload**: Automatic GitHub release asset upload
-4. **Naming Convention**: `harness-{target}`
+| Metric | Target |
+|---|---|
+| Cache hit rate | >85% |
+| Total pipeline time | <20 min |
+| Container build per image | <10 min |
+| Binary build per target | <5 min |
+| Cache storage | <50 GB |
 
-### 6. CI Summary (`ci-summary`)
+## Local reproduction
 
-**Purpose**: Aggregate pipeline status and reporting
-**Trigger**: Always runs (even on failures)
-**Dependencies**: All major pipeline jobs
-
-#### Summary Features
-- **Status Aggregation**: Overall pipeline health
-- **Job Matrix Overview**: Individual job status table
-- **Artifact Summary**: Build output overview
-- **Failure Detection**: Automatic failure reporting
-- **GitHub Integration**: Step Summary with rich formatting
-
-## Performance Optimizations
-
-### Caching Strategy
-
-#### Multi-Tier Caching
-1. **Cachix Binary Cache**: Persistent, shared across CI runs
-2. **Magic Nix Cache**: GitHub Actions automatic caching
-3. **Cargo Cache**: Rust dependency caching
-4. **Container Cache**: Docker layer caching
-
-#### Cache Configuration
-- **Push Filter**: Excludes source tarballs and nixpkgs
-- **Cache Keys**: Content-addressed for reproducibility
-- **TTL**: 300s for tarball caching
-- **Size Management**: 50GB maximum cache size
-
-### Parallel Execution
-
-#### Matrix Optimization
-- **Fail-Fast Disabled**: Independent job execution
-- **Resource Distribution**: Balanced across runner types
-- **Platform Specialization**: Optimal tool usage per platform
-- **Selective Testing**: Platform-appropriate test suites
-
-#### Build Optimization
-- **Incremental Compilation**: Cargo incremental builds
-- **Parallel Jobs**: Maximum CPU utilization
-- **Cross-Compilation**: Nix-based for Linux, Cargo for macOS
-- **Container Parallelization**: Simultaneous multi-image builds
-
-## Monitoring and Observability
-
-### Status Reporting
-
-#### GitHub Integration
-- **Step Summary**: Rich markdown reporting
-- **PR Comments**: Automated feedback
-- **Status Checks**: Required for branch protection
-- **Artifact Links**: Direct download access
-
-#### Metrics Collection
-- **Build Times**: Per-job execution tracking
-- **Cache Hit Rates**: Binary cache effectiveness
-- **Test Coverage**: Code coverage trends
-- **Performance Benchmarks**: Regression detection
-
-### Alerting
-
-#### Failure Notifications
-- **Email**: Automatic GitHub notifications
-- **Status Badges**: README integration
-- **PR Blocks**: Required checks for merging
-- **Performance Alerts**: Benchmark regression detection
-
-## Security Considerations
-
-### Supply Chain Security
-
-#### Dependency Management
-- **Cargo Audit**: Vulnerability scanning
-- **Cargo Deny**: License compliance
-- **Pinned Dependencies**: Reproducible builds
-- **SBOM Generation**: Software bill of materials
-
-#### Container Security
-- **Trivy Scanning**: Container vulnerability analysis
-- **SARIF Upload**: Security findings integration
-- **Base Image Updates**: Regular security patches
-- **Multi-stage Builds**: Minimal attack surface
-
-### Access Control
-
-#### GitHub Security
-- **Token Permissions**: Minimal required permissions
-- **Secret Management**: Encrypted secrets storage
-- **Branch Protection**: Required status checks
-- **Code Review**: Mandatory PR reviews
-
-#### Registry Security
-- **GHCR Integration**: GitHub-native container registry
-- **Image Signing**: Container image verification
-- **Access Control**: Organization-level permissions
-- **Vulnerability Scanning**: Automatic security analysis
-
-## Configuration Files
-
-### Main Pipeline
-- **File**: `.github/workflows/ci.yml`
-- **Triggers**: Push, PR, Release
-- **Jobs**: 6 major job types
-- **Matrix Size**: ~30 parallel jobs
-
-### Dependencies
-- **Nix Flake**: `flake.nix` (build configuration)
-- **Cargo Config**: `Cargo.toml` (Rust configuration)
-- **GitHub Actions**: Pinned action versions
-
-## Troubleshooting
-
-### Common Issues
-
-#### Cache Misses
-1. **Check Cachix Configuration**: Ensure auth token is set
-2. **Verify Cache Keys**: Content-addressed cache validation
-3. **Review Push Filters**: Exclude patterns verification
-4. **Monitor Cache Size**: Storage limit management
-
-#### Cross-Compilation Failures
-1. **Target Validation**: Ensure target is supported
-2. **Dependency Compatibility**: Cross-compilation support
-3. **Fallback Strategy**: Native compilation backup
-4. **Tool Availability**: Cross-compilation toolchain
-
-#### Container Build Issues
-1. **Registry Authentication**: GitHub token permissions
-2. **Base Image Updates**: Dependency availability
-3. **Multi-arch Support**: Platform compatibility
-4. **Resource Limits**: Memory and disk usage
-
-### Debug Commands
-
-#### Local Reproduction
 ```bash
-# Reproduce test issues
 nix develop --command cargo nextest run
 nix run .#dev-check
-
-# Reproduce build issues
 nix build .#nanna-coder
 nix flake check
-
-# Reproduce container issues
 nix build .#qwen3-container
 nix run .#container-test
 ```
 
-#### CI Investigation
+CI investigation:
+
 ```bash
-# Check cache status
 nix run .#cache-analytics
-
-# Verify binary cache
 nix path-info --json .#nanna-coder
-
-# Debug flake configuration
 nix flake show
 nix flake metadata
 ```
 
-## Performance Targets
+## Troubleshooting
 
-### Build Performance
-- **Cache Hit Rate**: >85% for CI builds
-- **Total Pipeline Time**: <20 minutes for full matrix
-- **Container Build Time**: <10 minutes per image
-- **Binary Build Time**: <5 minutes per target
+**Cache miss** — verify `CACHIX_AUTH` is set, cache keys are content-addressed correctly, and push filters do not exclude the artifact.
 
-### Resource Utilization
-- **Parallel Jobs**: ~30 concurrent jobs
-- **Runner Distribution**: Balanced across Ubuntu/macOS/Windows
-- **Cache Storage**: <50GB total usage
-- **Artifact Size**: <100MB per platform
+**Cross-compilation failure** — confirm target support in `flake.nix`; the workflow falls back to native compilation on failure.
 
----
+**Container build failure** — check `GITHUB_TOKEN` permissions, base-image availability, and runner disk/memory.
 
-For additional information about the CI/CD pipeline, consult the workflow files or create an issue for pipeline improvements.
+For pipeline change requests, open an issue.

--- a/docs/developer-experience.md
+++ b/docs/developer-experience.md
@@ -1,376 +1,170 @@
-# Developer Experience Guide
+# Developer Experience
 
-## Overview
+Day-to-day developer commands and workflows. For test scope, see [../TESTING.md](../TESTING.md). For the cache strategy that speeds these commands up, see [CACHE_STRATEGY.md](./CACHE_STRATEGY.md).
 
-This guide covers the optimized developer experience for the Nanna Coder project, including development utilities, workflows, and best practices.
-
-## Quick Start
+## Quick start
 
 ```bash
-# Enter development environment
+nix develop          # enter dev shell
+dev-check            # format + lint + compile
+container-dev        # start dev containers
+dev-test watch       # TDD loop
+```
+
+## What `nix develop` sets up
+
+### Pre-commit hooks
+
+- `cargo fmt`
+- `cargo clippy`
+- `cargo nextest`
+- `cargo audit`
+- `cargo deny`
+- `cargo tarpaulin`
+
+### Aliases
+
+| Group | Aliases |
+|---|---|
+| File navigation | `ll`, `la`, `l`, `..`, `...` |
+| Cargo | `cb`, `ct`, `cc`, `cf`, `cn` |
+| Git | `gs`, `ga`, `gc`, `gp`, `gl`, `gd` |
+| Nix | `nb`, `nr`, `nd`, `nf` |
+| Project | `dt`, `db`, `dc` |
+
+### Tools (auto-installed)
+
+- `cargo-watch`, `cargo-nextest`, `cargo-audit`, `cargo-deny`, `cargo-tarpaulin`, `cargo-expand`, `cargo-udeps`, `cargo-machete`, `cargo-outdated`.
+- Container tools: Podman (preferred), Buildah, Skopeo.
+
+## Core commands
+
+| Command | Purpose |
+|---|---|
+| `dev-check` | format, clippy, compile check |
+| `dev-build` | incremental build via `cargo-watch` |
+| `dev-test` | full test suite + clippy + format + audit + deny |
+| `dev-test unit` | unit tests only |
+| `dev-test integration` | integration tests only |
+| `dev-test watch` | continuous TDD |
+| `dev-clean` | clean cargo + container artifacts (24h prune) |
+| `dev-reset` | full env rebuild (updates flake inputs) |
+| `container-dev` | start dev containers (compose-based) |
+| `container-test` | run integration tests in containers |
+| `container-stop` | stop all dev containers |
+| `container-logs` | tail container logs |
+| `cache-warm` | pre-warm common builds |
+
+## Daily loop
+
+```bash
 nix develop
-
-# Quick development check
+dev-check                # quick health check
+container-dev            # only if needed
+# ... edit ...
 dev-check
-
-# Start development containers
-container-dev
-
-# Run tests in watch mode
-dev-test watch
-```
-
-## Development Environment
-
-### Automatic Setup
-
-When entering the development shell with `nix develop`, the following is automatically configured:
-
-#### Git Hooks
-- **Pre-commit hooks** with comprehensive checks:
-  - Code formatting (cargo fmt)
-  - Linting (cargo clippy)
-  - Tests (cargo nextest)
-  - Security audit (cargo audit)
-  - License compliance (cargo deny)
-  - Coverage validation (cargo tarpaulin)
-
-#### Development Aliases
-- **File navigation**: `ll`, `la`, `l`, `..`, `...`
-- **Cargo shortcuts**: `cb`, `ct`, `cc`, `cf`, `cn`
-- **Git shortcuts**: `gs`, `ga`, `gc`, `gp`, `gl`, `gd`
-- **Nix shortcuts**: `nb`, `nr`, `nd`, `nf`
-- **Project shortcuts**: `dt`, `db`, `dc`
-
-### Development Tools
-
-#### Core Tools (Auto-installed)
-- **cargo-watch**: Incremental compilation with file watching
-- **cargo-nextest**: Better test runner with parallel execution
-- **cargo-audit**: Security vulnerability scanning
-- **cargo-deny**: License and dependency compliance
-- **cargo-tarpaulin**: Code coverage analysis
-- **cargo-expand**: Macro expansion debugging
-- **cargo-udeps**: Unused dependency detection
-- **cargo-machete**: Remove unused dependencies
-- **cargo-outdated**: Check for outdated dependencies
-
-#### Container Tools
-- **Podman**: Rootless container runtime (preferred)
-- **Buildah**: Container image building
-- **Skopeo**: Container image management
-
-## Development Utilities
-
-### Core Development Commands
-
-#### `dev-check`
-Quick syntax and format validation.
-```bash
-dev-check
-```
-**Features:**
-- Fast formatting check
-- Clippy linting
-- Compilation verification
-- Early error detection
-
-#### `dev-build`
-Fast incremental development build.
-```bash
-dev-build
-```
-**Features:**
-- Uses cargo-watch for file monitoring
-- Incremental compilation
-- Real-time feedback
-
-#### `dev-test`
-Comprehensive test runner with multiple modes.
-```bash
-# Run all tests with full validation
-dev-test
-
-# Run only unit tests
 dev-test unit
-
-# Run only integration tests
-dev-test integration
-
-# Run tests in watch mode
-dev-test watch
-```
-**Features:**
-- Multiple test types
-- Watch mode for continuous testing
-- Comprehensive validation (clippy, format, audit, deny)
-
-#### `dev-clean`
-Clean development artifacts and containers.
-```bash
-dev-clean
-```
-**Features:**
-- Cleans Cargo artifacts
-- Removes target directory
-- Prunes container images (24h old)
-- Optional Nix store cleanup
-
-#### `dev-reset`
-Complete development environment reset.
-```bash
-dev-reset
-```
-**Features:**
-- Full cleanup
-- Updates flake inputs
-- Rebuilds development shell
-- Warms common builds
-
-### Container Development Commands
-
-#### `container-dev`
-Start development containers.
-```bash
-container-dev
-```
-**Features:**
-- Docker/Podman compose support
-- Automatic service orchestration
-- Health checks
-
-#### `container-test`
-Run containerized integration tests.
-```bash
-container-test
-```
-**Features:**
-- Loads test containers
-- Runs integration tests
-- Automatic cleanup
-
-#### `container-stop`
-Stop all development containers.
-```bash
-container-stop
+git add . && git commit  # pre-commit hooks run
 ```
 
-#### `container-logs`
-View container logs.
+## Testing patterns
+
 ```bash
-container-logs
-```
-
-### Cache Management Commands
-
-#### `cache-warm`
-Pre-warm frequently used builds.
-```bash
-cache-warm
-```
-**Features:**
-- Parallel build execution
-- Core package caching
-- Container image preparation
-- Performance analytics
-
-## Development Workflows
-
-### Daily Development Workflow
-
-1. **Start Development Session**
-   ```bash
-   nix develop
-   dev-check  # Quick health check
-   ```
-
-2. **Start Development Services**
-   ```bash
-   container-dev  # Start containers if needed
-   ```
-
-3. **Development Loop**
-   ```bash
-   # Make changes...
-   dev-check      # Quick validation
-   dev-test unit  # Run relevant tests
-   ```
-
-4. **Pre-commit Preparation**
-   ```bash
-   dev-test       # Full validation
-   git add .
-   git commit     # Pre-commit hooks run automatically
-   ```
-
-### Testing Workflow
-
-#### Unit Testing
-```bash
-# Quick unit tests
+# Unit (fast)
 dev-test unit
+dev-test watch           # TDD loop
 
-# Watch mode for TDD
-dev-test watch
-```
-
-#### Integration Testing
-```bash
-# Full integration tests
+# Integration
 dev-test integration
-
-# Containerized integration tests
 container-test
-```
 
-#### Performance Testing
-```bash
-# Code coverage
+# Coverage / benchmarks
 cargo tarpaulin --skip-clean --ignore-tests
-
-# Benchmark tests
 cargo bench
 ```
 
-### Debugging Workflow
+## Debugging
 
-#### Macro Expansion
 ```bash
-# Expand macros for debugging
+# Macro expansion
 cargo expand
+cargo expand <module>
 
-# Expand specific module
-cargo expand module_name
-```
-
-#### Dependency Analysis
-```bash
-# Check for unused dependencies
+# Dependency hygiene
 cargo udeps
-
-# Remove unused dependencies
 cargo machete
-
-# Check for outdated dependencies
 cargo outdated
 ```
 
-### Container Development Workflow
+## Container workflows
 
-#### Local Container Testing
 ```bash
-# Build and test locally
+# Local container build + test
 nix build .#qwen3-container
 container-test
-
-# Check container logs
 container-logs
-```
 
-#### Multi-Model Testing
-```bash
-# Test with different models
+# Multiple models
 nix build .#llama3-container
 nix build .#mistral-container
-# Test each configuration
 ```
 
-## Performance Optimization
+## Performance tips
 
-### Build Performance
-
-#### Cache Utilization
-```bash
-# Check cache status
-cache-analytics
-
-# Warm cache for faster builds
-cache-warm
-
-# Setup binary cache
-setup-cache
-```
-
-#### Incremental Builds
-- Use `dev-build` for file watching
-- Leverage cargo incremental compilation
-- Pre-warm dependencies with `cache-warm`
-
-### Test Performance
-
-#### Parallel Testing
-```bash
-# Use nextest for parallel execution
-cargo nextest run --workspace
-
-# Set test thread count
-cargo nextest run --test-threads=4
-```
-
-#### Selective Testing
-```bash
-# Run specific test patterns
-cargo nextest run test_pattern
-
-# Run tests for specific package
-cargo nextest run -p harness
-```
+- Run `cache-warm` before extended dev sessions; `setup-cache` if Cachix isn't configured yet (see [CACHE_STRATEGY.md](./CACHE_STRATEGY.md)).
+- `dev-build` (cargo-watch) for fast incremental feedback.
+- `cargo nextest run --test-threads=N` to tune parallelism.
+- `cargo nextest run -p harness <pattern>` to run a focused subset.
 
 ## Troubleshooting
 
-### Common Issues
+**Build failure**
 
-#### Build Failures
-1. **Check formatting**: `cargo fmt --all`
-2. **Fix clippy warnings**: `cargo clippy --workspace --fix`
-3. **Clean and rebuild**: `dev-clean && dev-build`
-
-#### Container Issues
-1. **Check runtime**: `podman --version` or `docker --version`
-2. **Restart services**: `container-stop && container-dev`
-3. **Check logs**: `container-logs`
-
-#### Cache Issues
-1. **Check cache status**: `cache-analytics`
-2. **Reconfigure cache**: `setup-cache`
-3. **Clear and rebuild**: `dev-reset`
-
-### Debug Commands
-
-#### Environment Debugging
 ```bash
-# Check development environment
+cargo fmt --all
+cargo clippy --workspace --fix
+dev-clean && dev-build
+```
+
+**Container failure**
+
+```bash
+podman --version || docker --version
+container-stop && container-dev
+container-logs
+```
+
+**Cache miss**
+
+```bash
+nix run .#cache-analytics
+nix run .#setup-cache
+dev-reset
+```
+
+**Environment**
+
+```bash
 echo $RUST_TOOLCHAIN_PATH
 echo $NIX_PATH
-
-# Verify tools
 which cargo-watch
 which cargo-nextest
 ```
 
-#### Container Debugging
+**Container introspection**
+
 ```bash
-# List containers
 podman ps -a
-
-# Inspect container
-podman inspect container-name
-
-# Execute commands in container
-podman exec -it container-name bash
+podman inspect <name>
+podman exec -it <name> bash
 ```
 
-## IDE Integration
+## IDE integration
 
-### VS Code Setup
+### VS Code
 
-#### Recommended Extensions
-- **rust-analyzer**: Rust language server
-- **CodeLLDB**: Debugging support
-- **Better TOML**: Cargo.toml syntax highlighting
-- **Nix IDE**: Nix language support
+Recommended extensions: rust-analyzer, CodeLLDB, Better TOML, Nix IDE.
 
-#### Settings Configuration
 ```json
 {
   "rust-analyzer.server.path": "rust-analyzer",
@@ -380,40 +174,14 @@ podman exec -it container-name bash
 }
 ```
 
-### Neovim Setup
+### Neovim
 
-#### Required Plugins
-- **nvim-lspconfig**: LSP configuration
-- **rust-tools.nvim**: Enhanced Rust support
-- **nvim-cmp**: Completion engine
-- **telescope.nvim**: Fuzzy finder
+Recommended plugins: nvim-lspconfig, rust-tools.nvim, nvim-cmp, telescope.nvim.
 
-## Best Practices
+## Best practices
 
-### Code Quality
-1. **Always run `dev-check` before committing**
-2. **Use `dev-test watch` for TDD workflow**
-3. **Keep dependencies up to date with `cargo outdated`**
-4. **Run security audits with `cargo audit`**
-
-### Performance
-1. **Use `cache-warm` for faster builds**
-2. **Leverage incremental compilation with `dev-build`**
-3. **Use `cargo nextest` for faster test execution**
-4. **Profile with `cargo bench` for performance-critical code**
-
-### Container Development
-1. **Use pre-built test containers when possible**
-2. **Clean up containers regularly with `dev-clean`**
-3. **Monitor resource usage with `container-logs`**
-4. **Test with multiple model configurations**
-
-### Git Workflow
-1. **Let pre-commit hooks enforce quality**
-2. **Use meaningful commit messages**
-3. **Test thoroughly before pushing**
-4. **Leverage branch protection with required checks**
-
----
-
-For additional help or feature requests, consult the project documentation or create an issue in the repository.
+- Run `dev-check` before committing; pre-commit hooks enforce the gate anyway.
+- Use `dev-test watch` for TDD.
+- Keep deps current: `cargo outdated`, `cargo audit`.
+- Clean containers regularly with `dev-clean`.
+- Test with multiple model configurations when changing model code.

--- a/docs/poc-system-overview.md
+++ b/docs/poc-system-overview.md
@@ -1,30 +1,26 @@
-# Nanna Coder PoC: System Overview
+# Nanna Coder PoC: System Overview (Historical)
 
-> Historical PoC summary. For current architecture see [ARCHITECTURE.md](../ARCHITECTURE.md); for cache specifics see [CACHE_STRATEGY.md](./CACHE_STRATEGY.md).
+> Historical PoC summary. For the current architecture see [../ARCHITECTURE.md](../ARCHITECTURE.md); for the cache setup see [CACHE_STRATEGY.md](./CACHE_STRATEGY.md); for testing see [../TESTING.md](../TESTING.md).
 
 ## Summary
 
-Overview of the Nanna Coder Proof of Concept: a containerized AI assistant system covering model caching, container infrastructure, monitoring, and automated quality validation.
+The PoC delivered a containerized agent system covering model caching, container infrastructure, observability, and automated quality validation. All listed phases were completed; subsequent work continues on `main`.
 
-### Delivered phases
+### Phases delivered
 
-| Phase | Component | Status | Success Criteria Met |
-|-------|-----------|---------|---------------------|
-| **1.1** | ModelJudge Framework | ✅ **COMPLETE** | ✅ Automated quality validation, ✅ Multi-criteria assessment |
-| **1.2** | Container Runtime Detection | ✅ **COMPLETE** | ✅ Podman/Docker/Mock fallback, ✅ Robust error handling |
-| **2.1** | Multi-Model Caching System | ✅ **COMPLETE** | ✅ Content-addressed storage, ✅ Multiple model support |
-| **2.2** | Binary Cache Strategy | ✅ **COMPLETE** | ✅ Cachix integration, ✅ CI/CD optimization |
-| **3.1** | Development Experience | ✅ **COMPLETE** | ✅ Comprehensive utilities, ✅ Pre-commit hooks |
-| **3.2** | CI/CD Pipeline Enhancement | ✅ **COMPLETE** | ✅ Parallel execution (~30 jobs), ✅ Multi-platform |
-| **4.1** | E2E Integration Tests | ✅ **COMPLETE** | ✅ Complete workflow validation, ✅ ModelJudge integration |
-| **4.2** | Monitoring & Observability | ✅ **COMPLETE** | ✅ Telemetry, ✅ Alerting, ✅ Health monitoring |
-| **5.1** | Documentation | ✅ **COMPLETE** | ✅ Comprehensive guides, ✅ API documentation |
+| Phase | Component | Notes |
+|---|---|---|
+| 1.1 | ModelJudge framework | automated quality validation, multi-criteria assessment |
+| 1.2 | Container runtime detection | Podman / Docker / mock fallback |
+| 2.1 | Multi-model caching | content-addressed storage, multiple models |
+| 2.2 | Binary cache strategy | Cachix integration, CI/CD optimization |
+| 3.1 | Developer experience | dev utilities, pre-commit hooks |
+| 3.2 | CI/CD pipeline | parallel execution (~30 jobs), multi-platform |
+| 4.1 | E2E integration tests | full-workflow validation, ModelJudge-gated |
+| 4.2 | Monitoring & observability | telemetry, alerting, health monitoring |
+| 5.1 | Documentation | guides and API reference |
 
----
-
-## 🏗️ System Architecture
-
-### High-Level Architecture
+## High-level architecture
 
 ```mermaid
 graph TB
@@ -35,19 +31,19 @@ graph TB
     end
 
     subgraph "Model Infrastructure"
-        JUDGE[ModelJudge Framework]
+        JUDGE[ModelJudge]
         CACHE_SYS[Multi-Model Cache]
         CONTAINERS[Test Containers]
     end
 
-    subgraph "Observability Stack"
-        MONITOR[Monitoring System]
-        TELEMETRY[Telemetry System]
-        ALERTS[Alert Management]
-        HEALTH[Health Monitoring]
+    subgraph "Observability"
+        MONITOR[Monitoring]
+        TELEMETRY[Telemetry]
+        ALERTS[Alerts]
+        HEALTH[Health]
     end
 
-    subgraph "CI/CD Pipeline"
+    subgraph "CI/CD"
         MATRIX[Test Matrix]
         BUILD[Build Matrix]
         DEPLOY[Container Matrix]
@@ -67,85 +63,26 @@ graph TB
     DEPLOY --> CONTAINERS
 ```
 
-### Core Components
+### Core components
 
-#### 🤖 ModelJudge Framework (`model/src/judge.rs`)
-- **Purpose**: Automated AI model quality validation and assessment
-- **Features**:
-  - API responsiveness validation with latency thresholds
-  - Response quality assessment (coherence, relevance, factual accuracy)
-  - Tool calling capability validation
-  - Consistency testing across multiple prompts
-  - Retry logic with exponential backoff and jitter
-- **Integration**: Used throughout E2E tests and quality gates
+- **ModelJudge** (`model/src/judge.rs`) — API responsiveness, response-quality, tool-calling, and consistency validation; retries with exponential backoff.
+- **Container infrastructure** (`harness/src/container.rs`) — multi-runtime (Podman / Docker / mock), image fallback, health checks, automatic cleanup.
+- **Multi-model caching** (`flake.nix`) — content-addressed model storage. Models exercised in PoC: `qwen3:0.6b` (560MB), `llama3:8b` (4.7GB), `mistral:7b` (4.1GB), `gemma:2b` (1.4GB).
+- **Monitoring & observability** (`harness/src/{monitoring,telemetry,observability}.rs`) — metrics collection, distributed tracing, multi-level alerting, health monitoring.
 
-#### 📦 Container Infrastructure (`harness/src/container.rs`)
-- **Purpose**: Robust containerized testing environment
-- **Features**:
-  - Multi-runtime support (Podman, Docker, Mock fallback)
-  - Intelligent image fallback (pre-built → base → mock)
-  - Health checking and automatic cleanup
-  - Container orchestration for testing
-- **Benefits**: Reproducible testing, isolated environments
+## Quick start
 
-#### 🗄️ Multi-Model Caching System (`flake.nix`)
-- **Purpose**: Efficient model storage and retrieval
-- **Features**:
-  - Content-addressed model storage
-  - Multiple model support (qwen3, llama3, mistral, gemma)
-  - Cache size management and cleanup utilities
-  - Nix-based reproducible builds
-- **Models Supported**:
-  - `qwen3:0.6b` (560MB) - Fast testing model
-  - `llama3:8b` (4.7GB) - Production model
-  - `mistral:7b` (4.1GB) - Alternative model
-  - `gemma:2b` (1.4GB) - Lightweight model
-
-#### 📊 Monitoring & Observability (`harness/src/{monitoring,telemetry,observability}.rs`)
-- **Monitoring System**: Metrics collection, health checks, alerting
-- **Telemetry System**: Distributed tracing, custom events, Prometheus export
-- **Observability System**: Comprehensive status reporting, trend analysis
-- **Features**:
-  - Real-time performance metrics
-  - Container health monitoring
-  - Multi-level alerting with escalation
-  - Performance trend analysis
-  - SLA compliance tracking
-
----
-
-## 🚀 Quick Start Guide
-
-### Prerequisites
-- Nix with flakes enabled
-- Container runtime (Podman or Docker)
-- Git with hooks support
-
-### 1. Enter Development Environment
 ```bash
-cd nanna-coder
-nix develop
+nix develop          # enter dev shell
+dev-check            # format + lint + compile
+container-dev        # start ollama + model containers
+dev-test             # full test suite
+dev-test integration # container-based integration tests
 ```
 
-### 2. Run Quick Health Check
-```bash
-dev-check  # Format, lint, compile validation
-```
+In-process observability:
 
-### 3. Start Development Containers
-```bash
-container-dev  # Start Ollama and model containers
-```
-
-### 4. Run Comprehensive Tests
-```bash
-dev-test              # Full test suite with validation
-dev-test integration  # Container-based integration tests
-```
-
-### 5. Monitor System Health
-```bash
-# In Rust code:
+```rust
 use harness::observability::ObservabilitySystem;
 
 let mut obs = ObservabilitySystem::new()
@@ -154,33 +91,28 @@ let mut obs = ObservabilitySystem::new()
 
 obs.initialize().await?;
 let status = obs.get_comprehensive_status().await?;
-println!("System health: {:?}", status.overall_health);
 ```
 
----
-
-## 🧪 Testing Strategy
-
-### Test Architecture
+## Test architecture
 
 ```mermaid
 graph LR
-    subgraph "Unit Tests"
-        UT1[Model Unit Tests]
-        UT2[Container Unit Tests]
-        UT3[Tool Unit Tests]
+    subgraph Unit
+        UT1[Model]
+        UT2[Container]
+        UT3[Tool]
     end
 
-    subgraph "Integration Tests"
-        IT1[ModelJudge Integration]
-        IT2[Container Integration]
-        IT3[E2E Workflow Tests]
+    subgraph Integration
+        IT1[ModelJudge]
+        IT2[Container]
+        IT3[E2E workflow]
     end
 
-    subgraph "E2E Tests"
-        E2E1[Complete Workflow]
-        E2E2[Multi-Model Compare]
-        E2E3[Performance Tests]
+    subgraph E2E
+        E2E1[Complete workflow]
+        E2E2[Multi-model compare]
+        E2E3[Performance]
     end
 
     UT1 --> IT1
@@ -191,190 +123,54 @@ graph LR
     IT3 --> E2E3
 ```
 
-### Test Coverage by Component
+| Component | Unit | Integration | E2E |
+|---|---|---|---|
+| ModelJudge | 8 tests | validation suite | complete workflow |
+| Container management | 6 tests | runtime detection | multi-container |
+| Monitoring | 5 tests | health checks | alert processing |
+| Telemetry | 8 tests | export formats | trace correlation |
+| Observability | 5 tests | status reporting | trend analysis |
+| Tools | 3 tests | registry ops | model integration |
 
-| Component | Unit Tests | Integration Tests | E2E Tests | Coverage |
-|-----------|------------|-------------------|-----------|----------|
-| **ModelJudge** | ✅ 8 tests | ✅ Validation suite | ✅ Complete workflow | 95%+ |
-| **Container Management** | ✅ 6 tests | ✅ Runtime detection | ✅ Multi-container | 90%+ |
-| **Monitoring** | ✅ 5 tests | ✅ Health checks | ✅ Alert processing | 85%+ |
-| **Telemetry** | ✅ 8 tests | ✅ Export formats | ✅ Trace correlation | 90%+ |
-| **Observability** | ✅ 5 tests | ✅ Status reporting | ✅ Trend analysis | 85%+ |
-| **Tools** | ✅ 3 tests | ✅ Registry ops | ✅ Model integration | 95%+ |
+### Key E2E scenarios
 
-### E2E Test Scenarios
+- `test_e2e_container_to_validated_inference` — 7-phase pipeline (container -> model -> judge -> cleanup), gated by ModelJudge criteria, with mock fallback.
+- `test_e2e_multi_model_comparison` — coherence/relevance/perf benchmark across multiple models.
+- `test_e2e_performance_and_reliability` — sequential request validation with real-time perf tracking.
 
-#### 1. Complete Workflow Validation (`test_e2e_container_to_validated_inference`)
-- **Phases**: 7-phase validation pipeline
-- **Coverage**: Container → Model → Judge → Cleanup
-- **Validation**: ModelJudge criteria enforcement
-- **Fallback**: Graceful mock implementation
+## Performance targets at end of PoC
 
-#### 2. Multi-Model Comparison (`test_e2e_multi_model_comparison`)
-- **Purpose**: Model quality benchmarking
-- **Models**: Multiple model configurations
-- **Metrics**: Coherence, relevance, performance
-- **Output**: Best model recommendation
+| Metric | Target | Achieved |
+|---|---|---|
+| Cache hit rate | >85% | ~90% |
+| API response time | <2000ms | ~150ms |
+| Error rate | <5% | <1% |
+| Container startup | <30s | ~15s |
+| Test suite runtime | <5min | ~2min |
+| Pipeline completion | <20min | ~15min |
 
-#### 3. Performance & Reliability (`test_e2e_performance_and_reliability`)
-- **Metrics**: Response time, throughput, resource usage
-- **Concurrency**: Sequential request validation
-- **Monitoring**: Real-time performance tracking
-- **Alerting**: Threshold-based notifications
+CI matrix at end of PoC: ~30 parallel jobs, 3 OS × 2 Rust × 4 test types, 4 build targets × 2 archs, 4 container images.
 
----
+## Production deployment notes (PoC plan)
 
-## 📈 Performance Benchmarks
+Registry strategy targeted `ghcr.io/anthropics/nanna-coder` with images for harness, ollama, and model containers. Tags: `latest{-arm64}`, `v<semver>`, `sha-<commit>`. Operational monitoring stack envisioned: Prometheus + Grafana, OpenTelemetry -> Jaeger, structured logs into ELK, AlertManager. SLA targets discussed (P95 < 1000ms, 99.9% uptime). None of these are committed to in the current codebase — see [CACHE_STRATEGY.md](./CACHE_STRATEGY.md) and the workflow files for what's actually wired up.
 
-### System Performance Targets
+## Development utilities (delivered)
 
-| Metric | Target | Current | Status |
-|--------|--------|---------|--------|
-| **Cache Hit Rate** | >85% | ~90% | ✅ **EXCEEDS** |
-| **API Response Time** | <2000ms | ~150ms | ✅ **EXCEEDS** |
-| **Error Rate** | <5% | <1% | ✅ **EXCEEDS** |
-| **Container Startup** | <30s | ~15s | ✅ **EXCEEDS** |
-| **Test Suite Runtime** | <5min | ~2min | ✅ **EXCEEDS** |
-| **Pipeline Completion** | <20min | ~15min | ✅ **EXCEEDS** |
+| Command | Purpose |
+|---|---|
+| `dev-check` | format + lint + compile check |
+| `dev-build` | incremental build with file watching |
+| `dev-test [unit\|integration\|watch]` | comprehensive testing |
+| `dev-clean` | clean cargo + container artifacts |
+| `dev-reset` | full env rebuild |
+| `container-dev` | start dev containers |
+| `container-test` | integration test containers |
+| `cache-warm` | pre-warm common builds |
 
-### Caching Performance
+Pre-commit pipeline: `cargo fmt`, `cargo clippy -- -D warnings`, `cargo nextest`, `cargo audit`, `cargo deny check`, `cargo tarpaulin`.
 
-```
-Cache Performance Analysis:
-├── Binary Cache Hit Rate: 87%
-├── Model Cache Hit Rate: 92%
-├── Build Cache Hit Rate: 85%
-└── Average Cache Retrieval: 45ms
-```
-
-### CI/CD Performance
-
-```
-Pipeline Execution Matrix:
-├── Parallel Jobs: ~30 concurrent
-├── Test Matrix: 3 OS × 2 Rust versions × 4 test types
-├── Build Matrix: 4 targets × 2 architectures
-├── Container Matrix: 4 images × 2 architectures
-└── Total Execution Time: ~15 minutes
-```
-
----
-
-## 🏛️ Production Deployment
-
-### Container Registry Strategy
-
-```yaml
-Registry: ghcr.io/anthropics/nanna-coder
-Images:
-  - harness:latest / harness:latest-arm64
-  - ollama:latest / ollama:latest-arm64
-  - qwen3-container:latest (x86_64 only)
-  - llama3-container:latest (x86_64 only)
-
-Tagging Strategy:
-  - latest: Main branch builds
-  - v1.0.0: Release tags
-  - sha-abcd123: Commit-specific builds
-```
-
-### Binary Cache Deployment
-
-```nix
-Binary Cache Configuration:
-├── Primary: cachix.app/nanna-coder
-├── Fallback: GitHub Actions cache
-├── Push Strategy: Exclude source, include derivations
-├── Storage Limit: 50GB maximum
-└── TTL: 300s for tarballs
-```
-
-### Monitoring in Production
-
-```yaml
-Monitoring Stack:
-  - Metrics: Prometheus + Grafana
-  - Tracing: OpenTelemetry → Jaeger
-  - Logging: Structured logs → ELK Stack
-  - Alerting: AlertManager → PagerDuty
-  - Health: Kubernetes readiness/liveness probes
-
-SLA Targets:
-  - Availability: 99.9% uptime
-  - Response Time: P95 < 1000ms
-  - Error Rate: < 0.1%
-  - Recovery Time: < 5 minutes
-```
-
----
-
-## 🔧 Development Utilities
-
-### Available Commands
-
-| Command | Purpose | Usage |
-|---------|---------|-------|
-| `dev-check` | Quick validation | Format, lint, compile check |
-| `dev-build` | Incremental build | File watching, real-time feedback |
-| `dev-test` | Comprehensive testing | Unit, integration, E2E tests |
-| `dev-test watch` | Continuous testing | TDD workflow support |
-| `dev-clean` | Environment cleanup | Clear caches, containers |
-| `dev-reset` | Complete reset | Full environment rebuild |
-| `container-dev` | Start containers | Development services |
-| `container-test` | Test containers | Integration test execution |
-| `cache-warm` | Pre-warm caches | Performance optimization |
-
-### Pre-commit Hook Suite
-
-```bash
-Pre-commit Validation Pipeline:
-├── cargo fmt --all
-├── cargo clippy --workspace --all-targets -- -D warnings
-├── cargo nextest run --workspace
-├── cargo audit (security scan)
-├── cargo deny check (license compliance)
-├── cargo tarpaulin (coverage validation)
-└── Security review (automated)
-```
-
----
-
-## 📊 Success Metrics & KPIs
-
-### Technical Success Metrics
-
-| Category | Metric | Target | Achieved | Status |
-|----------|--------|---------|----------|--------|
-| **Quality** | Test Coverage | >90% | 95%+ | ✅ **EXCEEDED** |
-| **Performance** | Build Time | <5min | 2-3min | ✅ **EXCEEDED** |
-| **Reliability** | Test Pass Rate | >95% | 100% | ✅ **EXCEEDED** |
-| **Maintainability** | Code Quality | A+ | A+ | ✅ **ACHIEVED** |
-| **Scalability** | Parallel Jobs | 20+ | ~30 | ✅ **EXCEEDED** |
-| **Efficiency** | Cache Hit Rate | >80% | >85% | ✅ **EXCEEDED** |
-
-### Model Judge Success Metrics
-
-| Validation Type | Success Rate | Average Response Time | Quality Score |
-|-----------------|--------------|----------------------|---------------|
-| **API Responsiveness** | 100% | ~150ms | ✅ Excellent |
-| **Response Quality** | 95%+ | ~2.5s | ✅ High Quality |
-| **Tool Calling** | 90%+ | ~3.0s | ✅ Functional |
-| **Consistency** | 88%+ | ~5.0s | ✅ Reliable |
-
-### Business Value Delivered
-
-1. **🚀 Rapid Development**: 5x faster iteration cycles
-2. **🛡️ Quality Assurance**: Automated validation prevents regressions
-3. **📈 Scalability**: Supports multiple models and environments
-4. **🔧 Maintainability**: Comprehensive tooling and documentation
-5. **💰 Cost Efficiency**: Optimized caching reduces compute costs
-6. **🌐 Production Ready**: Full observability and monitoring
-
----
-
-## 🎯 ModelJudge Framework Deep Dive
-
-### Validation Pipeline
+## ModelJudge framework
 
 ```mermaid
 sequenceDiagram
@@ -383,21 +179,19 @@ sequenceDiagram
     participant M as Model
     participant C as Container
 
-    T->>MJ: Validate Model
-    MJ->>C: Health Check
-    C-->>MJ: Container Status
-    MJ->>M: API Responsiveness
-    M-->>MJ: Latency Metrics
-    MJ->>M: Quality Assessment
-    M-->>MJ: Response + Metrics
-    MJ->>M: Tool Validation
-    M-->>MJ: Tool Call Results
-    MJ->>M: Consistency Check
-    M-->>MJ: Multiple Responses
-    MJ->>T: Validation Result
+    T->>MJ: validate
+    MJ->>C: health check
+    C-->>MJ: status
+    MJ->>M: API responsiveness
+    M-->>MJ: latency
+    MJ->>M: quality assessment
+    M-->>MJ: response + metrics
+    MJ->>M: tool validation
+    M-->>MJ: tool call results
+    MJ->>M: consistency check
+    M-->>MJ: multiple responses
+    MJ->>T: result
 ```
-
-### Quality Criteria Configuration
 
 ```rust
 use model::judge::{ValidationCriteria, ModelJudge};
@@ -405,139 +199,66 @@ use model::judge::{ValidationCriteria, ModelJudge};
 let criteria = ValidationCriteria {
     min_response_length: 30,
     max_response_length: 1000,
-    required_keywords: vec!["recursion".to_string(), "function".to_string()],
-    forbidden_keywords: vec!["I don't know".to_string()],
+    required_keywords: vec!["recursion".into(), "function".into()],
+    forbidden_keywords: vec!["I don't know".into()],
     min_coherence_score: 0.8,
     min_relevance_score: 0.9,
     require_factual_accuracy: true,
     custom_validators: vec![],
 };
 
-// Automated validation in tests
-let result = provider.validate_response_quality(
-    "Explain recursion in programming",
-    &criteria
-).await?;
-
-match result {
-    ValidationResult::Success { metrics, .. } => {
-        println!("✅ Quality validated: coherence={:.2}, relevance={:.2}",
-                metrics.coherence_score.unwrap_or(0.0),
-                metrics.relevance_score.unwrap_or(0.0));
-    }
-    ValidationResult::Failure { message, suggestions, .. } => {
-        println!("❌ Quality check failed: {}", message);
-        for suggestion in suggestions {
-            println!("   💡 {}", suggestion);
-        }
-    }
-}
+let result = provider
+    .validate_response_quality("Explain recursion", &criteria)
+    .await?;
 ```
 
----
+## Troubleshooting (PoC era)
 
-## 🔍 Troubleshooting Guide
+**No container runtime**
 
-### Common Issues & Solutions
-
-#### 1. Container Runtime Issues
 ```bash
-# Problem: No container runtime available
-# Solution: Install Podman or Docker
-sudo dnf install podman  # Fedora
-brew install podman      # macOS
-# Tests will gracefully fall back to mock implementations
-
-# Problem: Container pull fails
-# Solution: Check network and registry access
-podman pull docker.io/ollama/ollama:latest
+sudo dnf install podman   # Fedora
+brew install podman       # macOS
+# tests fall back to mock implementations
 ```
 
-#### 2. Cache Issues
+**Cache miss / slow build**
+
 ```bash
-# Problem: Cache misses
-# Solution: Warm cache and check configuration
 cache-warm
 nix path-info --json .#nanna-coder
-setup-cache  # Reconfigure binary cache
+setup-cache
 ```
 
-#### 3. Test Failures
+**Test failures**
+
 ```bash
-# Problem: Integration tests fail
-# Solution: Check container status and logs
 container-logs
-dev-test unit        # Run unit tests first
-dev-test integration # Debug integration issues
+dev-test unit
+dev-test integration
 ```
 
-#### 4. Build Issues
+**Build failures**
+
 ```bash
-# Problem: Nix build fails
-# Solution: Update flake and check dependencies
 nix flake update
 nix flake check
 dev-clean && dev-build
 ```
 
-### Debug Commands
-
-```bash
-# System Diagnostics
-nix-info -m                    # Nix system info
-cargo version                  # Rust toolchain info
-container-logs                 # Container diagnostics
-cache-analytics               # Cache performance info
-
-# Test Debugging
-dev-test unit --verbose       # Verbose unit tests
-cargo nextest run --nocapture # Integration test output
-cargo test -- --nocapture    # All test output
-
-# Performance Analysis
-cargo bench                   # Benchmark tests
-cargo tarpaulin --skip-clean  # Coverage analysis
-time dev-build                # Build performance
-```
-
----
-
-## 📚 API Documentation
-
-### ModelJudge API
+## API reference (sketched)
 
 ```rust
-// Core validation trait
 #[async_trait]
 pub trait ModelJudge: ModelProvider {
-    async fn validate_api_responsiveness(
-        &self,
-        latency_threshold: Duration
-    ) -> ModelResult<ValidationResult>;
-
-    async fn validate_response_quality(
-        &self,
-        prompt: &str,
-        expected_criteria: &ValidationCriteria
-    ) -> ModelResult<ValidationResult>;
-
-    async fn validate_tool_calling(
-        &self,
-        tools: &[ToolDefinition]
-    ) -> ModelResult<ValidationResult>;
-
-    async fn validate_consistency(
-        &self,
-        prompts: &[&str],
-        iterations: usize
-    ) -> ModelResult<ValidationResult>;
+    async fn validate_api_responsiveness(&self, latency_threshold: Duration) -> ModelResult<ValidationResult>;
+    async fn validate_response_quality(&self, prompt: &str, expected: &ValidationCriteria) -> ModelResult<ValidationResult>;
+    async fn validate_tool_calling(&self, tools: &[ToolDefinition]) -> ModelResult<ValidationResult>;
+    async fn validate_consistency(&self, prompts: &[&str], iterations: usize) -> ModelResult<ValidationResult>;
 }
 ```
 
-### Monitoring API
-
 ```rust
-// Comprehensive observability
 use harness::observability::ObservabilitySystem;
 
 let mut obs = ObservabilitySystem::new()
@@ -547,123 +268,30 @@ let mut obs = ObservabilitySystem::new()
 
 obs.initialize().await?;
 obs.start_monitoring().await?;
-
-// Get system status
 let status = obs.get_comprehensive_status().await?;
-println!("Overall health: {:?}", status.overall_health);
-println!("Performance score: {:.1}", status.performance_trends.performance_score);
 ```
 
-### Container API
-
 ```rust
-// Container orchestration
 use harness::container::{ContainerConfig, start_container_with_fallback};
 
 let config = ContainerConfig {
-    base_image: "ollama/ollama:latest".to_string(),
-    test_image: Some("nanna-coder-test-ollama-qwen3:latest".to_string()),
-    container_name: "my-test-container".to_string(),
+    base_image: "ollama/ollama:latest".into(),
+    test_image: Some("nanna-coder-test-ollama-qwen3:latest".into()),
+    container_name: "my-test-container".into(),
     port_mapping: Some((11435, 11434)),
-    model_to_pull: Some("qwen3:0.6b".to_string()),
+    model_to_pull: Some("qwen3:0.6b".into()),
     startup_timeout: Duration::from_secs(30),
     health_check_timeout: Duration::from_secs(10),
-    env_vars: vec![("OLLAMA_MODELS".to_string(), "/models".to_string())],
-    additional_args: vec!["--memory".to_string(), "2g".to_string()],
+    env_vars: vec![("OLLAMA_MODELS".into(), "/models".into())],
+    additional_args: vec!["--memory".into(), "2g".into()],
 };
-
 let handle = start_container_with_fallback(&config).await?;
-// Container automatically cleaned up when handle is dropped
 ```
 
----
+## Roadmap (post-PoC, not committed)
 
-## 🏆 Project Achievements
-
-### ✅ Completed Deliverables
-
-1. **🤖 Model Validation Framework**
-   - Comprehensive ModelJudge trait implementation
-   - Multi-criteria quality assessment
-   - Automated performance validation
-   - Consistency and reliability testing
-
-2. **📦 Container Infrastructure**
-   - Multi-runtime support (Podman/Docker/Mock)
-   - Intelligent fallback strategies
-   - Health monitoring and automatic cleanup
-   - Reproducible test environments
-
-3. **🗄️ Advanced Caching System**
-   - Content-addressed model storage
-   - Multi-model cache management
-   - Nix-based reproducible builds
-   - Binary cache optimization for CI/CD
-
-4. **📊 Production-Grade Monitoring**
-   - Comprehensive metrics collection
-   - Distributed tracing and telemetry
-   - Multi-level alerting with escalation
-   - Real-time health monitoring
-
-5. **🚀 Developer Experience**
-   - Rich development utilities
-   - Pre-commit validation pipeline
-   - Comprehensive testing framework
-   - Automated quality gates
-
-6. **🔄 CI/CD Excellence**
-   - Parallel execution matrix (~30 jobs)
-   - Multi-platform builds (Linux/macOS/Windows)
-   - Cross-architecture support (x86_64/aarch64)
-   - Optimized caching strategies
-
-### 🎖️ Success Metrics Achieved
-
-- **100% Phase Completion**: All 11 planned phases delivered
-- **95%+ Test Coverage**: Comprehensive test suite with high coverage
-- **Zero Critical Issues**: No blocking issues or technical debt
-- **5x Performance Improvement**: Faster development cycles
-- **Production Ready**: Full observability and monitoring
-- **Documentation Complete**: Comprehensive guides and API docs
-
----
-
-## 🚀 Next Steps & Future Enhancements
-
-### Immediate Opportunities
-1. **GPU Acceleration**: CUDA/ROCm support for larger models
-2. **Distributed Caching**: Multi-node cache clusters
-3. **Advanced Metrics**: ML model performance analytics
-4. **Security Hardening**: Container security scanning
-5. **Performance Optimization**: Model quantization and optimization
-
-### Strategic Roadmap
-1. **Production Deployment**: Kubernetes integration
-2. **Horizontal Scaling**: Multi-instance orchestration
-3. **Advanced AI Features**: Multi-modal model support
-4. **Enterprise Integration**: SSO, RBAC, audit logging
-5. **Cloud Native**: Serverless and edge deployment
-
----
-
-## 📞 Support & Contact
-
-### Documentation
-- **System Overview**: This document
-- **API Documentation**: `/docs/api/`
-- **Developer Guide**: `/docs/developer-experience.md`
-- **CI/CD Guide**: `/docs/ci-cd-pipeline.md`
-- **Troubleshooting**: See above section
-
-### Getting Help
-- **Issues**: GitHub Issues for bug reports
-- **Discussions**: GitHub Discussions for questions
-- **Contributing**: See `CONTRIBUTING.md`
-- **Security**: See `SECURITY.md`
-
----
+GPU acceleration; distributed caching; container security scanning; Kubernetes integration; multi-modal model support; SSO / RBAC; serverless / edge deployment.
 
 ## Status
 
-All PoC phases delivered. Subsequent work has continued on the `main` branch; consult current docs (README, ARCHITECTURE, TESTING) for the active state of the project.
+All PoC phases delivered. Subsequent work continues on `main`; consult the current docs ([../README.md](../README.md), [../ARCHITECTURE.md](../ARCHITECTURE.md), [../TESTING.md](../TESTING.md)) for the active state.

--- a/docs/test-execution-examples.md
+++ b/docs/test-execution-examples.md
@@ -1,16 +1,15 @@
 # Test Execution Examples
 
-This document shows what test execution looks like in different environments with the new Nix-based container caching.
+Reference traces of the integration-test runner under three conditions, showing how the Nix-based container caching changes behavior. For test scope and commands, see [../TESTING.md](../TESTING.md).
 
-## 🏠 Local Development (Without Dependencies)
-
-When running tests locally without Ollama or container runtime available:
+## Local, no Ollama / container runtime
 
 ```bash
 $ cargo test --test integration_tests -- --nocapture
 ```
 
-**Output:**
+Output (abridged):
+
 ```
 running 14 tests
 test test_chat_request_building ... ok
@@ -20,208 +19,94 @@ test test_calculator_tool_execution ... ok
 test test_model_provider_creation ... ok
 
 # Ollama tests skip gracefully:
-⚠️  Ollama health check failed: Service unavailable: Cannot connect to Ollama service
-   This is expected if Ollama is not running locally
-   In CI, containers are pre-built and this test will pass
+Ollama health check failed: Service unavailable
 test test_ollama_health_check ... ok
 
-⚠️  Failed to list models: Service unavailable: Cannot connect to Ollama service
-   This is expected if Ollama is not running locally
-   In CI, containers are pre-built and this test will pass
+Failed to list models: Service unavailable
 test test_ollama_list_models ... ok
 
 # Container test falls back gracefully:
-🚀 Starting containerized Ollama integration test with pre-built Nix container...
-🔍 Checking for pre-built test container: nanna-coder-test-ollama-qwen3:latest
-📦 Pre-built container not found, falling back to base container
+Pre-built container not found, falling back to base container
    To build cached container: nix build .#ollama-qwen3
-🚀 Starting Ollama container: ollama/ollama:latest
-⚠️  Failed to start Ollama container: Error: short-name resolution enforced but cannot prompt without a TTY
-   This is expected if container runtime is not available
-   In CI, containers are pre-built and this test will pass
+Failed to start Ollama container: short-name resolution enforced but cannot prompt without a TTY
 test test_containerized_ollama_qwen3_communication ... ok
 
 test result: ok. 14 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
 ```
 
-**Key Points:**
-- ✅ **All tests pass** (no failures, no ignored tests)
-- ⚠️ **Graceful degradation** when dependencies unavailable
-- 🔄 **Clear guidance** on how to enable full testing locally
-- ⚡ **Fast execution** (~0.1s) since no heavy operations
+Notes: all tests pass (no failures, no `ignored`); environment-dependent steps degrade gracefully and emit guidance; total time ~0.1 s.
 
----
+## Local, pre-built containers
 
-## 🏗️ Local Development (With Pre-built Containers)
-
-When test containers have been pre-built locally:
+One-time setup:
 
 ```bash
-# First, build the test containers (one-time setup)
 $ nix build .#ollama-qwen3
-🔄 Building qwen3:0.6b model cache...
-📥 Downloading qwen3:0.6b model (will be cached by hash)...
-   [████████████████████████████████] 560MB downloaded
-✅ qwen3:0.6b model cached at /nix/store/abc123.../models
-📦 Building container with pre-loaded model...
-✅ Container built: nanna-coder-test-ollama-qwen3:latest
-
-# Load into container runtime
+# Downloads qwen3:0.6b (~560MB), caches by hash, builds container
 $ podman load -i $(nix build .#ollama-qwen3 --print-out-paths --no-link)/image.tar
-✅ Loaded image: nanna-coder-test-ollama-qwen3:latest
+```
 
-# Now tests use cached containers
+Subsequent runs:
+
+```bash
 $ cargo test --test integration_tests -- --nocapture
 ```
 
-**Output:**
+Output (abridged):
+
 ```
-running 14 tests
-# ... basic tests pass as before ...
-
-# Ollama tests now work with real service:
-✓ Ollama health check passed
-test test_ollama_health_check ... ok
-
-✓ Found 1 models
-  - qwen3:0.6b
-test test_ollama_list_models ... ok
-
-# Container test uses pre-built image:
-🚀 Starting containerized Ollama integration test with pre-built Nix container...
-🔍 Checking for pre-built test container: nanna-coder-test-ollama-qwen3:latest
-✅ Using pre-built test container with qwen3:0.6b cached
-🚀 Starting Ollama container: nanna-coder-test-ollama-qwen3:latest
-⏳ Waiting for Ollama to be ready...
-✅ Using cached qwen3:0.6b model from pre-built container
-
-🏥 Testing health check...
-✅ Health check passed
-📋 Testing model listing...
-✅ Model listing passed - qwen3:0.6b found
-💬 Testing chat with qwen3:0.6b...
-✅ Chat response received: Hello from qwen3!
-🔧 Testing chat with tools enabled...
-✅ Tool calls received: 1 calls
-🧹 Cleaning up container...
-✅ Container cleaned up successfully
-🎉 Containerized Ollama integration test completed successfully!
+Using pre-built test container with qwen3:0.6b cached
+Health check passed
+Model listing passed - qwen3:0.6b found
+Chat response received
+Tool calls received: 1 calls
+Container cleaned up successfully
 test test_containerized_ollama_qwen3_communication ... ok
 
 test result: ok. 14 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
-Time: ~15s (first run), ~5s (subsequent runs with warm containers)
 ```
 
-**Key Points:**
-- 🚀 **Full integration testing** with real model
-- ⚡ **Fast subsequent runs** due to cached model
-- 🔒 **Reproducible** - identical across all machines
-- 📦 **Complete isolation** - containers cleaned up automatically
+First run ~15 s; subsequent runs with warm containers ~5 s.
 
----
+## CI
 
-## 🤖 CI Environment (GitHub Actions)
-
-In CI, the pre-commit hook configuration builds and caches everything:
+Workflow excerpt (`.github/workflows/ci.yml`):
 
 ```yaml
-# .github/workflows/ci.yml excerpt
 - name: Pre-build test containers (cached)
   run: |
-    echo "🔄 Building test containers for caching..."
-    # Build test containers in parallel for speed
     nix build .#ollama-base .#qwen3-model .#ollama-qwen3 --print-build-logs
-
-    # Load test containers into podman for integration tests
-    echo "📦 Loading test containers into podman..."
     podman load -i $(nix build .#ollama-qwen3 --print-out-paths --no-link)/image.tar
-
-    echo "✅ Test containers ready for integration tests"
 
 - name: Run tests
   run: nix develop --command cargo test --workspace --verbose
 ```
 
-**CI Output (First Run - Downloads Model):**
-```
-🔄 Building test containers for caching...
-building '/nix/store/xyz789.../qwen3-0.6b-model.drv'...
-🔄 Setting up qwen3:0.6b model download (reproducible)...
-🚀 Starting temporary Ollama server...
-⏳ Waiting for Ollama server...
-✅ Ollama server ready
-📥 Downloading qwen3:0.6b model (will be cached by hash)...
-   [████████████████████████████████] 560MB downloaded
-✅ qwen3:0.6b model cached at /nix/store/abc123.../models
-📊 Model cache contents:
-   -rw-r--r-- 1 root root 523M qwen3-0.6b-q4_0.gguf
-   -rw-r--r-- 1 root root 1.2K manifest.json
+First run ~3 min (model download); subsequent runs ~30 s (full cache hits).
 
-building '/nix/store/def456.../nanna-coder-test-ollama-qwen3.drv'...
-📦 Building container with pre-loaded model...
-✅ Container built successfully
+## Performance summary
 
-📦 Loading test containers into podman...
-✅ Test containers ready for integration tests
+| Scenario | Test time | Model download | Cache state |
+|---|---|---|---|
+| Local, no deps | ~0.1 s | none | n/a |
+| Local, first run | ~3 min | 560 MB | building |
+| Local, cached | ~15 s | none | hit |
+| CI, first run | ~3 min | 560 MB | building |
+| CI, cached | ~30 s | none | hit |
 
-🧪 Running tests...
-running 14 tests
-# ... all tests pass with full functionality ...
-test result: ok. 14 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
-Time: ~3m (first run - downloads model)
-```
+## Hash-mismatch workflow
 
-**CI Output (Subsequent Runs - Cache Hit):**
-```
-🔄 Building test containers for caching...
-cache hit: qwen3-0.6b-model from binary cache
-cache hit: nanna-coder-test-ollama-qwen3 from binary cache
-📦 Loading test containers into podman...
-✅ Test containers ready for integration tests
-
-🧪 Running tests...
-running 14 tests
-# ... all tests pass with full functionality ...
-test result: ok. 14 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
-Time: ~30s (cached run - no downloads)
-```
-
-**Key Points:**
-- 🚀 **First CI run**: Downloads model once, caches forever
-- ⚡ **Subsequent CI runs**: Instant cache hits, 30s total time
-- 🔒 **Reproducible**: Identical model across all CI runs
-- ✅ **100% test coverage**: All tests run, none ignored
-- 📊 **Efficient**: 560MB model cached in Nix binary cache
-
----
-
-## 📊 Performance Comparison
-
-| Scenario | Test Time | Model Download | Cache State |
-|----------|-----------|----------------|-------------|
-| **Local (no deps)** | ~0.1s | ❌ None | N/A |
-| **Local (first run)** | ~3m | ✅ 560MB | Building |
-| **Local (cached)** | ~15s | ❌ None | Hit |
-| **CI (first run)** | ~3m | ✅ 560MB | Building |
-| **CI (cached)** | ~30s | ❌ None | Hit |
-
-## 🔧 Hash Management Workflow
-
-When the model needs to be updated:
+When a model needs to be updated:
 
 ```bash
-# 1. Attempt to build (fails with hash mismatch)
 $ nix build .#qwen3-model
 error: hash mismatch in fixed-output derivation
   specified: sha256-AAAAAAAAAA...
   got:        sha256-b8f2c3d4e5...
 
-# 2. Update flake.nix with correct hash
+# Update flake.nix with the correct hash, then rebuild:
 $ sed -i 's/sha256-AAAAAAAAAA.../sha256-b8f2c3d4e5.../' flake.nix
-
-# 3. Now builds reproducibly
 $ nix build .#qwen3-model
-✅ Model cached with content hash: sha256-b8f2c3d4e5...
 ```
 
-This ensures **true reproducibility** - the model is cached by its actual content hash, making builds bit-for-bit identical across all machines and time periods.
+This keeps builds bit-for-bit reproducible across machines and time.


### PR DESCRIPTION
## Summary

Four `docs/` files were emoji-heavy, marketing-styled, and substantially duplicated content already present in the canonical refs (`README.md`, `ARCHITECTURE.md`, `TESTING.md`, `CACHE_STRATEGY.md`). This PR tightens each file to its actual job:

- **`poc-system-overview.md`** — explicitly framed as a historical PoC summary at the top; phase / metric / API tables retained; marketing prose, success-metric duplication, and emoji headers removed. 669 -> 297 lines.
- **`ci-cd-pipeline.md`** — replaced the ASCII matrix box with focused tables; cut content already covered in `CACHE_STRATEGY.md` / `TESTING.md`; troubleshooting reduced to the few items not already in those docs. 370 -> 137 lines.
- **`developer-experience.md`** — aliases consolidated into one table; removed repeated bullet fluff; pointed at canonical docs for shared content. 418 -> 187 lines.
- **`test-execution-examples.md`** — stripped emoji-heavy log decorations and unhelpful log filler; retained all three execution scenarios (local-no-deps, local-cached, CI) and the hash-mismatch flow. 226 -> 112 lines.

### Standardization

- Cross-doc links normalized to relative paths (`./CACHE_STRATEGY.md`, `../README.md`, `../ARCHITECTURE.md`, `../TESTING.md`).
- Heading levels consistent (`#` document title, `##` section, `###` subsection).
- Emoji headings (`### 🤖`, `### 📊`, etc.) removed from prose; preserved no emojis.
- File-path references kept consistent with `path/to/file.ext` style (no line numbers attached because none of these were code pointers — purely conceptual).

### Volume

Total: **1683 -> 733 lines (-56%)** across these four files, without dropping operational information; the cuts are duplication, marketing language, and ASCII art whose content is in adjacent tables.

## Test plan

- [ ] Render each file on GitHub and confirm sections still resolve.
- [ ] Confirm relative cross-doc links resolve.
- [ ] Confirm no other doc has a now-broken anchor pointing into these files.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ufspun8cJLsqJmeuYvP1Fk)_