### PR TITLE
[arch] remove dead AstEntity type alias

### DIFF
--- a/harness/src/entities/ast/types.rs
+++ b/harness/src/entities/ast/types.rs
@@ -154,9 +154,6 @@ impl FileEntity {
     }
 }
 
-#[deprecated(note = "Use FileEntity instead")]
-pub type AstEntity = FileEntity;
-
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Precept violation

`harness/src/entities/ast/types.rs` exports a deprecated type alias:

```rust
#[deprecated(note = "Use FileEntity instead")]
pub type AstEntity = FileEntity;
```

A workspace-wide grep for `AstEntity` finds **zero** call sites — the alias is dead. Per `AGENTS.md` / `TESTING.md`:

> Untested code is brittle. Harden it, don't bend it. Never merge `|| true`, silent failures, fallback parameters that shadow bad or dead code, or any other graceful-degradation pattern.

A deprecated public alias with no callers is exactly the "dead code shadowing" pattern that hardening rejects. It also widens the public API of `harness::entities::ast` for no benefit.

## Fix

Remove the `AstEntity` alias and its `#[deprecated]` attribute. The single canonical name is now `FileEntity`.

## Verification

- `cargo check --workspace --all-features` — clean
- `cargo clippy --workspace --all-features --all-targets` — no warnings
- `cargo test --workspace --all-features --lib` — 437 of the 437 unrelated unit tests pass; the only 2 failures (`eval::swebench::tests::materialize_from_url_*`) reproduce on the unmodified base branch (sandbox `git2` `InvalidOid("HEAD")`).

https://claude.ai/code/session_01Ufspun8cJLsqJmeuYvP1Fk

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ufspun8cJLsqJmeuYvP1Fk)_