### PR TITLE
[arch] drop unimplemented!() stub from agent::decision

### DIFF
--- a/harness/src/agent/decision.rs
+++ b/harness/src/agent/decision.rs
@@ -1,46 +1,18 @@
 //! Entity Modification Decision logic for the agent (ARCHITECTURE.md)
 //!
-//! This module implements the "Entity Modification Decision" node from the
-//! Harness Control Flow diagram: given the current entity state, decide
-//! whether to **Query Entities (RAG)** for more context or proceed to
-//! **Plan Entity Modification**.
+//! This module is a documentation anchor for the "Entity Modification
+//! Decision" node from the Harness Control Flow diagram: given the current
+//! entity state, decide whether to **Query Entities (RAG)** for more context
+//! or proceed to **Plan Entity Modification**.
 //!
-//! The implementation is currently a stub and needs further problem definition.
-
-use thiserror::Error;
-
-/// Errors related to entity modification decisions
-#[derive(Error, Debug)]
-pub enum DecisionError {
-    #[error("Entity modification decision error: {0}")]
-    DecisionFailed(String),
-}
-
-pub type DecisionResult<T> = Result<T, DecisionError>;
-
-/// Entity Modification Decision (ARCHITECTURE.md)
-///
-/// Determine whether additional entity context is needed (query) or
-/// whether the agent can proceed to plan the next modification.
-///
-/// # Note
-/// This is a stub implementation that requires further problem definition.
-pub fn entity_modification_decision() -> DecisionResult<()> {
-    unimplemented!(
-        "Entity modification decision logic requires further problem definition. \
-         This should analyze context and determine next actions."
-    )
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    #[should_panic(
-        expected = "Entity modification decision logic requires further problem definition"
-    )]
-    fn test_entity_modification_decision_unimplemented() {
-        let _ = entity_modification_decision();
-    }
-}
+//! The actual implementation lives on [`crate::agent::AgentLoop`] as the
+//! `entity_modification_decision` method, which runs the LLM-driven
+//! QUERY/PROCEED prompt against the conversation history.
+//!
+//! Previously this module exported a free-function stub that called
+//! `unimplemented!()` plus a `#[should_panic]` test that asserted the stub
+//! panicked. Per AGENTS.md / TESTING.md ("Untested code is brittle. Harden
+//! it, don't bend it. Never merge ... fallback parameters that shadow bad
+//! or dead code, or any other graceful-degradation pattern.") that pattern
+//! was deleted: a stub whose only purpose is to be tested-as-a-stub is dead
+//! code that misleads readers about the architecture.


### PR DESCRIPTION
## Precept violation

`harness/src/agent/decision.rs` exposed:

```rust
pub fn entity_modification_decision() -> DecisionResult<()> {
    unimplemented!("Entity modification decision logic requires further problem definition. ...")
}

#[test]
#[should_panic(expected = "...")]
fn test_entity_modification_decision_unimplemented() {
    let _ = entity_modification_decision();
}
```

Two AGENTS.md / TESTING.md precepts are violated:

1. **"Harden it, don't bend it. Never merge ... fallback parameters that shadow bad or dead code, or any other graceful-degradation pattern."** A stub whose only behaviour is `unimplemented!()` is precisely a placeholder shadowing real logic.
2. **"Surface failures as early as possible: compile-time > CI > runtime."** A `#[should_panic]` test that asserts the stub panics provides zero verification value — it tests the runtime panic of code that has no callers.

The actual "Entity Modification Decision" node from ARCHITECTURE.md is implemented on `AgentLoop::entity_modification_decision` (the async method called from the state machine in `agent/mod.rs`). The free-function stub and its self-panic test were misleading scaffolding from an earlier slice.

## Fix

Replace `decision.rs` with a documentation-only module that points readers at the real implementation on `AgentLoop`. The error enum (`DecisionError`), result alias (`DecisionResult`), free function, and self-panic test are removed. A repo-wide grep confirmed zero external call sites for any of the removed symbols, so this is API-safe.

## Verification

- `cargo check --workspace --all-features` — clean
- `cargo clippy --workspace --all-features --all-targets` — no warnings
- `cargo test --workspace --all-features --lib` — 436 unrelated unit tests pass; the only 2 failures (`eval::swebench::tests::materialize_from_url_*`) reproduce on the unmodified base branch (sandbox `git2` `InvalidOid("HEAD")`).

https://claude.ai/code/session_01Ufspun8cJLsqJmeuYvP1Fk

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ufspun8cJLsqJmeuYvP1Fk)_