### PR TITLE
[arch] drop dead extract_entity_ids helper from agent::rag

### DIFF
--- a/harness/src/agent/rag.rs
+++ b/harness/src/agent/rag.rs
@@ -52,11 +52,6 @@ pub async fn query_entities(
     Ok(results)
 }
 
-/// Extract relevant entity IDs from query results
-pub fn extract_entity_ids(results: &[QueryResult]) -> Vec<String> {
-    results.iter().map(|r| r.entity_id.clone()).collect()
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -81,26 +76,5 @@ mod tests {
         // Query should find it via JSON text search
         let results = query_entities(&store, "Git", Some(10)).await.unwrap();
         assert!(!results.is_empty(), "Should find git entity");
-    }
-
-    #[tokio::test]
-    async fn test_extract_entity_ids() {
-        let results = vec![
-            QueryResult {
-                entity_id: "id1".to_string(),
-                entity_type: crate::entities::EntityType::Git,
-                relevance: 1.0,
-                snippet: None,
-            },
-            QueryResult {
-                entity_id: "id2".to_string(),
-                entity_type: crate::entities::EntityType::Git,
-                relevance: 0.8,
-                snippet: None,
-            },
-        ];
-
-        let ids = extract_entity_ids(&results);
-        assert_eq!(ids, vec!["id1", "id2"]);
     }
 }


### PR DESCRIPTION
## Precept violation

`harness/src/agent/rag.rs` exports a public helper:

```rust
pub fn extract_entity_ids(results: &[QueryResult]) -> Vec<String> {
    results.iter().map(|r| r.entity_id.clone()).collect()
}
```

…together with `#[test] async fn test_extract_entity_ids` that calls it on a hand-rolled `Vec<QueryResult>`. A workspace-wide grep finds **zero** real call sites — the function exists only to be exercised by its own test.

This violates the AGENTS.md / TESTING.md precept:

> Untested code is brittle. Harden it, don't bend it. Never merge `|| true`, silent failures, fallback parameters that shadow bad or dead code, or any other graceful-degradation pattern.

A public helper whose only test is itself bends the test signal: it asserts that `iter().map().collect()` round-trips, not that any real caller works. It also widens the public API of `agent::rag` for no benefit.

## Fix

Remove `extract_entity_ids` and its self-test. The remaining `query_entities` function (the one actually called by `AgentLoop` in `Entity Enrichment` / `Query Entities (RAG)`) and its real tests are kept untouched.

## Verification

- `cargo check --workspace --all-features` — clean
- `cargo clippy --workspace --all-features --all-targets` — no warnings
- `cargo test --workspace --all-features --lib` — 436 unrelated unit tests pass; the only 2 failures (`eval::swebench::tests::materialize_from_url_*`) reproduce on the unmodified base branch (sandbox `git2` `InvalidOid("HEAD")`).

https://claude.ai/code/session_01Ufspun8cJLsqJmeuYvP1Fk

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ufspun8cJLsqJmeuYvP1Fk)_