### PR TITLE
[arch] replace stale "Placeholder" mod docs with real summaries

### DIFF
--- a/harness/src/entities/context/mod.rs
+++ b/harness/src/entities/context/mod.rs
@@ -1,12 +1,11 @@
 //! Project Context Entities
 //!
-//! This module implements conversation and project context entities for
-//! tracking user prompts, agent decisions, and development progress.
+//! Conversation and project-context entities for tracking user prompts,
+//! agent decisions, and per-run history (`ContextEntity`, `ToolCallRecord`).
+//! These power the "Project context entity" leg of the entity-store API
+//! described in ARCHITECTURE.md.
 //!
-//! See issue #26 and ARCHITECTURE.md for details.
-
-// Placeholder for context entity implementation
-// Full implementation tracked in issue #26
+//! Tracked in issue #26.
 
 pub mod types;
 

--- a/harness/src/entities/env/mod.rs
+++ b/harness/src/entities/env/mod.rs
@@ -4,11 +4,12 @@
 //! development, sandbox, and release environments described in
 //! ARCHITECTURE.md ("Container Topology"). The submodules cover:
 //!
-//! - [`types`] — `EnvEntity` and `DeploymentTier` schema
+//! - [`types`] — `EnvEntity`, `ContainerConfigEntity`, `RuntimeConfig`,
+//!   `PortMapping`, `VolumeMount`, `EnvVarRef`, and `EnvVarSource` schema
 //! - [`security`] — security-context primitives applied to a deployment
 //! - [`deployment`] — concrete deployment configuration helpers
-//! - [`bridge`] — bridge between an `EnvEntity` and the runtime container
-//!   handle (see `crate::container`)
+//! - [`bridge`] — converts a `container::ContainerConfig` into a
+//!   `ContainerConfigEntity` (see `crate::container`)
 //!
 //! Tracked in issue #25.
 

--- a/harness/src/entities/env/mod.rs
+++ b/harness/src/entities/env/mod.rs
@@ -1,12 +1,16 @@
 //! Environment & Deployment Entities
 //!
-//! This module implements container configuration and deployment entities for
-//! managing the development, sandbox, and release environments.
+//! Container configuration and deployment entities for managing the
+//! development, sandbox, and release environments described in
+//! ARCHITECTURE.md ("Container Topology"). The submodules cover:
 //!
-//! See issue #25 and ARCHITECTURE.md for details.
-
-// Placeholder for environment entity implementation
-// Full implementation tracked in issue #25
+//! - [`types`] — `EnvEntity` and `DeploymentTier` schema
+//! - [`security`] — security-context primitives applied to a deployment
+//! - [`deployment`] — concrete deployment configuration helpers
+//! - [`bridge`] — bridge between an `EnvEntity` and the runtime container
+//!   handle (see `crate::container`)
+//!
+//! Tracked in issue #25.
 
 pub mod bridge;
 pub mod deployment;

--- a/harness/src/entities/test/mod.rs
+++ b/harness/src/entities/test/mod.rs
@@ -1,12 +1,11 @@
 //! Testing & Analysis Entities
 //!
-//! This module implements test results and static analysis entities for
-//! tracking code quality metrics and test outcomes.
+//! Test-result and static-analysis entities for tracking code quality
+//! metrics and test outcomes. The current `TestEntity` schema is a
+//! minimal `EntityMetadata` wrapper; richer fields will be added as
+//! the test/analysis pipeline lands.
 //!
-//! See issue #24 and ARCHITECTURE.md for details.
-
-// Placeholder for test entity implementation
-// Full implementation tracked in issue #24
+//! Tracked in issue #24.
 
 pub mod types;
 


### PR DESCRIPTION
## Precept violation

Three entity-submodule `mod.rs` files each carry a stale "Placeholder for X entity implementation" comment despite all three now containing real code:

| File | Stale claim | Actual state |
|---|---|---|
| `entities/context/mod.rs` | "Placeholder for context entity implementation" | `context/types.rs` is 185 LOC with `ContextEntity`, `ToolCallRecord`, and full serde + entity-trait impls used by `agent::mod`, `task`, and `agent::eval`. |
| `entities/env/mod.rs`     | "Placeholder for environment entity implementation" | `env/{bridge,deployment,security,types}.rs` totals 908 LOC. |
| `entities/test/mod.rs`    | "Placeholder for test entity implementation" | `test/types.rs` provides a real `TestEntity` (still lean, but no longer TBD). |

The "Placeholder" wording misleads readers about the state of each subsystem. AGENTS.md warns against this pattern:

> Untested code is brittle. Harden it, don't bend it. Never merge `|| true`, silent failures, fallback parameters that shadow bad or dead code, or any other graceful-degradation pattern.

Stale "TODO/Placeholder" comments are the documentation analogue of fallback shadowing — they hide that real code already exists.

## Fix

Replace each `mod.rs` doc-comment with a short, accurate summary of what the submodule actually exposes, preserving the existing issue-tracker references (#24, #25, #26) for outstanding richer work.

## Verification

- `cargo check --workspace --all-features` — clean
- `cargo clippy --workspace --all-features --all-targets` — no warnings (the natural `doc list item overindented` lint was respected when re-flowing the bullets)

No code changes; only doc-comment text.

https://claude.ai/code/session_01Ufspun8cJLsqJmeuYvP1Fk

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ufspun8cJLsqJmeuYvP1Fk)_