### PR TITLE
feat(harness): add harness-eval bin and rewire eval.yml step 5 to call run_eval

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -17,7 +17,7 @@ on:
           - qwen3:0.6b
           - llama3.1:8b
       case_filter:
-        description: 'Additional nextest filter expression for case selection (optional)'
+        description: 'Substring matched against case ID (optional; empty = run all)'
         required: false
         default: ''
 
@@ -88,20 +88,14 @@ jobs:
         echo "**Triggered by:** @${{ github.actor }}" >> eval-results.md
         echo "" >> eval-results.md
 
-        echo "### Unit-level eval tests" >> eval-results.md
+        echo "### Eval cases" >> eval-results.md
         echo '```' >> eval-results.md
 
-        FILTER='test(eval)'
-        if [ -n "${CASE_FILTER}" ]; then
-          FILTER="${FILTER} & ${CASE_FILTER}"
-        fi
-
         set +e
-        nix develop --command cargo nextest run \
-          --workspace --all-features \
-          -E "$FILTER" \
-          --no-fail-fast 2>&1 | tee eval-output.txt
-        EXIT_CODE=$?
+        nix develop --command cargo run --release --bin harness-eval --features eval-runner -- \
+          --filter "${CASE_FILTER}" \
+          2>&1 | tee eval-output.txt
+        EXIT_CODE=${PIPESTATUS[0]}
         set -e
 
         cat eval-output.txt >> eval-results.md

--- a/harness/Cargo.toml
+++ b/harness/Cargo.toml
@@ -11,6 +11,11 @@ repository.workspace = true
 name = "harness"
 path = "src/main.rs"
 
+[[bin]]
+name = "harness-eval"
+path = "src/bin/eval.rs"
+required-features = ["eval-runner"]
+
 [features]
 # Gate the eval runner and its tempfile dependency behind this feature so that
 # production builds (the harness binary, container images) do not pull in

--- a/harness/src/bin/eval.rs
+++ b/harness/src/bin/eval.rs
@@ -1,0 +1,156 @@
+use clap::Parser;
+use harness::agent::eval_case::EvalCase;
+use harness::eval::runner::{run_eval, EvalRunResult, EvalRunnerConfig, EvalRunnerError};
+use std::path::PathBuf;
+use std::process::ExitCode;
+use std::time::Duration;
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "harness-eval",
+    about = "Run nanna-coder eval cases via harness::eval::runner::run_eval"
+)]
+struct Args {
+    #[arg(long, default_value = "evals/cases")]
+    cases_dir: PathBuf,
+
+    #[arg(long)]
+    filter: Option<String>,
+
+    #[arg(long)]
+    model: Option<String>,
+
+    #[arg(long)]
+    base_url: Option<String>,
+
+    #[arg(long, default_value_t = 100)]
+    max_iterations: usize,
+
+    #[arg(long)]
+    timeout_secs: Option<u64>,
+
+    #[arg(long)]
+    verbose: bool,
+}
+
+fn resolve_model(cli: Option<String>) -> String {
+    cli.or_else(|| std::env::var("NANNA_EVAL_MODEL").ok())
+        .or_else(|| std::env::var("MODEL").ok())
+        .unwrap_or_else(|| "qwen3:0.6b".to_string())
+}
+
+fn case_matches(case_id: &str, filter: &Option<String>) -> bool {
+    match filter {
+        Some(needle) if !needle.is_empty() => case_id.contains(needle.as_str()),
+        _ => true,
+    }
+}
+
+#[tokio::main]
+async fn main() -> ExitCode {
+    let args = Args::parse();
+    let model = resolve_model(args.model);
+    let cases = match EvalCase::discover(&args.cases_dir) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!(
+                "::error::failed to discover eval cases under {}: {e}",
+                args.cases_dir.display()
+            );
+            return ExitCode::from(2);
+        }
+    };
+    let selected: Vec<_> = cases
+        .into_iter()
+        .filter(|(c, _)| case_matches(&c.case.id, &args.filter))
+        .collect();
+
+    if selected.is_empty() {
+        eprintln!(
+            "::error::no eval cases matched filter {:?} under {}",
+            args.filter,
+            args.cases_dir.display()
+        );
+        return ExitCode::from(2);
+    }
+
+    println!(
+        "Running {} eval case(s) with model `{model}`",
+        selected.len()
+    );
+    let mut results: Vec<(String, Result<EvalRunResult, EvalRunnerError>)> = Vec::new();
+
+    for (case, case_dir) in &selected {
+        let config = EvalRunnerConfig::default()
+            .with_model(&model)
+            .with_max_iterations(args.max_iterations)
+            .with_verbose(args.verbose);
+        let config = match &args.base_url {
+            Some(url) => config.with_base_url(url),
+            None => config,
+        };
+
+        let timeout = Duration::from_secs(args.timeout_secs.unwrap_or(case.metadata.timeout_secs));
+
+        println!(
+            "── case {} (timeout {}s) ──",
+            case.case.id,
+            timeout.as_secs()
+        );
+
+        let res = match tokio::time::timeout(timeout, run_eval(case, case_dir, &config)).await {
+            Ok(inner) => inner,
+            Err(_) => Err(EvalRunnerError::Timeout(timeout)),
+        };
+
+        match &res {
+            Ok(r) => println!(
+                "  → {} in {:.2}s ({} iters, {} prompt + {} completion tokens)",
+                if r.success { "PASS" } else { "FAIL" },
+                r.execution_time.as_secs_f64(),
+                r.iterations,
+                r.token_usage.prompt_tokens,
+                r.token_usage.completion_tokens,
+            ),
+            Err(e) => println!("  → ERROR: {e}"),
+        }
+        results.push((case.case.id.clone(), res));
+    }
+
+    let total = results.len();
+    let passed = results
+        .iter()
+        .filter(|(_, r)| matches!(r, Ok(rr) if rr.success))
+        .count();
+    let failed: Vec<&(String, Result<EvalRunResult, EvalRunnerError>)> = results
+        .iter()
+        .filter(|(_, r)| !matches!(r, Ok(rr) if rr.success))
+        .collect();
+
+    println!();
+    println!("=== Summary ===");
+    println!("Model: {model}");
+    println!("Total: {total}, Passed: {passed}, Failed: {}", failed.len());
+    if !failed.is_empty() {
+        println!("Failures:");
+        for (id, res) in &failed {
+            match res {
+                Ok(r) => {
+                    let why = if r.failures.is_empty() {
+                        "verification failed".to_string()
+                    } else {
+                        r.failures.join("; ")
+                    };
+                    println!("  - {id}: {why}");
+                }
+                Err(e) => println!("  - {id}: {e}"),
+            }
+        }
+    }
+
+    if failed.is_empty() {
+        ExitCode::SUCCESS
+    } else {
+        ExitCode::FAILURE
+    }
+}


### PR DESCRIPTION
## Summary

Replaces the placeholder nextest filter (`-E 'test(eval)'`) in the Eval Suite workflow with a real invocation of the `harness::eval::runner::run_eval()` function that landed in #271.

**Stacked on #289** (eval.yml gemma4:e4b + NANNA_EVAL_MODEL + harden ollama pull). Set the base of this PR to `main` once #289 lands.

## What's new

### `harness/src/bin/eval.rs` (new)

Small `clap`-based driver around `harness::eval::runner::run_eval`. Behaviour:
- Discovers cases under `evals/cases/` (override with `--cases-dir`).
- Filters by substring against the case ID (`--filter`); empty filter runs all.
- Per-case timeout from `task.toml`'s `metadata.timeout_secs` (overridable via `--timeout-secs`).
- Model resolution priority: `--model` > `NANNA_EVAL_MODEL` env > `MODEL` env > `qwen3:0.6b`.
- Prints per-case status + a final summary; exits non-zero on any failure or runner error.

### `harness/Cargo.toml`

Adds `[[bin]] harness-eval` gated on the existing `eval-runner` feature, so production builds (the `harness` bin, container images) don't pull in `tempfile`.

### `.github/workflows/eval.yml` (step 5)

Replaces:
```bash
cargo nextest run --workspace --all-features -E "$FILTER" --no-fail-fast
```
with:
```bash
cargo run --release --bin harness-eval --features eval-runner -- --filter "${CASE_FILTER}"
```

Also captures the runner's exit code via `\${PIPESTATUS[0]}` so a real failure doesn't get masked by `tee`. Updates the `case_filter` input description to reflect substring semantics.

## Why this and not #272's happy-path step

PR #272 attempted the same rewire by running `cargo nextest run --features eval-runner --run-ignored ignored-only -E 'test(eval_runner)'`. The owner review flagged three blockers: `test(eval_runner)` matches zero tests (silent skip), the integration tests silently skip on `ModelProvider` errors, and `NANNA_EVAL_MODEL` doesn't reach `EvalRunnerConfig`. A dedicated bin avoids all three: filter is explicit, errors propagate to a non-zero exit, and the bin reads the env var directly.

## Local verification (this branch)

```
$ cargo build -p harness --bin harness-eval --features eval-runner   # clean
$ cargo fmt --all -- --check                                         # clean
$ cargo clippy --workspace --all-targets --all-features -- -D warnings   # clean
$ cargo nextest run --workspace --all-features ...                   # 587 passed, 13 ignored
$ cargo run -p harness --bin harness-eval --features eval-runner -- --help
                                                                     # OK
$ cargo run -p harness --bin harness-eval --features eval-runner -- \
    --filter happy-path-001 --max-iterations 1 --timeout-secs 5
                                                                     # exit=1, prints FAIL summary (no Ollama → expected)
$ cargo run -p harness --bin harness-eval --features eval-runner -- \
    --filter no-such-case
                                                                     # exit=2 (no cases matched)
```

## Test plan

- [ ] CI green on this PR
- [ ] Manual `workflow_dispatch` of `Eval Suite` (after stacking PRs land): step 5 invokes `harness-eval`, output appears in `eval-results.md`, non-zero from any failed case marks job failed
- [ ] Follow-up PR can extend the bin with a `--report-md <path>` flag to integrate with `harness::eval::report::EvalReport` (requires shaping `EvalRunResult` into `BatchEvaluationResult` first — out of scope here, related to #92)

🤖 Generated with [Claude Code](https://claude.com/claude-code)