### PR TITLE
fix(nanna-coder): remove duplicate tracing subscriber initialization from TelemetrySystem

### DIFF
--- a/harness/src/telemetry.rs
+++ b/harness/src/telemetry.rs
@@ -55,7 +55,6 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 use thiserror::Error;
 use tracing::{debug, info};
-use tracing_subscriber::{EnvFilter, FmtSubscriber};
 
 /// Telemetry system errors
 #[derive(Error, Debug)]
@@ -606,26 +605,6 @@ impl TelemetrySystem {
             return Ok(());
         }
 
-        // Initialize structured logging
-        if self.config.enable_logging {
-            let filter = EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| EnvFilter::new(&self.config.log_level));
-
-            let subscriber = FmtSubscriber::builder()
-                .with_env_filter(filter)
-                .with_target(false)
-                .with_thread_ids(true)
-                .with_file(true)
-                .with_line_number(true)
-                .finish();
-
-            tracing::subscriber::set_global_default(subscriber).map_err(|e| {
-                TelemetryError::InitializationFailed {
-                    reason: format!("Failed to set tracing subscriber: {}", e),
-                }
-            })?;
-        }
-
         // Add default Prometheus exporter if configured
         if let Some(endpoint) = &self.config.export_endpoints.prometheus_endpoint {
             let prometheus_exporter = PrometheusExporter::new(Some(endpoint.clone()));
@@ -936,17 +915,8 @@ mod tests {
             .with_version("1.0.0")
             .with_environment("test");
 
-        // In test environments, the tracing subscriber may already be initialized
-        match telemetry.initialize().await {
-            Ok(_) => assert!(telemetry.initialized),
-            Err(TelemetryError::InitializationFailed { reason })
-                if reason.contains("global default trace dispatcher has already been set") =>
-            {
-                // This is expected in parallel test runs - consider the test successful
-                println!("Tracing subscriber already initialized (expected in CI)");
-            }
-            Err(e) => panic!("Unexpected initialization error: {}", e),
-        }
+        assert_eq!(telemetry.initialize().await, Ok(()));
+        assert!(telemetry.initialized);
     }
 
     #[tokio::test]


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- `main.rs` already installs a global tracing subscriber via `tracing_subscriber::fmt().init()` at program startup.
- `TelemetrySystem::initialize` in `harness/src/telemetry.rs` was making a second call to `tracing::subscriber::set_global_default`, creating a race: whichever call runs second is silently dropped, meaning the telemetry system's configured log level and format were never actually applied in production.
- `test_telemetry_system_initialization` worked around this with a `match` that printed `"Expected failure: …"` on the subscriber-already-set error path, masking the bug rather than surfacing it.

## Changes

- **Removed** the `FmtSubscriber` / `EnvFilter` subscriber setup block from `TelemetrySystem::initialize` (`harness/src/telemetry.rs`).
- **Removed** the now-unused `use tracing_subscriber::{EnvFilter, FmtSubscriber};` import.
- **Updated** `test_telemetry_system_initialization` to assert `Ok(())` unconditionally — initialization no longer touches the global subscriber, so it always succeeds regardless of test ordering.

## Test plan

- [ ] `cargo test -p harness telemetry` passes with no "expected failure" output.
- [ ] `cargo clippy -p harness` reports no unused-import warnings for `EnvFilter`/`FmtSubscriber`.
- [ ] Running the binary (`cargo run -- health`) still produces structured log output (subscriber installed by `main.rs` remains active).

https://claude.ai/code/session_011LYFrHwghQBPNBWVeVhvjd
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_011LYFrHwghQBPNBWVeVhvjd)_