### PR TITLE
Update Apache License 2.0 text with clarifications and formatting

### DIFF
--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -137,8 +137,8 @@
 
    6. Trademarks. This License does not grant permission to use the trade
       names, trademarks, service marks, or product names of the Licensor,
-      except as required for describing the origin of the Work and
-      reproducing the content of the NOTICE file.
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
 
    7. Disclaimer of Warranty. Unless required by applicable law or
       agreed to in writing, Licensor provides the Work (and each
@@ -162,15 +162,16 @@
       other commercial damages or losses), even if such Contributor
       has been advised of the possibility of such damages.
 
-   9. Accepting Warranty or Support. While redistributing the Work or
-      Derivative Works thereof, You may accept support, warranty, indemnity,
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
       or other liability obligations and/or rights consistent with this
-      License, and may charge a fee for doing so. However, in accepting such
-      obligations, You may act only on Your own behalf and on Your sole
-      responsibility, not on behalf of any other Contributor, and only if
-      You agree to indemnify, defend, and hold each Contributor harmless
-      for any liability incurred by, or claims asserted against, such
-      Contributor by reason of your accepting any such warranty or support.
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
 
    END OF TERMS AND CONDITIONS
 
@@ -181,8 +182,9 @@
       replaced with your own identifying information. (Don't include
       the brackets!)  The text should be enclosed in the appropriate
       comment syntax for the file format. We also recommend that a
-      file or class name and description of any copyright notice be
-      included on the same line as the file's content.
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
 
    Copyright 2025 Dominic Burkart
 
@@ -194,6 +196,6 @@
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-   implied. See the License for the specific language governing
-   permissions and limitations under the License.
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.


### PR DESCRIPTION
## Summary
This PR updates the LICENSE-APACHE file with clarifications to the Apache License 2.0 terms and improved formatting for better readability and compliance documentation.

## Key Changes
- **Section 6 (Trademarks)**: Added "reasonable and customary use" qualifier to clarify permitted trademark usage in describing the Work's origin
- **Section 9 (Liability)**: Renamed from "Accepting Warranty or Support" to "Accepting Warranty or Additional Liability" and expanded language to explicitly permit charging fees for warranty/support/indemnity obligations while maintaining contributor protection requirements
- **Header Comments**: Updated guidance on copyright notice placement to reference "same printed page" concept and clarify that file descriptions should focus on purpose rather than copyright details
- **Formatting**: Improved line wrapping and text flow in the disclaimer section for better readability

## Notable Details
These changes align with common interpretations and clarifications of the Apache License 2.0, making the license terms more explicit regarding:
- Reasonable use of trademarks in attribution
- Commercial support offerings under the license
- Proper copyright notice placement in derivative works

https://claude.ai/code/session_01AZcMx2688eSzcnweHJkLeq