### PR TITLE
chore: maintenance pass (architecture, tests, clarity)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Rust
 /target/
+**/target/
 **/*.rs.bk
 
 # IDE

--- a/docs/agent-evaluation-patterns.md
+++ b/docs/agent-evaluation-patterns.md
@@ -24,8 +24,7 @@ Tests interaction between agent subsystems:
 
 ### Level 3: System Evaluations
 Tests the full containerized system:
-- Model provider integration (Ollama/vLLM)
-- Observability and telemetry collection
+- Model provider integration (Ollama)
 - End-to-end task completion with real LLMs
 - Performance and reliability under load
 

--- a/harness/src/onboarding/flake_template.rs
+++ b/harness/src/onboarding/flake_template.rs
@@ -196,4 +196,41 @@ mod tests {
         let flake = generate_flake(&profile).unwrap();
         assert!(flake.contains("1.75.0"));
     }
+
+    /// When `rust_version` is `None`, the generator must fall back to
+    /// `DEFAULT_RUST_VERSION` rather than emitting a literal placeholder
+    /// or panicking. This guards the `unwrap_or(DEFAULT_RUST_VERSION)`
+    /// branch in `generate_cargo_flake`.
+    #[test]
+    fn generated_flake_falls_back_to_default_rust_version_when_unset() {
+        let mut profile = minimal_cargo_profile("myapp");
+        profile.rust_version = None;
+        let flake = generate_flake(&profile).unwrap();
+        assert!(
+            flake.contains(DEFAULT_RUST_VERSION),
+            "fallback default {} should appear in generated flake",
+            DEFAULT_RUST_VERSION
+        );
+        assert!(
+            !flake.contains("__RUST_VERSION__"),
+            "placeholder must be substituted even with no explicit rust_version"
+        );
+    }
+
+    /// Every templated placeholder must be substituted; a leaked
+    /// `__FOO__` token would produce an invalid flake at evaluation
+    /// time. Asserting on placeholders directly catches future
+    /// template additions that forget to wire a substitution.
+    #[test]
+    fn generated_flake_has_no_unsubstituted_placeholders() {
+        let profile = minimal_cargo_profile("myapp");
+        let flake = generate_flake(&profile).unwrap();
+        for token in ["__PROJECT_NAME__", "__RUST_VERSION__", "__PACKAGES__"] {
+            assert!(
+                !flake.contains(token),
+                "placeholder {} leaked into generated flake",
+                token
+            );
+        }
+    }
 }

--- a/harness/src/onboarding/mod.rs
+++ b/harness/src/onboarding/mod.rs
@@ -173,4 +173,21 @@ edition = "2021"
         let result = ensure_dev_container(dir.path(), &NeverOnboarder).await;
         assert!(result.is_err());
     }
+
+    /// `OnboardingError` exposes a `From<image_builder::ImageBuilderError>`
+    /// so that `ensure_dev_container` can use `?` against
+    /// `image_builder::build_dev_container`. The conversion stringifies
+    /// the source error into the `ImageBuilder` variant. This pins the
+    /// contract (variant + message preservation) so a future refactor of
+    /// either error enum cannot silently break the bridge.
+    #[test]
+    fn onboarding_error_from_image_builder_error_preserves_message() {
+        let inner = image_builder::ImageBuilderError::InvalidConfig("missing flake".into());
+        let inner_msg = inner.to_string();
+        let onboarding: OnboardingError = inner.into();
+        match onboarding {
+            OnboardingError::ImageBuilder(msg) => assert_eq!(msg, inner_msg),
+            other => panic!("expected ImageBuilder variant, got {:?}", other),
+        }
+    }
 }

--- a/model/src/config.rs
+++ b/model/src/config.rs
@@ -233,4 +233,28 @@ mod tests {
             deserialized.default_context_length
         );
     }
+
+    /// `with_max_tokens` is the only way to set a non-`None` cap from the
+    /// builder, and `validate` rejects a zero cap. Together they pin the
+    /// invariant that an explicit cap is strictly positive.
+    #[test]
+    fn with_max_tokens_sets_some_and_validates() {
+        let config = OllamaConfig::new().with_max_tokens(4096);
+        assert_eq!(config.default_max_tokens, Some(4096));
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_zero_max_tokens() {
+        let config = OllamaConfig {
+            default_max_tokens: Some(0),
+            ..OllamaConfig::default()
+        };
+        let err = config.validate().unwrap_err();
+        assert!(
+            err.contains("Max tokens"),
+            "expected error to mention max tokens, got: {}",
+            err
+        );
+    }
 }

--- a/model/src/lib.rs
+++ b/model/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod config;
 pub mod judge;
+#[cfg(feature = "ollama")]
 pub mod ollama;
 pub mod provider;
 pub mod types;


### PR DESCRIPTION
## 1. Architecture alignment & simplification

- **`model/src/lib.rs`**: gate `pub mod ollama;` behind `#[cfg(feature = "ollama")]`. The submodule references `ollama_rs::*` types only available with the `ollama` feature; without the guard, `cargo build --no-default-features` failed with E0432/E0433. The matching guard already existed on the `pub use ollama::OllamaProvider;` re-export — this aligns the module declaration so the feature flag actually behaves as advertised.
- **`.gitignore`**: add `**/target/` so cargo runs in nested workspaces (e.g. `tests/integration/repo/`, the fibonacci-example dev-container fixture loaded by `harness/tests/dev_container_integration.rs:25-30`) cannot leak build artifacts into git. Past commits e19eefd, 7001311, 0e1b2cb removed individual leaked artifacts piecemeal; this prevents the regression at the source.

## 2. Testing posture

Three small, high-value gaps closed; all pin previously-unexercised invariants. Component / current-disposition / new-coverage:

- **`model::config::OllamaConfig`** — builder + validate had unit tests but `with_max_tokens(_)` and the `default_max_tokens == Some(0)` rejection branch in `validate()` were unreachable from the existing tests (everything used the default `None`). Added `model/src/config.rs:240-259`. Invariants: builder produces `Some(_)`; an explicit cap of 0 is rejected with a message naming "Max tokens".
- **`harness::onboarding::flake_template::generate_cargo_flake`** — generator was tested for happy-path strings but not for the `unwrap_or(DEFAULT_RUST_VERSION)` fallback when `rust_version: None`, and there was no negative-space assertion that placeholders were substituted. Added `harness/src/onboarding/flake_template.rs:200-235`. Invariants: `None` rust_version yields `DEFAULT_RUST_VERSION` in output; no `__FOO__` template placeholder leaks past substitution (catches future template additions that forget to wire substitution).
- **`harness::onboarding::OnboardingError`** — the `From<image_builder::ImageBuilderError>` impl is the bridge that lets `ensure_dev_container` use `?` against `image_builder::build_dev_container`, but neither variant nor message preservation was tested. Added `harness/src/onboarding/mod.rs:177-192`. Invariants: conversion lands in `OnboardingError::ImageBuilder(_)` and the inner `Display` text is preserved.

Local results: `cargo test --workspace --lib` 440 passed, 0 failed (was 435). `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean. `cargo fmt --all -- --check` clean.

## 3. Clarity

- **`docs/agent-evaluation-patterns.md:27`**: drop stale `(Ollama/vLLM)` reference. `model/src/vllm.rs` was deleted in commit 68fab04 ("Remove dead vllm.rs module that is never compiled"); only the Ollama provider survives under `model/src/ollama.rs`. The doc bullet on observability/telemetry collection was also dropped from the same list since it referenced subsystems that are themselves being removed in #324.

## Notes

- A separate cleanup of the ~141 already-checked-in files under `tests/integration/repo/target/` (~29 MB of build artifacts) was prepared locally but is not in this PR — the MCP push API only supports adds/updates, and 141 individual `delete_file` calls is not a workable interaction. The `**/target/` rule added here prevents future regressions; the bulk deletion is best done in a follow-up via direct `git push`.
- Did not duplicate work from open PRs #270 (clarity/headings), #305 (MCP handler contract tests), #304 (image-builder dead `unimplemented!()` stubs), #324 (drop dead monitoring/telemetry/observability subsystem).


---
_Generated by [Claude Code](https://claude.ai/code/session_01L3gFY2LhHNQWKKBUXHTuVp)_