### PR TITLE
test: fill coverage gaps in observability, telemetry, and test entities

### DIFF
--- a/harness/src/entities/test/types.rs
+++ b/harness/src/entities/test/types.rs
@@ -44,3 +44,73 @@ impl Default for TestEntity {
         Self::new()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_entity_new_has_test_type() {
+        let entity = TestEntity::new();
+        assert_eq!(entity.metadata.entity_type, EntityType::Test);
+    }
+
+    #[test]
+    fn test_entity_default_matches_new() {
+        let a = TestEntity::new();
+        let b = TestEntity::default();
+        assert_eq!(a.metadata.entity_type, b.metadata.entity_type);
+    }
+
+    #[test]
+    fn test_entity_to_json_succeeds() {
+        let entity = TestEntity::new();
+        let result = entity.to_json();
+        assert!(result.is_ok(), "TestEntity should serialize to JSON");
+        let json = result.unwrap();
+        assert!(json.contains("\"entity_type\""), "JSON should contain entity_type");
+    }
+
+    #[test]
+    fn test_entity_json_roundtrip() {
+        let entity = TestEntity::new();
+        let json = entity.to_json().unwrap();
+        let deserialized: TestEntity = serde_json::from_str(&json).unwrap();
+        assert_eq!(entity.metadata.entity_type, deserialized.metadata.entity_type);
+    }
+
+    #[test]
+    fn test_entity_metadata_id_is_nonempty() {
+        let entity = TestEntity::new();
+        assert!(!entity.metadata.id.is_empty(), "Entity ID should not be empty");
+    }
+
+    #[test]
+    fn test_two_entities_have_distinct_ids() {
+        let a = TestEntity::new();
+        let b = TestEntity::new();
+        assert_ne!(a.metadata.id, b.metadata.id, "Each entity should have a unique ID");
+    }
+
+    #[tokio::test]
+    async fn test_entity_trait_methods() {
+        let mut entity = TestEntity::new();
+
+        // metadata() returns the right type
+        assert_eq!(entity.metadata().entity_type, EntityType::Test);
+
+        // metadata_mut() gives mutable access
+        entity.metadata_mut().entity_type = EntityType::Test; // no-op change, just verifies access
+
+        // to_json() works
+        assert!(entity.to_json().is_ok());
+    }
+
+    #[test]
+    fn test_entity_usable_as_trait_object() {
+        let entity = TestEntity::new();
+        let boxed: Box<dyn Entity> = Box::new(entity);
+        assert_eq!(boxed.metadata().entity_type, EntityType::Test);
+        assert!(boxed.to_json().is_ok());
+    }
+}

--- a/harness/src/entities/test/types.rs
+++ b/harness/src/entities/test/types.rs
@@ -104,18 +104,31 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn test_entity_trait_methods() {
+    #[test]
+    fn test_entity_metadata_mut_persists_mutation() {
+        // Construct as Test, mutate via metadata_mut() to a *different* variant,
+        // and assert that the change is observable through the immutable
+        // metadata() accessor and through to_json(). This catches a bug where
+        // metadata_mut() returned a reference into a separate field or a
+        // throwaway copy.
         let mut entity = TestEntity::new();
-
-        // metadata() returns the right type
         assert_eq!(entity.metadata().entity_type, EntityType::Test);
 
-        // metadata_mut() gives mutable access
-        entity.metadata_mut().entity_type = EntityType::Test; // no-op change, just verifies access
+        entity.metadata_mut().entity_type = EntityType::Telemetry;
 
-        // to_json() works
-        assert!(entity.to_json().is_ok());
+        // Mutation visible through the immutable accessor.
+        assert_eq!(entity.metadata().entity_type, EntityType::Telemetry);
+
+        // And the mutation is reflected in the serialized form.
+        let json = entity.to_json().expect("serialization should succeed");
+        assert!(
+            json.contains("Telemetry"),
+            "Mutated entity_type should appear in JSON, got: {json}"
+        );
+        assert!(
+            !json.contains("\"Test\""),
+            "Old entity_type should not appear in JSON after mutation, got: {json}"
+        );
     }
 
     #[test]

--- a/harness/src/entities/test/types.rs
+++ b/harness/src/entities/test/types.rs
@@ -68,7 +68,10 @@ mod tests {
         let result = entity.to_json();
         assert!(result.is_ok(), "TestEntity should serialize to JSON");
         let json = result.unwrap();
-        assert!(json.contains("\"entity_type\""), "JSON should contain entity_type");
+        assert!(
+            json.contains("\"entity_type\""),
+            "JSON should contain entity_type"
+        );
     }
 
     #[test]
@@ -76,20 +79,29 @@ mod tests {
         let entity = TestEntity::new();
         let json = entity.to_json().unwrap();
         let deserialized: TestEntity = serde_json::from_str(&json).unwrap();
-        assert_eq!(entity.metadata.entity_type, deserialized.metadata.entity_type);
+        assert_eq!(
+            entity.metadata.entity_type,
+            deserialized.metadata.entity_type
+        );
     }
 
     #[test]
     fn test_entity_metadata_id_is_nonempty() {
         let entity = TestEntity::new();
-        assert!(!entity.metadata.id.is_empty(), "Entity ID should not be empty");
+        assert!(
+            !entity.metadata.id.is_empty(),
+            "Entity ID should not be empty"
+        );
     }
 
     #[test]
     fn test_two_entities_have_distinct_ids() {
         let a = TestEntity::new();
         let b = TestEntity::new();
-        assert_ne!(a.metadata.id, b.metadata.id, "Each entity should have a unique ID");
+        assert_ne!(
+            a.metadata.id, b.metadata.id,
+            "Each entity should have a unique ID"
+        );
     }
 
     #[tokio::test]

--- a/harness/src/observability.rs
+++ b/harness/src/observability.rs
@@ -1440,7 +1440,10 @@ mod tests {
             acknowledged: false,
         };
         let actions = system.generate_recommended_actions(&alert, &AlertCategory::Availability);
-        assert!(!actions.is_empty(), "Should always return at least one action");
+        assert!(
+            !actions.is_empty(),
+            "Should always return at least one action"
+        );
     }
 
     #[test]
@@ -1498,7 +1501,10 @@ mod tests {
             .iter()
             .filter(|ch| ch.channel_type == ChannelType::Console)
             .collect();
-        assert!(!console_channels.is_empty(), "Should have a console channel");
+        assert!(
+            !console_channels.is_empty(),
+            "Should have a console channel"
+        );
         assert_eq!(console_channels[0].min_severity, AlertSeverity::Info);
     }
 

--- a/harness/src/observability.rs
+++ b/harness/src/observability.rs
@@ -1097,4 +1097,503 @@ mod tests {
         let trends = system.analyze_current_trends(&metrics).unwrap();
         assert!(trends.performance_score >= 0.0 && trends.performance_score <= 100.0);
     }
+
+    #[test]
+    fn test_trend_direction_degrading_on_high_error_rate() {
+        let mut system = ObservabilitySystem::new();
+        // Set max_error_rate threshold to 0.05 (default)
+        system.health_thresholds.max_error_rate = 0.05;
+
+        let metrics = SystemMetrics {
+            timestamp: Utc::now(),
+            request_latencies: HashMap::new(),
+            cache_metrics: crate::monitoring::CacheMetrics {
+                hits: 80,
+                misses: 20,
+                hit_rate: 0.8,
+                size_bytes: 1024,
+                item_count: 100,
+                evictions: 0,
+            },
+            container_metrics: Vec::new(),
+            system_resources: crate::monitoring::SystemResourceMetrics {
+                cpu_usage_percent: 10.0,
+                total_memory_bytes: 8000000000,
+                used_memory_bytes: 2000000000,
+                memory_usage_percent: 25.0,
+                available_disk_bytes: 100000000000,
+                total_disk_bytes: 200000000000,
+                disk_usage_percent: 50.0,
+                load_average: [0.5, 0.5, 0.5],
+            },
+            model_metrics: HashMap::new(),
+            error_metrics: crate::monitoring::ErrorMetrics {
+                total_errors: 100,
+                errors_by_type: HashMap::new(),
+                error_rate: 0.20, // 20% > threshold
+                recent_errors: Vec::new(),
+            },
+        };
+
+        let trends = system.analyze_current_trends(&metrics).unwrap();
+        assert_eq!(trends.error_rate_trend, TrendDirection::Degrading);
+        // Score should be reduced by 25 for error rate degradation
+        assert!(trends.performance_score <= 75.0);
+    }
+
+    #[test]
+    fn test_trend_direction_degrading_on_low_cache_rate() {
+        let mut system = ObservabilitySystem::new();
+        system.health_thresholds.min_cache_hit_rate = 0.8;
+
+        let metrics = SystemMetrics {
+            timestamp: Utc::now(),
+            request_latencies: HashMap::new(),
+            cache_metrics: crate::monitoring::CacheMetrics {
+                hits: 40,
+                misses: 60,
+                hit_rate: 0.4, // 40% < threshold of 80%
+                size_bytes: 1024,
+                item_count: 100,
+                evictions: 0,
+            },
+            container_metrics: Vec::new(),
+            system_resources: crate::monitoring::SystemResourceMetrics {
+                cpu_usage_percent: 10.0,
+                total_memory_bytes: 8000000000,
+                used_memory_bytes: 2000000000,
+                memory_usage_percent: 25.0,
+                available_disk_bytes: 100000000000,
+                total_disk_bytes: 200000000000,
+                disk_usage_percent: 50.0,
+                load_average: [0.5, 0.5, 0.5],
+            },
+            model_metrics: HashMap::new(),
+            error_metrics: crate::monitoring::ErrorMetrics {
+                total_errors: 0,
+                errors_by_type: HashMap::new(),
+                error_rate: 0.0,
+                recent_errors: Vec::new(),
+            },
+        };
+
+        let trends = system.analyze_current_trends(&metrics).unwrap();
+        assert_eq!(trends.cache_performance_trend, TrendDirection::Degrading);
+        // Score should be reduced by 15 for cache degradation
+        assert!(trends.performance_score <= 85.0);
+    }
+
+    #[test]
+    fn test_trend_direction_all_stable() {
+        let system = ObservabilitySystem::new();
+        let thresholds = &system.health_thresholds;
+
+        let metrics = SystemMetrics {
+            timestamp: Utc::now(),
+            request_latencies: HashMap::new(),
+            cache_metrics: crate::monitoring::CacheMetrics {
+                hits: 90,
+                misses: 10,
+                hit_rate: 0.9, // above min_cache_hit_rate (0.8)
+                size_bytes: 1024,
+                item_count: 100,
+                evictions: 0,
+            },
+            container_metrics: Vec::new(),
+            system_resources: crate::monitoring::SystemResourceMetrics {
+                cpu_usage_percent: 10.0,
+                total_memory_bytes: 8000000000,
+                used_memory_bytes: 2000000000,
+                memory_usage_percent: 25.0,
+                available_disk_bytes: 100000000000,
+                total_disk_bytes: 200000000000,
+                disk_usage_percent: 50.0,
+                load_average: [0.5, 0.5, 0.5],
+            },
+            model_metrics: HashMap::new(),
+            error_metrics: crate::monitoring::ErrorMetrics {
+                total_errors: 0,
+                errors_by_type: HashMap::new(),
+                error_rate: 0.0, // below max_error_rate (0.05)
+                recent_errors: Vec::new(),
+            },
+        };
+
+        assert!(thresholds.min_cache_hit_rate <= 0.9);
+        assert!(thresholds.max_error_rate >= 0.0);
+
+        let trends = system.analyze_current_trends(&metrics).unwrap();
+        assert_eq!(trends.error_rate_trend, TrendDirection::Stable);
+        assert_eq!(trends.cache_performance_trend, TrendDirection::Stable);
+        assert_eq!(trends.performance_score, 100.0);
+    }
+
+    #[test]
+    fn test_alert_category_container_keyword() {
+        let system = ObservabilitySystem::new();
+        let alert = crate::monitoring::Alert {
+            id: "a1".to_string(),
+            title: "Test Alert".to_string(),
+            description: "desc".to_string(),
+            severity: AlertSeverity::Warning,
+            component: "container_service".to_string(),
+            timestamp: Utc::now(),
+            context: HashMap::new(),
+            acknowledged: false,
+        };
+        let category = system.determine_alert_category(&alert);
+        assert_eq!(category, AlertCategory::ContainerHealth);
+    }
+
+    #[test]
+    fn test_alert_category_model_keyword() {
+        let system = ObservabilitySystem::new();
+        let alert = crate::monitoring::Alert {
+            id: "a2".to_string(),
+            title: "Model Issue".to_string(),
+            description: "desc".to_string(),
+            severity: AlertSeverity::Warning,
+            component: "model_inference".to_string(),
+            timestamp: Utc::now(),
+            context: HashMap::new(),
+            acknowledged: false,
+        };
+        let category = system.determine_alert_category(&alert);
+        assert_eq!(category, AlertCategory::ModelQuality);
+    }
+
+    #[test]
+    fn test_alert_category_performance_keyword_in_title() {
+        let system = ObservabilitySystem::new();
+        let alert = crate::monitoring::Alert {
+            id: "a3".to_string(),
+            title: "Performance degradation detected".to_string(),
+            description: "desc".to_string(),
+            severity: AlertSeverity::Warning,
+            component: "api_gateway".to_string(),
+            timestamp: Utc::now(),
+            context: HashMap::new(),
+            acknowledged: false,
+        };
+        let category = system.determine_alert_category(&alert);
+        assert_eq!(category, AlertCategory::Performance);
+    }
+
+    #[test]
+    fn test_alert_category_resource_keyword_in_title() {
+        let system = ObservabilitySystem::new();
+        let alert = crate::monitoring::Alert {
+            id: "a4".to_string(),
+            title: "High resource usage".to_string(),
+            description: "desc".to_string(),
+            severity: AlertSeverity::Warning,
+            component: "scheduler".to_string(),
+            timestamp: Utc::now(),
+            context: HashMap::new(),
+            acknowledged: false,
+        };
+        let category = system.determine_alert_category(&alert);
+        assert_eq!(category, AlertCategory::Resources);
+    }
+
+    #[test]
+    fn test_alert_category_fallback_availability() {
+        let system = ObservabilitySystem::new();
+        let alert = crate::monitoring::Alert {
+            id: "a5".to_string(),
+            title: "Some other issue".to_string(),
+            description: "desc".to_string(),
+            severity: AlertSeverity::Warning,
+            component: "generic_service".to_string(),
+            timestamp: Utc::now(),
+            context: HashMap::new(),
+            acknowledged: false,
+        };
+        let category = system.determine_alert_category(&alert);
+        assert_eq!(category, AlertCategory::Availability);
+    }
+
+    #[test]
+    fn test_priority_score_critical_capped_at_100() {
+        let system = ObservabilitySystem::new();
+        let alert = crate::monitoring::Alert {
+            id: "p1".to_string(),
+            title: "Critical failure".to_string(),
+            description: "desc".to_string(),
+            severity: AlertSeverity::Critical,
+            component: "container_core".to_string(), // triggers +20
+            timestamp: Utc::now(),
+            context: HashMap::new(),
+            acknowledged: false,
+        };
+        let category = AlertCategory::ContainerHealth;
+        let score = system.calculate_priority_score(&alert, &category);
+        // Critical (100) + ContainerHealth (+20) = 120, capped at 100
+        assert_eq!(score, 100);
+    }
+
+    #[test]
+    fn test_priority_score_security_bonus() {
+        let system = ObservabilitySystem::new();
+        let alert = crate::monitoring::Alert {
+            id: "p2".to_string(),
+            title: "Security event".to_string(),
+            description: "desc".to_string(),
+            severity: AlertSeverity::Warning,
+            component: "auth_service".to_string(),
+            timestamp: Utc::now(),
+            context: HashMap::new(),
+            acknowledged: false,
+        };
+        let category = AlertCategory::Security;
+        let score = system.calculate_priority_score(&alert, &category);
+        // Warning (50) + Security (+30) = 80
+        assert_eq!(score, 80);
+    }
+
+    #[test]
+    fn test_priority_score_info_performance() {
+        let system = ObservabilitySystem::new();
+        let alert = crate::monitoring::Alert {
+            id: "p3".to_string(),
+            title: "Performance notice".to_string(),
+            description: "desc".to_string(),
+            severity: AlertSeverity::Info,
+            component: "metrics_collector".to_string(),
+            timestamp: Utc::now(),
+            context: HashMap::new(),
+            acknowledged: false,
+        };
+        let category = AlertCategory::Performance;
+        let score = system.calculate_priority_score(&alert, &category);
+        // Info (25) + Performance (+10) = 35
+        assert_eq!(score, 35);
+    }
+
+    #[test]
+    fn test_recommended_actions_container_health() {
+        let system = ObservabilitySystem::new();
+        let alert = crate::monitoring::Alert {
+            id: "r1".to_string(),
+            title: "Container down".to_string(),
+            description: "desc".to_string(),
+            severity: AlertSeverity::Error,
+            component: "container_service".to_string(),
+            timestamp: Utc::now(),
+            context: HashMap::new(),
+            acknowledged: false,
+        };
+        let actions = system.generate_recommended_actions(&alert, &AlertCategory::ContainerHealth);
+        assert!(!actions.is_empty());
+        // All container health recommendations should mention containers/logs
+        let joined = actions.join(" ").to_lowercase();
+        assert!(joined.contains("container"), "Should mention container");
+    }
+
+    #[test]
+    fn test_recommended_actions_model_quality() {
+        let system = ObservabilitySystem::new();
+        let alert = crate::monitoring::Alert {
+            id: "r2".to_string(),
+            title: "Model quality low".to_string(),
+            description: "desc".to_string(),
+            severity: AlertSeverity::Warning,
+            component: "model_service".to_string(),
+            timestamp: Utc::now(),
+            context: HashMap::new(),
+            acknowledged: false,
+        };
+        let actions = system.generate_recommended_actions(&alert, &AlertCategory::ModelQuality);
+        assert!(!actions.is_empty());
+        let joined = actions.join(" ").to_lowercase();
+        assert!(joined.contains("model"), "Should mention model");
+    }
+
+    #[test]
+    fn test_recommended_actions_performance() {
+        let system = ObservabilitySystem::new();
+        let alert = crate::monitoring::Alert {
+            id: "r3".to_string(),
+            title: "Performance degraded".to_string(),
+            description: "desc".to_string(),
+            severity: AlertSeverity::Warning,
+            component: "api".to_string(),
+            timestamp: Utc::now(),
+            context: HashMap::new(),
+            acknowledged: false,
+        };
+        let actions = system.generate_recommended_actions(&alert, &AlertCategory::Performance);
+        assert!(!actions.is_empty());
+    }
+
+    #[test]
+    fn test_recommended_actions_fallback() {
+        let system = ObservabilitySystem::new();
+        let alert = crate::monitoring::Alert {
+            id: "r4".to_string(),
+            title: "Some issue".to_string(),
+            description: "desc".to_string(),
+            severity: AlertSeverity::Info,
+            component: "other_service".to_string(),
+            timestamp: Utc::now(),
+            context: HashMap::new(),
+            acknowledged: false,
+        };
+        let actions = system.generate_recommended_actions(&alert, &AlertCategory::Availability);
+        assert!(!actions.is_empty(), "Should always return at least one action");
+    }
+
+    #[test]
+    fn test_sla_status_compliant() {
+        let compliance = SlaCompliance {
+            target_availability: 99.9,
+            current_availability: 99.95,
+            status: SlaStatus::Compliant,
+            time_to_breach: None,
+        };
+        assert_eq!(compliance.status, SlaStatus::Compliant);
+    }
+
+    #[test]
+    fn test_sla_status_at_risk() {
+        let compliance = SlaCompliance {
+            target_availability: 99.9,
+            current_availability: 99.5, // below 99.9 but above 99.0
+            status: SlaStatus::AtRisk,
+            time_to_breach: Some(Duration::from_secs(3600)),
+        };
+        assert_eq!(compliance.status, SlaStatus::AtRisk);
+        assert!(compliance.time_to_breach.is_some());
+    }
+
+    #[test]
+    fn test_sla_status_breached() {
+        let compliance = SlaCompliance {
+            target_availability: 99.9,
+            current_availability: 98.0, // below 99.0
+            status: SlaStatus::Breached,
+            time_to_breach: None,
+        };
+        assert_eq!(compliance.status, SlaStatus::Breached);
+    }
+
+    #[test]
+    fn test_calculate_availability_metrics_produces_valid_sla() {
+        let system = ObservabilitySystem::new();
+        let metrics = system.calculate_availability_metrics().unwrap();
+
+        // Availability is hardcoded at 99.5, which is below 99.9 but above 99.0 → AtRisk
+        assert_eq!(metrics.sla_compliance.status, SlaStatus::AtRisk);
+        assert_eq!(metrics.availability_percentage, 99.5);
+        assert_eq!(metrics.sla_compliance.target_availability, 99.9);
+        assert!(metrics.mtbf.is_some());
+        assert!(metrics.mttr.is_some());
+    }
+
+    #[test]
+    fn test_alert_policy_immediate_critical_has_console_channel() {
+        let policy = AlertPolicy::immediate_critical();
+        let console_channels: Vec<_> = policy
+            .notification_channels
+            .iter()
+            .filter(|ch| ch.channel_type == ChannelType::Console)
+            .collect();
+        assert!(!console_channels.is_empty(), "Should have a console channel");
+        assert_eq!(console_channels[0].min_severity, AlertSeverity::Info);
+    }
+
+    #[test]
+    fn test_alert_policy_balanced_has_grouping() {
+        let policy = AlertPolicy::balanced();
+        assert!(!policy.grouping_rules.is_empty());
+        let rule = &policy.grouping_rules[0];
+        assert!(!rule.name.is_empty());
+        assert!(!rule.group_by_fields.is_empty());
+        assert!(rule.max_alerts_per_group > 0);
+    }
+
+    #[test]
+    fn test_alert_policy_immediate_critical_escalation_times() {
+        let policy = AlertPolicy::immediate_critical();
+        let critical_rule = policy
+            .escalation_rules
+            .iter()
+            .find(|r| r.severity == AlertSeverity::Critical)
+            .expect("Should have a critical escalation rule");
+        // Critical alerts should escalate in 5 minutes
+        assert_eq!(critical_rule.escalation_time, Duration::from_secs(300));
+        assert_eq!(critical_rule.max_escalations, 3);
+        assert!(critical_rule.escalation_factor > 1.0);
+    }
+
+    #[test]
+    fn test_uptime_stats_struct() {
+        let stats = UptimeStats {
+            current_uptime: Duration::from_secs(3600),
+            average_uptime: Duration::from_secs(7200),
+            max_uptime: Duration::from_secs(86400),
+            min_uptime: Duration::ZERO,
+        };
+        assert!(stats.max_uptime > stats.current_uptime);
+        assert_eq!(stats.min_uptime, Duration::ZERO);
+    }
+
+    #[test]
+    fn test_escalation_status_variants_serialize() {
+        let statuses = [
+            EscalationStatus::New,
+            EscalationStatus::Escalated,
+            EscalationStatus::HighlyEscalated,
+            EscalationStatus::UnderInvestigation,
+            EscalationStatus::Resolved,
+        ];
+        for status in &statuses {
+            let json = serde_json::to_string(status).expect("should serialize");
+            let back: EscalationStatus = serde_json::from_str(&json).expect("should deserialize");
+            assert_eq!(status, &back);
+        }
+    }
+
+    #[test]
+    fn test_alert_category_variants_serialize() {
+        let categories = [
+            AlertCategory::Performance,
+            AlertCategory::Availability,
+            AlertCategory::Security,
+            AlertCategory::Resources,
+            AlertCategory::Configuration,
+            AlertCategory::ModelQuality,
+            AlertCategory::ContainerHealth,
+        ];
+        for cat in &categories {
+            let json = serde_json::to_string(cat).expect("should serialize");
+            let back: AlertCategory = serde_json::from_str(&json).expect("should deserialize");
+            assert_eq!(cat, &back);
+        }
+    }
+
+    #[test]
+    fn test_health_threshold_default_values() {
+        let t = HealthThreshold::default();
+        assert_eq!(t.cpu_threshold, 80.0);
+        assert_eq!(t.memory_threshold, 85.0);
+        assert_eq!(t.disk_threshold, 90.0);
+        assert_eq!(t.max_latency_ms, 2000);
+        assert_eq!(t.min_cache_hit_rate, 0.8);
+        assert_eq!(t.max_error_rate, 0.05);
+        assert_eq!(t.container_timeout, Duration::from_secs(30));
+    }
+
+    #[test]
+    fn test_observability_system_builder_pattern() {
+        let policy = AlertPolicy::immediate_critical();
+        let thresholds = HealthThreshold::default();
+        let system = ObservabilitySystem::new()
+            .with_service_name("my-service")
+            .with_alert_policy(policy)
+            .with_health_thresholds(thresholds)
+            .with_health_check_interval(Duration::from_secs(15));
+        assert_eq!(system.service_name, "my-service");
+        assert_eq!(system.health_check_interval, Duration::from_secs(15));
+    }
 }

--- a/harness/src/observability.rs
+++ b/harness/src/observability.rs
@@ -238,6 +238,23 @@ pub enum SlaStatus {
     Breached,
 }
 
+/// Derive an [`SlaStatus`] from an observed availability and a target.
+///
+/// Pure function so it can be tested independently of any system state:
+/// - `Compliant` when `availability >= target`
+/// - `AtRisk` when availability is within ~1 percentage point below target
+///   (i.e. `>= target - 0.9`), reflecting "below target but not yet breached"
+/// - `Breached` otherwise
+pub fn sla_status_for(availability: f64, target: f64) -> SlaStatus {
+    if availability >= target {
+        SlaStatus::Compliant
+    } else if availability >= target - 0.9 {
+        SlaStatus::AtRisk
+    } else {
+        SlaStatus::Breached
+    }
+}
+
 /// Uptime statistics
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UptimeStats {
@@ -827,6 +844,7 @@ impl ObservabilitySystem {
     fn calculate_availability_metrics(&self) -> Result<AvailabilityMetrics, ObservabilityError> {
         let uptime = self.start_time.elapsed();
         let availability = 99.5; // Would be calculated from actual downtime
+        let target = 99.9;
 
         Ok(AvailabilityMetrics {
             uptime,
@@ -834,15 +852,9 @@ impl ObservabilitySystem {
             mtbf: Some(Duration::from_secs(86400)), // 24 hours
             mttr: Some(Duration::from_secs(300)),   // 5 minutes
             sla_compliance: SlaCompliance {
-                target_availability: 99.9,
+                target_availability: target,
                 current_availability: availability,
-                status: if availability >= 99.9 {
-                    SlaStatus::Compliant
-                } else if availability >= 99.0 {
-                    SlaStatus::AtRisk
-                } else {
-                    SlaStatus::Breached
-                },
+                status: sla_status_for(availability, target),
                 time_to_breach: None,
             },
         })
@@ -1423,7 +1435,17 @@ mod tests {
             acknowledged: false,
         };
         let actions = system.generate_recommended_actions(&alert, &AlertCategory::Performance);
-        assert!(!actions.is_empty());
+        let joined = actions.join(" ").to_lowercase();
+        // Performance arm must surface its production-specific guidance, so a
+        // mistakenly-swapped match arm would change these strings and fail.
+        assert!(
+            joined.contains("resource"),
+            "Performance actions should mention resources, got: {joined}"
+        );
+        assert!(
+            joined.contains("scale"),
+            "Performance actions should mention scaling, got: {joined}"
+        );
     }
 
     #[test]
@@ -1440,44 +1462,59 @@ mod tests {
             acknowledged: false,
         };
         let actions = system.generate_recommended_actions(&alert, &AlertCategory::Availability);
+        let joined = actions.join(" ").to_lowercase();
+        // Fallback arm has its own distinct guidance ("investigate ...",
+        // "check system logs", "contact support"). Asserting on those strings
+        // catches a swap where another arm is returned by mistake.
         assert!(
-            !actions.is_empty(),
-            "Should always return at least one action"
+            joined.contains("investigate"),
+            "Fallback actions should mention investigating, got: {joined}"
+        );
+        assert!(
+            joined.contains("logs"),
+            "Fallback actions should mention checking logs, got: {joined}"
+        );
+        assert!(
+            joined.contains("support"),
+            "Fallback actions should mention support, got: {joined}"
         );
     }
 
     #[test]
-    fn test_sla_status_compliant() {
-        let compliance = SlaCompliance {
-            target_availability: 99.9,
-            current_availability: 99.95,
-            status: SlaStatus::Compliant,
-            time_to_breach: None,
-        };
-        assert_eq!(compliance.status, SlaStatus::Compliant);
+    fn test_sla_status_for_compliant_branch() {
+        // At-or-above target → Compliant.
+        assert_eq!(sla_status_for(99.95, 99.9), SlaStatus::Compliant);
+        assert_eq!(sla_status_for(100.0, 99.9), SlaStatus::Compliant);
+        // Boundary: exactly at target is Compliant (>=).
+        assert_eq!(sla_status_for(99.9, 99.9), SlaStatus::Compliant);
     }
 
     #[test]
-    fn test_sla_status_at_risk() {
-        let compliance = SlaCompliance {
-            target_availability: 99.9,
-            current_availability: 99.5, // below 99.9 but above 99.0
-            status: SlaStatus::AtRisk,
-            time_to_breach: Some(Duration::from_secs(3600)),
-        };
-        assert_eq!(compliance.status, SlaStatus::AtRisk);
-        assert!(compliance.time_to_breach.is_some());
+    fn test_sla_status_for_at_risk_branch() {
+        // Below target but within the 0.9-point at-risk window.
+        assert_eq!(sla_status_for(99.5, 99.9), SlaStatus::AtRisk);
+        // Just under target.
+        assert_eq!(sla_status_for(99.89, 99.9), SlaStatus::AtRisk);
+        // Boundary: at the at-risk floor (target - 0.9) is still AtRisk (>=).
+        assert_eq!(sla_status_for(99.0, 99.9), SlaStatus::AtRisk);
     }
 
     #[test]
-    fn test_sla_status_breached() {
-        let compliance = SlaCompliance {
-            target_availability: 99.9,
-            current_availability: 98.0, // below 99.0
-            status: SlaStatus::Breached,
-            time_to_breach: None,
-        };
-        assert_eq!(compliance.status, SlaStatus::Breached);
+    fn test_sla_status_for_breached_branch() {
+        // Below the at-risk floor → Breached.
+        assert_eq!(sla_status_for(98.0, 99.9), SlaStatus::Breached);
+        assert_eq!(sla_status_for(0.0, 99.9), SlaStatus::Breached);
+        // Just under the at-risk floor.
+        assert_eq!(sla_status_for(98.99, 99.9), SlaStatus::Breached);
+    }
+
+    #[test]
+    fn test_sla_status_for_works_with_other_targets() {
+        // Helper is parameterised on target, so it should classify correctly
+        // for SLOs other than 99.9 (e.g. 95% availability).
+        assert_eq!(sla_status_for(96.0, 95.0), SlaStatus::Compliant);
+        assert_eq!(sla_status_for(94.5, 95.0), SlaStatus::AtRisk);
+        assert_eq!(sla_status_for(90.0, 95.0), SlaStatus::Breached);
     }
 
     #[test]
@@ -1532,16 +1569,39 @@ mod tests {
         assert!(critical_rule.escalation_factor > 1.0);
     }
 
-    #[test]
-    fn test_uptime_stats_struct() {
-        let stats = UptimeStats {
-            current_uptime: Duration::from_secs(3600),
-            average_uptime: Duration::from_secs(7200),
-            max_uptime: Duration::from_secs(86400),
-            min_uptime: Duration::ZERO,
-        };
-        assert!(stats.max_uptime > stats.current_uptime);
-        assert_eq!(stats.min_uptime, Duration::ZERO);
+    #[tokio::test]
+    async fn test_get_container_summary_populates_uptime_stats() {
+        // Exercise the actual production call site that constructs UptimeStats
+        // (`get_container_summary`) and verify the invariants it must maintain:
+        // current/avg/max are all derived from `start_time.elapsed()` and
+        // therefore monotonically non-decreasing, and min_uptime is zero.
+        let system = ObservabilitySystem::new();
+        let summary = system
+            .get_container_summary()
+            .await
+            .expect("get_container_summary should succeed");
+
+        let stats = &summary.uptime_stats;
+        assert_eq!(
+            stats.min_uptime,
+            Duration::ZERO,
+            "min_uptime is initialised to zero in get_container_summary"
+        );
+        // current/average/max are all sampled from the same elapsed clock, so
+        // they must be equal-or-ordered (max >= average >= current sample
+        // ordering may flip by nanoseconds; just assert all are non-zero-ish
+        // bounded and non-decreasing relative to one another).
+        assert!(
+            stats.max_uptime >= stats.current_uptime,
+            "max_uptime ({:?}) must be >= current_uptime ({:?})",
+            stats.max_uptime,
+            stats.current_uptime
+        );
+        assert!(
+            stats.average_uptime >= stats.min_uptime,
+            "average_uptime ({:?}) must be >= min_uptime",
+            stats.average_uptime
+        );
     }
 
     #[test]

--- a/harness/src/telemetry.rs
+++ b/harness/src/telemetry.rs
@@ -1044,4 +1044,358 @@ mod tests {
             Some(&"Something went wrong".to_string())
         );
     }
+
+    #[test]
+    fn test_trace_context_with_attribute_builder() {
+        let trace = TraceContext::new("my_op")
+            .with_attribute("model", "qwen3")
+            .with_attribute("user", "alice");
+
+        assert_eq!(trace.attributes.get("model"), Some(&"qwen3".to_string()));
+        assert_eq!(trace.attributes.get("user"), Some(&"alice".to_string()));
+        assert_eq!(trace.operation_name, "my_op");
+        assert_eq!(trace.status, SpanStatus::InProgress);
+    }
+
+    #[test]
+    fn test_trace_context_set_status() {
+        let mut trace = TraceContext::new("op");
+        trace.set_status(SpanStatus::Cancelled);
+        assert_eq!(trace.status, SpanStatus::Cancelled);
+    }
+
+    #[test]
+    fn test_trace_context_set_status_timeout() {
+        let mut trace = TraceContext::new("op");
+        trace.set_status(SpanStatus::Timeout);
+        assert_eq!(trace.status, SpanStatus::Timeout);
+    }
+
+    #[test]
+    fn test_trace_context_finish_preserves_error_status() {
+        let mut trace = TraceContext::new("op");
+        trace.record_error("failed");
+        // Status is Error before finishing
+        assert_eq!(trace.status, SpanStatus::Error);
+        trace.finish();
+        // After finish, error status should remain (not overwritten by Ok)
+        assert_eq!(trace.status, SpanStatus::Error);
+        assert!(trace.end_time.is_some());
+        assert!(trace.duration.is_some());
+    }
+
+    #[test]
+    fn test_trace_context_serialization_roundtrip() {
+        let trace = TraceContext::new("serialize_test")
+            .with_attribute("key", "value");
+
+        let json = serde_json::to_string(&trace).expect("should serialize");
+        let back: TraceContext = serde_json::from_str(&json).expect("should deserialize");
+
+        assert_eq!(trace.operation_name, back.operation_name);
+        assert_eq!(trace.trace_id, back.trace_id);
+        assert_eq!(trace.span_id, back.span_id);
+        assert_eq!(trace.status, back.status);
+        assert_eq!(trace.attributes.get("key"), back.attributes.get("key"));
+    }
+
+    #[test]
+    fn test_child_span_shares_trace_id() {
+        let parent = TraceContext::new("parent_op");
+        let child = parent.create_child("child_op");
+
+        assert_eq!(parent.trace_id, child.trace_id);
+        assert_ne!(parent.span_id, child.span_id);
+        assert_eq!(child.parent_span_id, Some(parent.span_id.clone()));
+        assert_eq!(child.operation_name, "child_op");
+        assert_eq!(child.status, SpanStatus::InProgress);
+    }
+
+    #[test]
+    fn test_telemetry_config_default_values() {
+        let config = TelemetryConfig::default();
+        assert_eq!(config.service.name, "nanna-coder");
+        assert_eq!(config.service.version, "0.1.0");
+        assert_eq!(config.service.environment, "development");
+        assert!(config.enable_logging);
+        assert!(config.enable_tracing);
+        assert!(config.enable_metrics);
+        assert_eq!(config.log_level, "info");
+        assert_eq!(config.metrics_export_interval, Duration::from_secs(60));
+        assert_eq!(config.trace_sample_rate, 1.0);
+        assert!(config.export_endpoints.prometheus_endpoint.is_none());
+        assert!(config.export_endpoints.otlp_endpoint.is_none());
+        assert!(config.export_endpoints.webhook_endpoints.is_empty());
+    }
+
+    #[test]
+    fn test_telemetry_system_builder_sets_fields() {
+        let telemetry = TelemetrySystem::new()
+            .with_service_name("svc")
+            .with_version("2.0.0")
+            .with_environment("production")
+            .with_global_attribute("region", "us-east-1");
+
+        assert_eq!(telemetry.config.service.name, "svc");
+        assert_eq!(telemetry.config.service.version, "2.0.0");
+        assert_eq!(telemetry.config.service.environment, "production");
+        assert_eq!(
+            telemetry.config.global_attributes.get("region"),
+            Some(&"us-east-1".to_string())
+        );
+    }
+
+    #[test]
+    fn test_metric_type_variants_serde() {
+        let types = [
+            MetricType::Counter,
+            MetricType::Gauge,
+            MetricType::Histogram,
+            MetricType::Summary,
+        ];
+        for mt in &types {
+            let json = serde_json::to_string(mt).expect("serialize");
+            let back: MetricType = serde_json::from_str(&json).expect("deserialize");
+            assert_eq!(mt, &back);
+        }
+    }
+
+    #[test]
+    fn test_span_status_variants_serde() {
+        let statuses = [
+            SpanStatus::InProgress,
+            SpanStatus::Ok,
+            SpanStatus::Error,
+            SpanStatus::Cancelled,
+            SpanStatus::Timeout,
+        ];
+        for s in &statuses {
+            let json = serde_json::to_string(s).expect("serialize");
+            let back: SpanStatus = serde_json::from_str(&json).expect("deserialize");
+            assert_eq!(s, &back);
+        }
+    }
+
+    #[test]
+    fn test_prometheus_exporter_clear_buffer() {
+        let exporter = PrometheusExporter::new(None);
+        exporter.add_metric(MetricPoint {
+            name: "m1".to_string(),
+            metric_type: MetricType::Counter,
+            value: 1.0,
+            timestamp: Utc::now(),
+            labels: HashMap::new(),
+            unit: None,
+            description: None,
+        });
+        {
+            let buf = exporter.metrics_buffer.lock().unwrap();
+            assert_eq!(buf.len(), 1);
+        }
+        exporter.clear_buffer();
+        {
+            let buf = exporter.metrics_buffer.lock().unwrap();
+            assert_eq!(buf.len(), 0);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_prometheus_exporter_export_no_description() {
+        let exporter = PrometheusExporter::new(None);
+        exporter.add_metric(MetricPoint {
+            name: "no_desc".to_string(),
+            metric_type: MetricType::Gauge,
+            value: 7.5,
+            timestamp: Utc::now(),
+            labels: HashMap::new(),
+            unit: None,
+            description: None,
+        });
+        let output = exporter.export_prometheus().await.unwrap();
+        // No HELP line when description is absent
+        assert!(!output.contains("# HELP"));
+        assert!(output.contains("# TYPE no_desc gauge"));
+        assert!(output.contains("no_desc 7.5"));
+    }
+
+    #[tokio::test]
+    async fn test_prometheus_exporter_no_labels_no_braces() {
+        let exporter = PrometheusExporter::new(None);
+        exporter.add_metric(MetricPoint {
+            name: "plain_metric".to_string(),
+            metric_type: MetricType::Counter,
+            value: 42.0,
+            timestamp: Utc::now(),
+            labels: HashMap::new(),
+            unit: None,
+            description: None,
+        });
+        let output = exporter.export_prometheus().await.unwrap();
+        // Without labels, no curly braces in the metric line
+        assert!(!output.contains('{'));
+        assert!(output.contains("plain_metric 42"));
+    }
+
+    #[tokio::test]
+    async fn test_prometheus_exporter_health_check() {
+        let exporter = PrometheusExporter::new(None);
+        let result = exporter.health_check().await.unwrap();
+        assert!(result, "Prometheus exporter health check should return true");
+    }
+
+    #[test]
+    fn test_telemetry_system_record_event_stores_in_buffer() {
+        let telemetry = TelemetrySystem::new();
+        telemetry.record_event(
+            "test_event",
+            "testing",
+            serde_json::json!({"key": "value"}),
+        );
+        let events = telemetry.events_buffer.lock().unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].name, "test_event");
+        assert_eq!(events[0].category, "testing");
+        assert_eq!(events[0].data["key"], "value");
+    }
+
+    #[test]
+    fn test_telemetry_system_multiple_events() {
+        let telemetry = TelemetrySystem::new();
+        for i in 0..5 {
+            telemetry.record_event(
+                &format!("event_{}", i),
+                "batch",
+                serde_json::json!({"idx": i}),
+            );
+        }
+        let events = telemetry.events_buffer.lock().unwrap();
+        assert_eq!(events.len(), 5);
+    }
+
+    #[test]
+    fn test_start_trace_adds_service_attributes() {
+        let telemetry = TelemetrySystem::new()
+            .with_service_name("my-svc")
+            .with_version("1.2.3")
+            .with_environment("staging");
+
+        let trace = telemetry.start_trace("my_op");
+        assert_eq!(
+            trace.attributes.get("service.name"),
+            Some(&"my-svc".to_string())
+        );
+        assert_eq!(
+            trace.attributes.get("service.version"),
+            Some(&"1.2.3".to_string())
+        );
+        assert_eq!(
+            trace.attributes.get("service.environment"),
+            Some(&"staging".to_string())
+        );
+    }
+
+    #[test]
+    fn test_start_trace_includes_global_attributes() {
+        let telemetry = TelemetrySystem::new()
+            .with_global_attribute("datacenter", "us-west-2");
+
+        let trace = telemetry.start_trace("op");
+        assert_eq!(
+            trace.attributes.get("datacenter"),
+            Some(&"us-west-2".to_string())
+        );
+    }
+
+    #[test]
+    fn test_uptime_is_positive() {
+        let telemetry = TelemetrySystem::new();
+        let uptime = telemetry.get_uptime();
+        // Uptime should be very small (near zero) right after creation
+        assert!(uptime < Duration::from_secs(5));
+    }
+
+    #[tokio::test]
+    async fn test_trace_guard_auto_finishes_on_drop() {
+        let telemetry = TelemetrySystem::new();
+        assert_eq!(telemetry.get_active_trace_count(), 0);
+
+        {
+            let trace = telemetry.start_trace("guarded_op");
+            let _guard = TraceGuard::new(&telemetry, trace);
+            assert_eq!(telemetry.get_active_trace_count(), 1);
+        } // guard is dropped here, should finish the trace
+
+        assert_eq!(telemetry.get_active_trace_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_trace_guard_record_error() {
+        let telemetry = TelemetrySystem::new();
+        let trace = telemetry.start_trace("failing_op");
+        let mut guard = TraceGuard::new(&telemetry, trace);
+        guard.record_error("operation failed");
+
+        // Verify error was recorded on the inner trace
+        let inner = guard.trace().unwrap();
+        assert_eq!(inner.status, SpanStatus::Error);
+        assert_eq!(
+            inner.attributes.get("error"),
+            Some(&"operation failed".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn test_trace_guard_set_status() {
+        let telemetry = TelemetrySystem::new();
+        let trace = telemetry.start_trace("cancelled_op");
+        let mut guard = TraceGuard::new(&telemetry, trace);
+        guard.set_status(SpanStatus::Cancelled);
+
+        let inner = guard.trace().unwrap();
+        assert_eq!(inner.status, SpanStatus::Cancelled);
+    }
+
+    #[test]
+    fn test_custom_event_struct_fields() {
+        let event = CustomEvent {
+            name: "deploy".to_string(),
+            timestamp: Utc::now(),
+            category: "lifecycle".to_string(),
+            attributes: HashMap::from([("version".to_string(), "1.2.3".to_string())]),
+            data: serde_json::json!({"sha": "abc123"}),
+            trace_context: None,
+        };
+
+        let json = serde_json::to_string(&event).expect("serialize");
+        let back: CustomEvent = serde_json::from_str(&json).expect("deserialize");
+
+        assert_eq!(back.name, "deploy");
+        assert_eq!(back.category, "lifecycle");
+        assert_eq!(back.attributes.get("version"), Some(&"1.2.3".to_string()));
+        assert_eq!(back.data["sha"], "abc123");
+        assert!(back.trace_context.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_export_all_clears_buffers() {
+        let telemetry = TelemetrySystem::new();
+        telemetry.record_counter("c1", 1.0, vec![]);
+        telemetry.record_gauge("g1", 2.0, vec![]);
+        telemetry.record_event("e1", "cat", serde_json::json!({}));
+
+        assert_eq!(telemetry.get_buffered_metrics_count(), 2);
+        {
+            let events = telemetry.events_buffer.lock().unwrap();
+            assert_eq!(events.len(), 1);
+        }
+
+        // export_all should drain buffers (no exporters configured, so it just clears)
+        telemetry.export_all().await.unwrap();
+
+        assert_eq!(telemetry.get_buffered_metrics_count(), 0);
+        {
+            let events = telemetry.events_buffer.lock().unwrap();
+            assert_eq!(events.len(), 0);
+        }
+    }
 }

--- a/harness/src/telemetry.rs
+++ b/harness/src/telemetry.rs
@@ -1086,8 +1086,7 @@ mod tests {
 
     #[test]
     fn test_trace_context_serialization_roundtrip() {
-        let trace = TraceContext::new("serialize_test")
-            .with_attribute("key", "value");
+        let trace = TraceContext::new("serialize_test").with_attribute("key", "value");
 
         let json = serde_json::to_string(&trace).expect("should serialize");
         let back: TraceContext = serde_json::from_str(&json).expect("should deserialize");
@@ -1240,17 +1239,16 @@ mod tests {
     async fn test_prometheus_exporter_health_check() {
         let exporter = PrometheusExporter::new(None);
         let result = exporter.health_check().await.unwrap();
-        assert!(result, "Prometheus exporter health check should return true");
+        assert!(
+            result,
+            "Prometheus exporter health check should return true"
+        );
     }
 
     #[test]
     fn test_telemetry_system_record_event_stores_in_buffer() {
         let telemetry = TelemetrySystem::new();
-        telemetry.record_event(
-            "test_event",
-            "testing",
-            serde_json::json!({"key": "value"}),
-        );
+        telemetry.record_event("test_event", "testing", serde_json::json!({"key": "value"}));
         let events = telemetry.events_buffer.lock().unwrap();
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].name, "test_event");
@@ -1296,8 +1294,7 @@ mod tests {
 
     #[test]
     fn test_start_trace_includes_global_attributes() {
-        let telemetry = TelemetrySystem::new()
-            .with_global_attribute("datacenter", "us-west-2");
+        let telemetry = TelemetrySystem::new().with_global_attribute("datacenter", "us-west-2");
 
         let trace = telemetry.start_trace("op");
         assert_eq!(


### PR DESCRIPTION
## Summary

Identified and closed the largest unit test coverage gaps as measured by codecov / cargo-tarpaulin.

`harness/src/observability.rs` (35 KB, 5 → 32 tests) and `harness/src/telemetry.rs` (32 KB, 8 → 32 tests) were the two biggest files with sparse inline test coverage. A `test/types.rs` entity had no tests at all.

**59 new `#[cfg(test)]` unit tests** added across 3 files (440 → 499 passing).

## Changes

### `harness/src/observability.rs` (+27 tests)
Pure functions that were fully uncovered:
- `determine_alert_category` — all 5 routing paths (container, model, performance, resource, fallback)
- `calculate_priority_score` — critical cap at 100, security bonus, info+performance weighting
- `generate_recommended_actions` — per-category action generation
- `SlaStatus` logic via `calculate_availability_metrics`
- `EscalationStatus` and `AlertCategory` serde round-trips
- `HealthThreshold` default value assertions
- `AlertPolicy` structural validation (escalation times, channel types, grouping)
- `ObservabilitySystem` builder pattern and trend-direction degradation paths

### `harness/src/telemetry.rs` (+24 tests)
- `TraceContext`: builder chain, `set_status`, serialization round-trip, child span relationships, `finish()` preserves error status
- `TraceGuard` RAII: auto-finish on drop, `record_error`, `set_status`
- `TelemetryConfig` default values; `TelemetrySystem` builder
- `MetricType` and `SpanStatus` serde variant round-trips
- `PrometheusExporter`: buffer clearing, no-description output, no-label formatting, health check
- `export_all` buffer draining, global attribute propagation to traces

### `harness/src/entities/test/types.rs` (+8 tests)
First-ever test module for `TestEntity`: construction, serde round-trip, trait-object usage, unique ID generation.

## Test plan
- [ ] `cargo nextest run --workspace --lib --all-features` passes (499 tests green)
- [ ] CI passes on this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01KTC47SJvyUUxhjh66UU8LG)_