### PR TITLE
fix(nix): apply ollama overlay to the packages block (follow-up to #337)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -278,9 +278,18 @@
     {
       packages = nixpkgs.lib.genAttrs [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ] (system:
         let
+          # The container images defined in this block (ollamaImage,
+          # harnessImage, etc.) need the same ollama-overlay applied as
+          # the eachSystem block above, otherwise the registry-published
+          # ollama container ends up with the stale `pkgs.ollama` from
+          # the main nixpkgs pin (0.11.10, no Gemma 4 support).
+          ollamaPkgs = import nixpkgs-ollama { inherit system; config.allowUnfree = false; };
           pkgs = import nixpkgs {
             inherit system;
-            overlays = [ (import rust-overlay) ];
+            overlays = [
+              (import rust-overlay)
+              (final: prev: { ollama = ollamaPkgs.ollama; })
+            ];
             config.allowUnfree = false;
           };
           rustToolchain = pkgs.rust-bin.stable."1.87.0".default.override {


### PR DESCRIPTION
## Summary

Follow-up to #337. The overlay it added landed in the `eachSystem` `pkgs` binding, but `ollamaImage` itself lives in a separate `genAttrs` block (`flake.nix:~279`) with its own `pkgs` import that hadn't been updated. Net result: dev shell got ollama 0.21.1, but the **container** still bundled 0.11.10.

## Verified after #337 merge

```
$ podman pull ghcr.io/dominicburkart/nanna-coder/ollama:latest
$ podman run --rm --entrypoint '' .../ollama:latest /bin/ollama --version
client version is 0.11.10
```

Image config sha was unchanged from before #337 — `db1ba3f52bd8...` — meaning the rebuild produced bit-identical output because the actual `pkgs.ollama` going into the derivation was unchanged.

## Fix

Add the same `ollamaPkgs = import nixpkgs-ollama …` + overlay entry to the second `pkgs` binding at `flake.nix:281`. Both code paths now share the same overlay shape.

## Test plan

- [ ] CI green.
- [ ] After merge: `podman pull ghcr.io/dominicburkart/nanna-coder/ollama:latest` produces a *new* config sha and `ollama --version` reports 0.21.1.
- [ ] After merge: `curl https://raw.githubusercontent.com/DominicBurkart/nanna-coder/main/scripts/install.sh | bash` completes including the `gemma4:e4b` model pull (the original failure that motivated #337).