### PR TITLE
arch(harness/main): drop redundant create_tool_registry wrapper

### DIFF
--- a/harness/src/main.rs
+++ b/harness/src/main.rs
@@ -2,7 +2,7 @@ use clap::{Parser, Subcommand};
 use harness::entities::ast::WorkspaceScanner;
 use harness::entities::git::GitRepository;
 use harness::entities::{EntityStore, InMemoryEntityStore};
-use harness::tools::ToolRegistry;
+use harness::tools::{create_tool_registry, ToolRegistry};
 use model::prelude::*;
 use std::io::{self, Write};
 use tracing::{error, info};
@@ -152,10 +152,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     Ok(())
-}
-
-fn create_tool_registry(workspace_root: &std::path::Path) -> ToolRegistry {
-    harness::tools::create_tool_registry(workspace_root)
 }
 
 async fn initialize_workspace(workspace_root: &std::path::Path) -> InMemoryEntityStore {


### PR DESCRIPTION
## Summary

`harness/src/main.rs` defined a local `create_tool_registry` whose entire body was a single call to `harness::tools::create_tool_registry`. Import the canonical function directly and drop the wrapper.

Net: -4 lines, no behavior change.

## Test plan

- [x] `cargo build -p harness --bin harness` — clean
- [x] `cargo test -p harness --lib --bin harness` — 393 passed (the two `eval::swebench::tests::materialize_from_url_*` failures reproduce on `origin/main` and are pre-existing / unrelated to this change)
- [x] `cargo clippy -p harness --bin harness --lib -- -D warnings` — clean

https://claude.ai/code/session_011C3Q2no7XQp7MfxDcEEhDT

---
_Generated by [Claude Code](https://claude.ai/code/session_011C3Q2no7XQp7MfxDcEEhDT)_