### PR TITLE
cron(arch): drop unused extract_entity_ids RAG helper

### DIFF
--- a/harness/src/agent/rag.rs
+++ b/harness/src/agent/rag.rs
@@ -52,11 +52,6 @@ pub async fn query_entities(
     Ok(results)
 }
 
-/// Extract relevant entity IDs from query results
-pub fn extract_entity_ids(results: &[QueryResult]) -> Vec<String> {
-    results.iter().map(|r| r.entity_id.clone()).collect()
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -81,27 +76,6 @@ mod tests {
         // Query should find it via JSON text search
         let results = query_entities(&store, "Git", Some(10)).await.unwrap();
         assert!(!results.is_empty(), "Should find git entity");
-    }
-
-    #[tokio::test]
-    async fn test_extract_entity_ids() {
-        let results = vec![
-            QueryResult {
-                entity_id: "id1".to_string(),
-                entity_type: crate::entities::EntityType::Git,
-                relevance: 1.0,
-                snippet: None,
-            },
-            QueryResult {
-                entity_id: "id2".to_string(),
-                entity_type: crate::entities::EntityType::Git,
-                relevance: 0.8,
-                snippet: None,
-            },
-        ];
-
-        let ids = extract_entity_ids(&results);
-        assert_eq!(ids, vec!["id1", "id2"]);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

`harness::agent::rag::extract_entity_ids` was a public helper with no callers outside its own unit test (the only call sites were a test in the same module). Verified via:

```
grep -rn "extract_entity_ids" --include="*.rs"
```

Per `AGENTS.md` / `TESTING.md` ("Untested code is brittle. Harden it, don't bend it."), pruning a one-liner public wrapper is cleaner than carrying a test-only API.

## Changes

- Remove `extract_entity_ids` and its test from `harness/src/agent/rag.rs`.

## Verification

- `cargo check -p harness --all-features` passes.
- `cargo test -p harness --lib agent::rag` passes (3 tests, 0 failures).

https://claude.ai/code/session_014Wsc8JzCphZKZAtzDF4fuK

---
_Generated by [Claude Code](https://claude.ai/code/session_014Wsc8JzCphZKZAtzDF4fuK)_