### PR TITLE
cron(test): cover OllamaConfig::with_max_tokens and zero-max_tokens validate branch

### DIFF
--- a/model/src/config.rs
+++ b/model/src/config.rs
@@ -233,4 +233,21 @@ mod tests {
             deserialized.default_context_length
         );
     }
+
+    #[test]
+    fn test_with_max_tokens_sets_field_and_validates() {
+        let config = OllamaConfig::new().with_max_tokens(2048);
+        assert_eq!(config.default_max_tokens, Some(2048));
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn test_validate_rejects_zero_max_tokens() {
+        let config = OllamaConfig {
+            default_max_tokens: Some(0),
+            ..Default::default()
+        };
+        let err = config.validate().expect_err("zero max_tokens must error");
+        assert!(err.contains("Max tokens"));
+    }
 }


### PR DESCRIPTION
## Summary

`OllamaConfig::with_max_tokens` (`model/src/config.rs:50`) and the `Some(0)` arm of `OllamaConfig::validate` (`model/src/config.rs:72-76`) had no Rust unit-test coverage. Verified by `grep -n with_max_tokens model/src/**/*.rs model/tests/**/*.rs` — the only hit was the definition itself.

The project enforces 100% codecov patch coverage (`codecov.yml`), so every branch on touched files must be exercised. Added two minimal unit tests:

- `test_with_max_tokens_sets_field_and_validates` — exercises the builder and the happy `Some(n>0)` arm of `validate()`.
- `test_validate_rejects_zero_max_tokens` — exercises the `Some(0)` rejection path.

## Verification

- `cargo test -p model --lib config` passes: 9 tests, 0 failures (was 7).

## Files

- `model/src/config.rs:237-252` — two new `#[test]` functions appended to the existing `tests` module.

https://claude.ai/code/session_014Wsc8JzCphZKZAtzDF4fuK

---
_Generated by [Claude Code](https://claude.ai/code/session_014Wsc8JzCphZKZAtzDF4fuK)_