### PR TITLE
feat(install): WSL2 systemd-aware gate + portable install_smoke.sh (closes #326)

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -23,6 +23,14 @@
 #   --yes               Don't prompt; assume yes for sudo notices.
 #   --no-claude-mcp     Don't register nanna-coder as a Claude Code MCP server even
 #                       if a Claude Code config is detected.
+#   --force-wsl         On WSL2, proceed even if systemd is not detected as active.
+#                       Default behavior on WSL2: probe for systemd; if missing,
+#                       die with an actionable error pointing at /etc/wsl.conf.
+#                       Use this flag if you have a non-systemd workaround
+#                       (e.g. rootless podman with custom netns plumbing).
+#   --branch <name>     No-op accepted for compatibility with scripts/install.ps1,
+#                       which forwards its --Branch parameter to this script when
+#                       delegating into WSL2. Recorded in plan output for parity.
 #   -h, --help          Show this help.
 #
 # What this script does (in order):
@@ -48,6 +56,8 @@ NO_PULL=0
 DRY_RUN=0
 ASSUME_YES=0
 NO_CLAUDE_MCP=0
+FORCE_WSL=0
+BRANCH=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -62,7 +72,9 @@ while [[ $# -gt 0 ]]; do
     --ollama-image)    OLLAMA_IMAGE_OVERRIDE="$2"; shift 2;;
     --yes|-y)          ASSUME_YES=1; shift;;
     --no-claude-mcp)   NO_CLAUDE_MCP=1; shift;;
-    -h|--help)         sed -n '2,32p' "$0" 2>/dev/null || true; exit 0;;
+    --force-wsl)       FORCE_WSL=1; shift;;
+    --branch)          BRANCH="$2"; shift 2;;
+    -h|--help)         sed -n '2,40p' "$0" 2>/dev/null || true; exit 0;;
     *) echo "unknown flag: $1" >&2; exit 64;;
   esac
 done
@@ -89,38 +101,87 @@ notify_sudo() {
   # The wizard's plan + confirmation already covered the sudo step. Print
   # a short banner so the user knows this is the privileged moment, but
   # don't double-prompt; sudo itself will ask for the password.
-  printf '\n%s┌─ sudo step ─────────────────────────────────────%s\n' "$C_YELLOW$C_BOLD" "$C_RESET"
+  printf '\n%s┌─ sudo step ──────────────────────────────────%s\n' "$C_YELLOW$C_BOLD" "$C_RESET"
   printf '%s│%s component: %s\n' "$C_YELLOW" "$C_RESET" "$1"
   printf '%s│%s reason:    %s\n' "$C_YELLOW" "$C_RESET" "$2"
-  printf '%s└─────────────────────────────────────────────────%s\n\n' "$C_YELLOW" "$C_RESET"
+  printf '%s└───────────────────────────────────────────────%s\n\n' "$C_YELLOW" "$C_RESET"
 }
 
 have() { command -v "$1" >/dev/null 2>&1; }
 
 is_wsl() { [[ -r /proc/version ]] && grep -qiE 'microsoft|wsl' /proc/version; }
 
+# Probe whether systemd is the running PID-1 / active inside this WSL distro.
+# WSL2 only routes /run/netns bind mounts through podman's pod infra container
+# correctly when systemd is enabled (`[boot] systemd=true` in /etc/wsl.conf,
+# applied after `wsl --shutdown`). Without systemd, `podman pod create` fails
+# with "failed to bind mount ns at /run/netns/...: invalid argument".
+#
+# We accept any of:
+#   - PID 1's comm is "systemd" (most reliable signal)
+#   - `systemctl is-system-running` returns one of the live states
+#   - /run/systemd/system exists (tmpfs marker created by systemd at boot)
+is_wsl_systemd_active() {
+  if [[ -r /proc/1/comm ]] && grep -qx 'systemd' /proc/1/comm 2>/dev/null; then
+    return 0
+  fi
+  if have systemctl; then
+    local state
+    state="$(systemctl is-system-running 2>/dev/null || true)"
+    case "$state" in
+      running|degraded|starting|maintenance) return 0 ;;
+    esac
+  fi
+  [[ -d /run/systemd/system ]]
+}
+
 # ---------- OS detection ----------
 
+IS_WSL=no
 case "$(uname -s)" in
   Linux*)
+    OS=linux
     if is_wsl; then
-      cat >&2 <<'EOF'
-✗ WSL2 (Windows Subsystem for Linux) is not a supported install target for
-  scripts/install.sh.
+      IS_WSL=yes
+      if is_wsl_systemd_active; then
+        warn "WSL2 detected with systemd active — proceeding (experimental)."
+        warn "If \`podman pod create\` later fails with \"failed to bind mount ns\","
+        warn "the kernel does not expose /run/netns; fall back to scripts/install.ps1."
+      elif [[ $FORCE_WSL -eq 1 ]]; then
+        warn "WSL2 detected without systemd; --force-wsl set, proceeding anyway."
+        warn "Expect netns failures during pod creation if your distro lacks the"
+        warn "/run/netns bind-mount path that podman pod infra containers need."
+      else
+        cat >&2 <<'EOF'
+✗ WSL2 (Windows Subsystem for Linux) detected without systemd active.
 
-  The bash installer drives podman directly inside the host kernel, but
-  WSL2's kernel does not provide the network-namespace bind-mount path
-  (/run/netns/) that podman pod creation requires. You will get errors
-  such as:
+  The bash installer drives podman directly, and WSL2's default (non-systemd)
+  init does not provide the /run/netns bind-mount path that podman pod
+  infra containers require. Pod creation will fail with:
     failed to bind mount ns at /run/netns/...: invalid argument
 
-  Supported Windows install path: run scripts/install.ps1 from a Windows
-  PowerShell session, which sets up Podman Desktop / WSL with a
-  preconfigured environment. See README for details.
+  Two supported paths forward:
+
+  1. Enable systemd in this WSL distro (recommended):
+       sudo tee /etc/wsl.conf >/dev/null <<'CONF'
+       [boot]
+       systemd=true
+       CONF
+     Then from a Windows PowerShell:  wsl --shutdown
+     Reopen the WSL shell and re-run this installer. The check above will
+     pass once `systemctl is-system-running` reports a live state.
+
+  2. Use the Windows-native entry point: scripts/install.ps1 (run from a
+     Windows PowerShell session). It bootstraps WSL + this script with
+     systemd preconfigured. See README for details.
+
+  Override (advanced): re-run with --force-wsl if you have a non-systemd
+  workaround in place. Tracked in https://github.com/DominicBurkart/nanna-coder/issues/326.
 EOF
-      die "WSL2 detected; not supported by install.sh"
+        die "WSL2 without systemd; not supported by install.sh (see above for fix)"
+      fi
     fi
-    OS=linux ;;
+    ;;
   Darwin*) OS=macos ;;
   *) die "unsupported OS: $(uname -s). Linux and macOS only. (Windows: use scripts/install.ps1)" ;;
 esac
@@ -204,9 +265,13 @@ audit_system() {
 
 print_plan() {
   printf '\n%sNanna Coder installer%s\n' "$C_BOLD" "$C_RESET"
-  printf '  detected:       %s/%s\n' "$OS" "$ARCH"
+  printf '  detected:       %s/%s%s\n' "$OS" "$ARCH" \
+    "$([[ "$IS_WSL" == yes ]] && echo ' (WSL2)')"
   printf '  registry:       %s\n' "$REGISTRY"
   printf '  tag:            %s\n' "$TAG"
+  if [[ -n "$BRANCH" ]]; then
+    printf '  branch:         %s (informational; passed in by install.ps1)\n' "$BRANCH"
+  fi
   printf '  model:          %s%s\n' "$MODEL" \
     "$([[ $SKIP_MODEL_PULL -eq 1 ]] && echo ' (skipped)')"
   printf '  pod name:       %s\n' "$POD_NAME"

--- a/scripts/install_smoke.sh
+++ b/scripts/install_smoke.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# Portable smoke test for scripts/install.sh.
+#
+# Exercises install.sh's static surface (syntax, --help, --dry-run, OS
+# detection, WSL2 systemd-aware gate) without requiring podman, sudo, or
+# network access. Designed to run on:
+#   - Linux (bash 4+/5)
+#   - macOS (system /bin/bash 3.2)
+#   - WSL2 (any distro)
+#
+# CI uses this as the cheap, fast portable check. Full bring-up coverage
+# (image load → install.sh → ollama API) lives in install-test.yml.
+#
+# Exit codes:
+#   0  — all checks passed
+#   1  — at least one check failed (details printed inline)
+#   2  — invocation error (missing install.sh, etc.)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INSTALL_SH="$SCRIPT_DIR/install.sh"
+
+if [[ ! -f "$INSTALL_SH" ]]; then
+  printf 'install_smoke: %s not found\n' "$INSTALL_SH" >&2
+  exit 2
+fi
+
+PASSED=0
+FAILED=0
+FAILURES=""
+
+check() {
+  local name="$1"; shift
+  if "$@" >/dev/null 2>&1; then
+    printf '  [OK]   %s\n' "$name"
+    PASSED=$((PASSED + 1))
+  else
+    printf '  [FAIL] %s\n' "$name"
+    FAILED=$((FAILED + 1))
+    FAILURES="${FAILURES}${name}"$'\n'
+  fi
+}
+
+check_grep() {
+  local name="$1" pattern="$2"; shift 2
+  local out
+  if out="$("$@" 2>&1)" && printf '%s\n' "$out" | grep -qE "$pattern"; then
+    printf '  [OK]   %s\n' "$name"
+    PASSED=$((PASSED + 1))
+  else
+    printf '  [FAIL] %s (pattern: %s)\n' "$name" "$pattern"
+    FAILED=$((FAILED + 1))
+    FAILURES="${FAILURES}${name}"$'\n'
+  fi
+}
+
+printf 'install_smoke: %s\n' "$INSTALL_SH"
+printf '  bash:  %s\n' "$BASH_VERSION"
+printf '  os:    %s\n' "$(uname -s)"
+printf '\n'
+
+# --- 1. syntax ---
+# `bash -n` parses the script without executing. Catches accidental
+# bashisms broken on macOS bash 3.2 only if the parser itself is 3.2;
+# the CI matrix runs this on a real macOS runner so the actual 3.2
+# parser exercises the file.
+check "bash -n parse" bash -n "$INSTALL_SH"
+
+# --- 2. --help exits 0 ---
+# install.sh's --help slices the leading comment block via sed. Regression
+# guard: if the slice range drifts, --help silently empties out.
+check_grep "--help prints usage" "Nanna Coder one-line installer" \
+  bash "$INSTALL_SH" --help
+
+check_grep "--help mentions --skip-model-pull" "skip-model-pull" \
+  bash "$INSTALL_SH" --help
+
+check_grep "--help mentions --force-wsl" "force-wsl" \
+  bash "$INSTALL_SH" --help
+
+# --- 3. unknown flag rejection ---
+if bash "$INSTALL_SH" --no-such-flag-xyzzy >/dev/null 2>&1; then
+  printf '  [FAIL] %s\n' "unknown flag should fail"
+  FAILED=$((FAILED + 1))
+  FAILURES="${FAILURES}unknown flag should fail"$'\n'
+else
+  printf '  [OK]   %s\n' "unknown flag rejected"
+  PASSED=$((PASSED + 1))
+fi
+
+# --- 4. --branch flag accepted (no-op for parity with install.ps1) ---
+# install.ps1 forwards `--branch <name>` to install.sh when delegating into
+# WSL2; before issue #326 the bash side rejected it as "unknown flag" and
+# the entire WSL install path failed at flag-parse. Smoke that the flag is
+# now consumed silently. We pair it with --help so the test exits 0
+# without needing podman; flag-parse runs before --help is honored only
+# when the unknown flag would have come first, so we put --branch first.
+check_grep "--branch <name> accepted" "Nanna Coder one-line installer" \
+  bash "$INSTALL_SH" --branch some-feature-branch --help
+
+# --- 5. WSL2 systemd-aware gate ---
+# Direct-invoke is_wsl / is_wsl_systemd_active by sourcing the script up
+# to the OS-detection block. We can't easily source the whole file (it
+# runs side effects), so we grep the source instead — the assertions
+# below guard the structure that issue #326 codified.
+check_grep "is_wsl helper present"        "is_wsl\\(\\) \\{"               grep -F "is_wsl()"            "$INSTALL_SH"
+check_grep "is_wsl_systemd_active helper" "is_wsl_systemd_active\\(\\) \\{" grep -F "is_wsl_systemd_active()" "$INSTALL_SH"
+check_grep "FORCE_WSL flag wired"         "FORCE_WSL=1"                    grep -F "FORCE_WSL=1"         "$INSTALL_SH"
+check_grep "WSL systemd error mentions wsl.conf" "/etc/wsl.conf" grep -F "/etc/wsl.conf" "$INSTALL_SH"
+check_grep "WSL fallback points at install.ps1"  "install.ps1"   grep -F "install.ps1"   "$INSTALL_SH"
+
+# --- 6. shellcheck if available (informational on macOS) ---
+if command -v shellcheck >/dev/null 2>&1; then
+  check "shellcheck -x install.sh" shellcheck -x "$INSTALL_SH"
+else
+  printf '  [SKIP] shellcheck not installed\n'
+fi
+
+# --- 7. portability: no bash 4+ features in install.sh ---
+# Hard-fail patterns: `mapfile`, `readarray`, associative arrays
+# (`declare -A`), and `[[ -v VAR ]]` are bash 4+. macOS ships bash 3.2.
+if grep -nE 'mapfile|readarray|declare -A|\[\[ -v ' "$INSTALL_SH" >/dev/null 2>&1; then
+  printf '  [FAIL] install.sh uses bash 4+ features (mapfile/readarray/declare -A/[[ -v ]])\n'
+  grep -nE 'mapfile|readarray|declare -A|\[\[ -v ' "$INSTALL_SH" | sed 's/^/         /' >&2
+  FAILED=$((FAILED + 1))
+  FAILURES="${FAILURES}bash 4+ feature in install.sh"$'\n'
+else
+  printf '  [OK]   no bash 4+ features in install.sh (macOS bash 3.2 compatible)\n'
+  PASSED=$((PASSED + 1))
+fi
+
+printf '\n'
+printf 'install_smoke: %d passed, %d failed\n' "$PASSED" "$FAILED"
+if [[ $FAILED -gt 0 ]]; then
+  printf '\nfailed checks:\n%s\n' "$FAILURES" >&2
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Closes #326. Replaces the hard "WSL2 not supported" early-exit in `scripts/install.sh` with a systemd-aware gate, and adds a portable `scripts/install_smoke.sh` for fast static checks across Linux, macOS (bash 3.2), and WSL2.

## What ships

### `scripts/install.sh`

- **WSL2 systemd-aware gate.** New `is_wsl_systemd_active()` helper probes three signals (PID-1 comm == `systemd`, `systemctl is-system-running` returning a live state, presence of `/run/systemd/system`). Decision tree on WSL2:
  - **systemd active** → `warn` and proceed (experimental but functional; matches issue #326 path 4 "Document the systemd requirement and gate on it").
  - **no systemd + `--force-wsl`** → warn and proceed (escape hatch for power users with their own netns plumbing).
  - **no systemd, no override** → `die` with an actionable error block: an inline `/etc/wsl.conf` snippet, the `wsl --shutdown` instruction, and a pointer at `scripts/install.ps1` as the supported alternative. Replaces the prior `WSL2 detected; not supported` flat-out refusal.
- **`--force-wsl` flag.** Override switch for the systemd check.
- **`--branch <name>` flag.** Accepted as a no-op recorded in the plan output. `scripts/install.ps1` already forwards its `-Branch` parameter as `--branch <name>` when delegating into WSL2 (line 145 of install.ps1); before this change, install.sh's flag parser rejected the unknown flag with exit 64, so every install.ps1-driven WSL hand-off failed at flag-parse. Now silently consumed.
- **`IS_WSL` flag** surfaced in the audit; `print_plan()` now annotates the `detected:` line with `(WSL2)` and prints the `branch:` line when set.

### `scripts/install_smoke.sh` (new)

Portable, no-deps static smoke test for `install.sh`. Designed to run on:
- Linux (bash 4/5)
- macOS (system `/bin/bash` 3.2)
- WSL2 (any distro)

Covers 13 checks: `bash -n` parse, `--help` output structure, all flag parsing, unknown-flag rejection, `--branch` flag round-trip, WSL systemd-gate structural assertions, optional shellcheck, and a `grep` guard against `mapfile`/`readarray`/`declare -A`/`[[ -v ]]` (bash 4+ features that would break on macOS bash 3.2).

The smoke test passes 13/13 on the local sandbox (bash 5.2). It does not require podman/sudo/network and is suitable for the lint-tier of any future macOS CI lane (issue #327).

## Acceptance criteria mapping (#326)

| Criterion | Status |
|---|---|
| `bash scripts/install.sh` either works on WSL2 or `install.ps1` covers the full install on Windows | Partial: works on WSL2 *with systemd*; clear actionable fallback otherwise. |
| `windows-bringup` lane flips from "expected fail" to "must pass" | **Not in this PR** — workflow file changes need maintainer (token lacks `workflows` permission). See residual comment. |
| Gate logic carve-out removed | Not in this PR — same workflow-permission residual. |
| `is_wsl()` early-exit removed or relaxed to a systemd-only check | Done: `is_wsl()` retained, but the early-exit now only fires when systemd is absent and `--force-wsl` is not set. |

## Test plan

- [x] `bash -n scripts/install.sh` clean
- [x] `shellcheck -x scripts/install.sh` clean
- [x] `bash -n scripts/install_smoke.sh` clean
- [x] `shellcheck scripts/install_smoke.sh` clean
- [x] `bash scripts/install_smoke.sh` → 13/13 PASS on local Linux sandbox
- [ ] CI `linux-bringup` lane re-runs (no behavior change on Linux; should still pass)
- [ ] CI `windows-bringup` lane: with stock setup-wsl Ubuntu-24.04 (no systemd), the new die-message fires (still expected-fail, but with the new structured error). Maintainer can opt into the systemd-WSL flow by updating the lane to write `[boot] systemd=true` to `/etc/wsl.conf` then `wsl --shutdown` before running.
- [ ] Reviewer to spot-check the systemd-WSL2 path on a real systemd-enabled WSL distro.

## Residuals

- The `windows-bringup` lane's "expected to fail" gate logic in `.github/workflows/install-test.yml` (lines 312–329) still treats install.sh on WSL2 as a fail. To flip it to a real success path, the lane needs `[boot] systemd=true` in `/etc/wsl.conf` + `wsl --shutdown` before invoking install.sh. Workflow changes are out of scope for this PR (token lacks `workflows` permission). Maintainer follow-up.

job-id: cron-2026-05-07-QPJmn
oldest-issue-id: 326

---
_Generated by [Claude Code](https://claude.ai/code/session_016n1SSHTyeVW7nR9X39SYk7)_