### PR TITLE
test: cover observability private methods + monitoring/telemetry public API

### DIFF
--- a/harness/Cargo.toml
+++ b/harness/Cargo.toml
@@ -45,6 +45,7 @@ workspace = true
 futures = "0.3"
 serial_test = "3.4"
 tempfile = "3.0"
+serde_json = "1.0"
 criterion = { version = "0.5", default-features = false, features = ["cargo_bench_support"] }
 
 [[bench]]

--- a/harness/src/observability.rs
+++ b/harness/src/observability.rs
@@ -1097,4 +1097,199 @@ mod tests {
         let trends = system.analyze_current_trends(&metrics).unwrap();
         assert!(trends.performance_score >= 0.0 && trends.performance_score <= 100.0);
     }
+
+    #[tokio::test]
+    async fn test_determine_alert_category_container() {
+        let system = ObservabilitySystem::new();
+        let alert = crate::monitoring::Alert {
+            id: "test-1".to_string(),
+            title: "Container crash".to_string(),
+            description: "Container stopped unexpectedly".to_string(),
+            severity: AlertSeverity::Error,
+            component: "container:nanna-coder".to_string(),
+            timestamp: Utc::now(),
+            context: HashMap::new(),
+            acknowledged: false,
+        };
+        assert_eq!(
+            system.determine_alert_category(&alert),
+            AlertCategory::ContainerHealth
+        );
+    }
+
+    #[tokio::test]
+    async fn test_determine_alert_category_model() {
+        let system = ObservabilitySystem::new();
+        let alert = crate::monitoring::Alert {
+            id: "test-2".to_string(),
+            title: "Quality degraded".to_string(),
+            description: "Model quality below threshold".to_string(),
+            severity: AlertSeverity::Warning,
+            component: "model:qwen3".to_string(),
+            timestamp: Utc::now(),
+            context: HashMap::new(),
+            acknowledged: false,
+        };
+        assert_eq!(
+            system.determine_alert_category(&alert),
+            AlertCategory::ModelQuality
+        );
+    }
+
+    #[tokio::test]
+    async fn test_determine_alert_category_performance() {
+        let system = ObservabilitySystem::new();
+        let alert = crate::monitoring::Alert {
+            id: "test-3".to_string(),
+            title: "Performance degradation detected".to_string(),
+            description: "Latency increased 3x".to_string(),
+            severity: AlertSeverity::Warning,
+            component: "system".to_string(),
+            timestamp: Utc::now(),
+            context: HashMap::new(),
+            acknowledged: false,
+        };
+        assert_eq!(
+            system.determine_alert_category(&alert),
+            AlertCategory::Performance
+        );
+    }
+
+    #[tokio::test]
+    async fn test_determine_alert_category_availability_fallback() {
+        let system = ObservabilitySystem::new();
+        let alert = crate::monitoring::Alert {
+            id: "test-4".to_string(),
+            title: "Something is wrong".to_string(),
+            description: "Unknown issue".to_string(),
+            severity: AlertSeverity::Info,
+            component: "network".to_string(),
+            timestamp: Utc::now(),
+            context: HashMap::new(),
+            acknowledged: false,
+        };
+        assert_eq!(
+            system.determine_alert_category(&alert),
+            AlertCategory::Availability
+        );
+    }
+
+    #[tokio::test]
+    async fn test_calculate_priority_score_critical_capped() {
+        let system = ObservabilitySystem::new();
+        let alert = crate::monitoring::Alert {
+            id: "test-5".to_string(),
+            title: "Critical failure".to_string(),
+            description: "System down".to_string(),
+            severity: AlertSeverity::Critical,
+            component: "container:main".to_string(),
+            timestamp: Utc::now(),
+            context: HashMap::new(),
+            acknowledged: false,
+        };
+        // Critical(100) + ContainerHealth(+20) = 120, capped at 100
+        let score =
+            system.calculate_priority_score(&alert, &AlertCategory::ContainerHealth);
+        assert_eq!(score, 100);
+    }
+
+    #[tokio::test]
+    async fn test_calculate_priority_score_warning_performance() {
+        let system = ObservabilitySystem::new();
+        let alert = crate::monitoring::Alert {
+            id: "test-6".to_string(),
+            title: "Perf warning".to_string(),
+            description: "Slow response".to_string(),
+            severity: AlertSeverity::Warning,
+            component: "system".to_string(),
+            timestamp: Utc::now(),
+            context: HashMap::new(),
+            acknowledged: false,
+        };
+        // Warning(50) + Performance(+10) = 60
+        let score = system.calculate_priority_score(&alert, &AlertCategory::Performance);
+        assert_eq!(score, 60);
+    }
+
+    #[tokio::test]
+    async fn test_calculate_priority_score_info_availability() {
+        let system = ObservabilitySystem::new();
+        let alert = crate::monitoring::Alert {
+            id: "test-7".to_string(),
+            title: "Info alert".to_string(),
+            description: "FYI".to_string(),
+            severity: AlertSeverity::Info,
+            component: "api".to_string(),
+            timestamp: Utc::now(),
+            context: HashMap::new(),
+            acknowledged: false,
+        };
+        // Info(25) + Availability(+20) = 45
+        let score = system.calculate_priority_score(&alert, &AlertCategory::Availability);
+        assert_eq!(score, 45);
+    }
+
+    #[tokio::test]
+    async fn test_sla_compliance_at_risk() {
+        let system = ObservabilitySystem::new();
+        let metrics = system.calculate_availability_metrics().unwrap();
+        assert_eq!(metrics.sla_compliance.status, SlaStatus::AtRisk);
+        assert!(metrics.sla_compliance.current_availability < 99.9);
+        assert!(
+            (metrics.sla_compliance.target_availability - 99.9).abs() < f64::EPSILON
+        );
+    }
+
+    #[tokio::test]
+    async fn test_generate_recommended_actions_container() {
+        let system = ObservabilitySystem::new();
+        let alert = crate::monitoring::Alert {
+            id: "test-8".to_string(),
+            title: "Container issue".to_string(),
+            description: "".to_string(),
+            severity: AlertSeverity::Error,
+            component: "container:x".to_string(),
+            timestamp: Utc::now(),
+            context: HashMap::new(),
+            acknowledged: false,
+        };
+        let actions =
+            system.generate_recommended_actions(&alert, &AlertCategory::ContainerHealth);
+        assert!(!actions.is_empty());
+        assert!(actions.iter().any(|a| a.to_lowercase().contains("container")));
+    }
+
+    #[tokio::test]
+    async fn test_generate_recommended_actions_performance() {
+        let system = ObservabilitySystem::new();
+        let alert = crate::monitoring::Alert {
+            id: "test-9".to_string(),
+            title: "Slow response".to_string(),
+            description: "".to_string(),
+            severity: AlertSeverity::Warning,
+            component: "api".to_string(),
+            timestamp: Utc::now(),
+            context: HashMap::new(),
+            acknowledged: false,
+        };
+        let actions =
+            system.generate_recommended_actions(&alert, &AlertCategory::Performance);
+        assert!(!actions.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_health_threshold_defaults() {
+        let thresholds = HealthThreshold::default();
+        assert!((thresholds.cpu_threshold - 80.0).abs() < f64::EPSILON);
+        assert!((thresholds.memory_threshold - 85.0).abs() < f64::EPSILON);
+        assert!((thresholds.disk_threshold - 90.0).abs() < f64::EPSILON);
+        assert_eq!(thresholds.max_latency_ms, 2000);
+    }
+
+    #[tokio::test]
+    async fn test_alert_policy_balanced_has_grouping_rules() {
+        let policy = AlertPolicy::balanced();
+        assert!(!policy.grouping_rules.is_empty());
+        assert!(!policy.escalation_rules.is_empty());
+    }
 }

--- a/harness/tests/monitoring_unit_tests.rs
+++ b/harness/tests/monitoring_unit_tests.rs
@@ -1,0 +1,157 @@
+//! Unit tests for monitoring module public APIs
+
+use chrono::Utc;
+use harness::monitoring::{
+    AlertManager, AlertSeverity, AlertThresholds, DefaultAlertManager, DefaultHealthMonitor,
+    DefaultMetricsCollector, ErrorEvent, ErrorSeverity, HealthStatus, MetricsCollector,
+    MetricsFormat,
+};
+use std::time::Duration;
+
+#[tokio::test]
+async fn health_status_is_healthy() {
+    assert!(HealthStatus::Healthy.is_healthy());
+    assert!(!HealthStatus::Warning.is_healthy());
+    assert!(!HealthStatus::Degraded.is_healthy());
+    assert!(!HealthStatus::Unhealthy.is_healthy());
+    assert!(!HealthStatus::Unknown.is_healthy());
+}
+
+#[tokio::test]
+async fn health_status_requires_attention() {
+    assert!(!HealthStatus::Healthy.requires_attention());
+    assert!(HealthStatus::Warning.requires_attention());
+    assert!(HealthStatus::Degraded.requires_attention());
+    assert!(HealthStatus::Unhealthy.requires_attention());
+    assert!(!HealthStatus::Unknown.requires_attention());
+}
+
+#[tokio::test]
+async fn sequential_alert_ids() {
+    let manager = DefaultAlertManager::new();
+    let id1 = manager
+        .send_alert("Alert 1", "First alert", AlertSeverity::Info)
+        .await
+        .unwrap();
+    let id2 = manager
+        .send_alert("Alert 2", "Second alert", AlertSeverity::Info)
+        .await
+        .unwrap();
+    assert_eq!(id1, "alert_1");
+    assert_eq!(id2, "alert_2");
+}
+
+#[tokio::test]
+async fn reset_metrics_clears_state() {
+    let mut collector = DefaultMetricsCollector::new();
+    collector
+        .record_request_latency("svc", Duration::from_millis(50))
+        .await;
+    collector.record_cache_hit("k1").await;
+
+    let metrics_before = collector.get_current_metrics().await.unwrap();
+    assert!(!metrics_before.request_latencies.is_empty());
+    assert_eq!(metrics_before.cache_metrics.hits, 1);
+
+    collector.reset_metrics().await;
+
+    let metrics_after = collector.get_current_metrics().await.unwrap();
+    assert!(metrics_after.request_latencies.is_empty());
+    assert_eq!(metrics_after.cache_metrics.hits, 0);
+}
+
+#[tokio::test]
+async fn custom_metrics_format_returns_error() {
+    let collector = DefaultMetricsCollector::new();
+    let result = collector
+        .export_metrics(MetricsFormat::Custom("my-format".to_string()))
+        .await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn latency_statistics_correct() {
+    let mut collector = DefaultMetricsCollector::new();
+    for ms in [100u64, 200, 300] {
+        collector
+            .record_request_latency("svc", Duration::from_millis(ms))
+            .await;
+    }
+    let metrics = collector.get_current_metrics().await.unwrap();
+    let latency = &metrics.request_latencies["svc"];
+    assert_eq!(latency.request_count, 3);
+    assert!((latency.avg_latency_ms - 200.0).abs() < 1.0);
+    assert!((latency.min_latency_ms - 100.0).abs() < 1.0);
+    assert!((latency.max_latency_ms - 300.0).abs() < 1.0);
+}
+
+#[tokio::test]
+async fn acknowledge_nonexistent_alert_returns_error() {
+    let manager = DefaultAlertManager::new();
+    let result = manager.acknowledge_alert("alert_999").await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn alert_history_respects_limit() {
+    let manager = DefaultAlertManager::new();
+    for i in 0..5 {
+        manager
+            .send_alert(&format!("Alert {}", i), "desc", AlertSeverity::Info)
+            .await
+            .unwrap();
+    }
+    let history = manager.get_alert_history(3).await.unwrap();
+    assert_eq!(history.len(), 3);
+}
+
+#[tokio::test]
+async fn cache_hit_rate_zero_when_no_activity() {
+    let collector = DefaultMetricsCollector::new();
+    let metrics = collector.get_current_metrics().await.unwrap();
+    assert_eq!(metrics.cache_metrics.hit_rate, 0.0);
+    assert_eq!(metrics.cache_metrics.hits, 0);
+    assert_eq!(metrics.cache_metrics.misses, 0);
+}
+
+#[tokio::test]
+async fn alert_thresholds_default_values() {
+    let thresholds = AlertThresholds::default();
+    assert_eq!(thresholds.max_latency_ms, 5000);
+    assert!((thresholds.min_cache_hit_rate - 0.8).abs() < f64::EPSILON);
+    assert!((thresholds.max_error_rate - 0.05).abs() < f64::EPSILON);
+    assert!((thresholds.max_cpu_usage - 0.9).abs() < f64::EPSILON);
+}
+
+#[tokio::test]
+async fn model_health_check_returns_healthy() {
+    let monitor = DefaultHealthMonitor::new(Duration::from_secs(30));
+    let result = monitor.check_model_health("qwen3:0.6b").await.unwrap();
+    assert_eq!(result.status, HealthStatus::Healthy);
+    assert!(result.component.contains("model"));
+}
+
+#[tokio::test]
+async fn multiple_error_events_tracked() {
+    let mut collector = DefaultMetricsCollector::new();
+    let err1 = ErrorEvent {
+        timestamp: Utc::now(),
+        error_type: "network".to_string(),
+        message: "connection timeout".to_string(),
+        component: "http-client".to_string(),
+        severity: ErrorSeverity::Error,
+    };
+    let err2 = ErrorEvent {
+        timestamp: Utc::now(),
+        error_type: "network".to_string(),
+        message: "dns failure".to_string(),
+        component: "http-client".to_string(),
+        severity: ErrorSeverity::Warning,
+    };
+    collector.record_error(err1).await;
+    collector.record_error(err2).await;
+
+    let metrics = collector.get_current_metrics().await.unwrap();
+    assert_eq!(metrics.error_metrics.total_errors, 2);
+    assert_eq!(metrics.error_metrics.errors_by_type["network"], 2);
+}

--- a/harness/tests/telemetry_unit_tests.rs
+++ b/harness/tests/telemetry_unit_tests.rs
@@ -1,0 +1,213 @@
+//! Unit tests for telemetry module public APIs
+
+use chrono::Utc;
+use harness::telemetry::{
+    CustomEvent, MetricPoint, MetricType, PrometheusExporter, SpanStatus, TelemetryExporter,
+    TelemetrySystem, TraceContext, TraceGuard,
+};
+use std::collections::HashMap;
+use std::time::Duration;
+
+#[tokio::test]
+async fn trace_context_with_attribute_builder() {
+    let trace = TraceContext::new("test_op")
+        .with_attribute("key1", "value1")
+        .with_attribute("key2", "value2");
+    assert_eq!(
+        trace.attributes.get("key1").map(String::as_str),
+        Some("value1")
+    );
+    assert_eq!(
+        trace.attributes.get("key2").map(String::as_str),
+        Some("value2")
+    );
+}
+
+#[tokio::test]
+async fn trace_context_set_status() {
+    let mut trace = TraceContext::new("test_op");
+    trace.set_status(SpanStatus::Cancelled);
+    assert_eq!(trace.status, SpanStatus::Cancelled);
+}
+
+#[tokio::test]
+async fn trace_context_record_error_sets_error_status() {
+    let mut trace = TraceContext::new("test_op");
+    trace.record_error("something broke");
+    assert_eq!(trace.status, SpanStatus::Error);
+    assert_eq!(
+        trace.attributes.get("error").map(String::as_str),
+        Some("something broke")
+    );
+}
+
+#[tokio::test]
+async fn trace_context_finish_preserves_error_status() {
+    let mut trace = TraceContext::new("test_op");
+    trace.record_error("pre-existing error");
+    trace.finish();
+    assert_eq!(trace.status, SpanStatus::Error);
+    assert!(trace.end_time.is_some());
+    assert!(trace.duration.is_some());
+}
+
+#[tokio::test]
+async fn prometheus_exporter_clear_buffer() {
+    let exporter = PrometheusExporter::new(None);
+    let metric = MetricPoint {
+        name: "test_metric".to_string(),
+        metric_type: MetricType::Counter,
+        value: 1.0,
+        timestamp: Utc::now(),
+        labels: HashMap::new(),
+        unit: None,
+        description: None,
+    };
+    exporter.add_metric(metric);
+
+    let output = exporter.export_prometheus().await.unwrap();
+    assert!(!output.is_empty());
+
+    exporter.clear_buffer();
+
+    let output_after_clear = exporter.export_prometheus().await.unwrap();
+    assert!(output_after_clear.is_empty());
+}
+
+#[tokio::test]
+async fn export_traces_adds_finished_trace_to_buffer() {
+    let exporter = PrometheusExporter::new(None);
+    let mut trace = TraceContext::new("my_op");
+    trace.finish();
+
+    exporter.export_traces(vec![trace]).await.unwrap();
+
+    let output = exporter.export_prometheus().await.unwrap();
+    assert!(output.contains("trace_duration_seconds"));
+}
+
+#[tokio::test]
+async fn export_traces_skips_unfinished_traces() {
+    let exporter = PrometheusExporter::new(None);
+    let trace = TraceContext::new("my_op"); // not finished
+    exporter.export_traces(vec![trace]).await.unwrap();
+
+    let output = exporter.export_prometheus().await.unwrap();
+    assert!(output.is_empty());
+}
+
+#[tokio::test]
+async fn export_events_creates_counter_metric() {
+    let exporter = PrometheusExporter::new(None);
+    let event = CustomEvent {
+        name: "user_action".to_string(),
+        timestamp: Utc::now(),
+        category: "ui".to_string(),
+        attributes: HashMap::new(),
+        data: serde_json::Value::Null,
+        trace_context: None,
+    };
+
+    exporter.export_events(vec![event]).await.unwrap();
+
+    let output = exporter.export_prometheus().await.unwrap();
+    assert!(output.contains("custom_events_total"));
+}
+
+#[tokio::test]
+async fn global_attributes_appear_in_trace() {
+    let telemetry = TelemetrySystem::new()
+        .with_global_attribute("env", "test")
+        .with_global_attribute("region", "us-east-1");
+
+    let trace = telemetry.start_trace("op");
+    assert_eq!(
+        trace.attributes.get("env").map(String::as_str),
+        Some("test")
+    );
+    assert_eq!(
+        trace.attributes.get("region").map(String::as_str),
+        Some("us-east-1")
+    );
+    telemetry.finish_trace(trace);
+}
+
+#[tokio::test]
+async fn service_info_embedded_in_traces() {
+    let telemetry = TelemetrySystem::new()
+        .with_service_name("my-service")
+        .with_version("2.0.0")
+        .with_environment("staging");
+
+    let trace = telemetry.start_trace("op");
+    assert_eq!(
+        trace.attributes.get("service.name").map(String::as_str),
+        Some("my-service")
+    );
+    assert_eq!(
+        trace.attributes.get("service.version").map(String::as_str),
+        Some("2.0.0")
+    );
+    assert_eq!(
+        trace
+            .attributes
+            .get("service.environment")
+            .map(String::as_str),
+        Some("staging")
+    );
+    telemetry.finish_trace(trace);
+}
+
+#[tokio::test]
+async fn trace_guard_drop_finishes_trace() {
+    let telemetry = TelemetrySystem::new();
+    assert_eq!(telemetry.get_active_trace_count(), 0);
+
+    {
+        let trace = telemetry.start_trace("guarded_op");
+        assert_eq!(telemetry.get_active_trace_count(), 1);
+        let _guard = TraceGuard::new(&telemetry, trace);
+        // _guard dropped here at end of block
+    }
+
+    assert_eq!(telemetry.get_active_trace_count(), 0);
+}
+
+#[tokio::test]
+async fn prometheus_exporter_health_check() {
+    let exporter = PrometheusExporter::new(None);
+    let result = exporter.health_check().await.unwrap();
+    assert!(result);
+}
+
+#[tokio::test]
+async fn metric_type_format_strings() {
+    let exporter = PrometheusExporter::new(None);
+
+    let cases: &[(MetricType, &str)] = &[
+        (MetricType::Counter, "counter"),
+        (MetricType::Gauge, "gauge"),
+        (MetricType::Histogram, "histogram"),
+        (MetricType::Summary, "summary"),
+    ];
+
+    for (metric_type, expected) in cases {
+        exporter.clear_buffer();
+        let metric = MetricPoint {
+            name: "type_test".to_string(),
+            metric_type: metric_type.clone(),
+            value: 1.0,
+            timestamp: Utc::now(),
+            labels: HashMap::new(),
+            unit: None,
+            description: None,
+        };
+        exporter.add_metric(metric);
+        let output = exporter.export_prometheus().await.unwrap();
+        assert!(
+            output.contains(&format!("# TYPE type_test {}", expected)),
+            "expected TYPE line for {}",
+            expected
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Expands harness test coverage across three modules, targeting the largest gaps identified by codecov:

### `harness/src/observability.rs` — 11 new `#[cfg(test)]` unit tests
The existing tests called `get_comprehensive_status()` with no active alerts, so `enhance_alerts([])` iterated over nothing — leaving `determine_alert_category`, `calculate_priority_score`, and `generate_recommended_actions` as dead code from coverage's perspective. New tests exercise:
- `determine_alert_category` for all four branches (`container`, `model`, performance title, fallback Availability)
- `calculate_priority_score` for Critical+ContainerHealth (capped at 100), Warning+Performance (60), Info+Availability (45)
- `calculate_availability_metrics` — asserts `SlaStatus::AtRisk` and correct target (99.9%)
- `generate_recommended_actions` for ContainerHealth and Performance categories
- `HealthThreshold::default()` field values, `AlertPolicy::balanced()` grouping rules

### `harness/tests/monitoring_unit_tests.rs` — 12 new integration tests
Covers public API surface not exercised by existing unit tests:
- `HealthStatus::is_healthy()` and `requires_attention()` for all variants
- Sequential alert ID generation (`alert_1`, `alert_2`, …)
- `reset_metrics()` clears all counters
- `MetricsFormat::Custom` returns error
- Latency statistics (avg, min, max)
- Acknowledging a nonexistent alert returns error
- `get_alert_history(limit)` respects the limit
- Zero cache hit rate on fresh collector
- `AlertThresholds::default()` field values
- `check_model_health` returns Healthy
- Multiple errors aggregated by type

### `harness/tests/telemetry_unit_tests.rs` — 13 new integration tests
Covers public API surface not exercised by existing unit tests:
- `TraceContext::with_attribute()` builder chain
- `set_status()` and `record_error()` mutations
- `finish()` preserves Error status (vs. overwriting to Ok)
- `PrometheusExporter::clear_buffer()`
- `export_traces()` only emits metrics for finished traces
- `export_events()` creates `custom_events_total` counter
- Global attributes from `with_global_attribute()` appear in traces
- Service info (`service.name`, `service.version`, `service.environment`) embedded in traces
- `TraceGuard` drop removes trace from active set
- `PrometheusExporter::health_check()` returns true
- Metric type strings (`counter`, `gauge`, `histogram`, `summary`)

### `harness/Cargo.toml`
Added `serde_json = "1.0"` to `[dev-dependencies]` so integration test files can use `serde_json::Value` directly.

## Test plan
- [ ] `cargo nextest run --workspace --lib --all-features` passes (unit tests)
- [ ] `cargo nextest run --workspace --test '*' --all-features` passes (integration tests)
- [ ] codecov delta shows increased coverage for `observability.rs`, `monitoring.rs`, `telemetry.rs`


---
_Generated by [Claude Code](https://claude.ai/code/session_01CzzytFc7uSgKLfQMQzTnGo)_