### PR TITLE
arch(harness): drop unused AgentComponent re-export

### DIFF
--- a/harness/src/lib.rs
+++ b/harness/src/lib.rs
@@ -38,8 +38,7 @@ pub use tools::{
 
 // Export agent types
 pub use agent::{
-    AgentComponent, AgentConfig, AgentContext, AgentError, AgentLoop, AgentResult, AgentRunResult,
-    AgentState,
+    AgentConfig, AgentContext, AgentError, AgentLoop, AgentResult, AgentRunResult, AgentState,
 };
 
 // Export eval types


### PR DESCRIPTION
## Summary

Removes `AgentComponent` from the public re-export list in `harness/src/lib.rs`.

## Why

`AgentComponent` is dead architectural surface:

- The trait is defined in `harness/src/agent/mod.rs:1158` with three methods (`initialize` / `process` / `cleanup`).
- It has **zero implementations** anywhere in the workspace (no `impl AgentComponent for ...`, no `dyn AgentComponent`, no `: AgentComponent` bound).
- Its only references are the trait body itself and the `pub use agent::{ AgentComponent, ... }` re-export this PR drops.

ARCHITECTURE.md's "Harness Control Flow" describes the agent as a single state machine: `EnrichingEntities` → `PlanningEntityModification` → `PerformingEntityModification` → `UpdatingEntities` → `CheckingTaskCompletion` → (`Completed` | `EntityModificationDecision`). The implementation in `AgentLoop` (`harness/src/agent/mod.rs`) follows this flow directly without any componentization layer. `AgentComponent` is a parallel "process(state)" abstraction that was never wired in and that the architecture diagram does not call for.

Per AGENTS.md guidance, untestable / orphan abstractions that don't match the documented control flow should not be carried in the API surface.

## Scope

This PR is intentionally narrow: it only drops the **public re-export** so `harness::AgentComponent` no longer leaks the dead symbol. Removing the trait body itself in `harness/src/agent/mod.rs` is the obvious follow-up (a 12-line deletion), kept out of this commit so the diff is reviewable as a single re-export change.

## Test plan

- [x] `cargo build --workspace` — clean
- [x] `cargo clippy --workspace --tests` — clean
- [x] `cargo test --workspace --lib` — same baseline as `main` (415 passing; 2 pre-existing swebench tests fail in this sandbox because commit signing is enforced; 1 ignored)
- [ ] CI green on the PR

https://claude.ai/code/session_014QXNr53WUnK5g2bLJkyE5E

---
_Generated by [Claude Code](https://claude.ai/code/session_014QXNr53WUnK5g2bLJkyE5E)_