### PR TITLE
arch(onboarding): drop dead ensure_dev_container helper

### DIFF
--- a/harness/src/onboarding/mod.rs
+++ b/harness/src/onboarding/mod.rs
@@ -85,16 +85,6 @@ impl Onboarder for DeterministicOnboarder {
     }
 }
 
-pub async fn ensure_dev_container(
-    source: &Path,
-    onboarder: &dyn Onboarder,
-) -> Result<PathBuf, OnboardingError> {
-    if !source.join("flake.nix").exists() {
-        onboarder.onboard(source).await?;
-    }
-    image_builder::build_dev_container(source).map_err(Into::into)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -155,22 +145,5 @@ edition = "2021"
         assert!(result.flake_path.ends_with("flake.nix"));
         let written = fs::read_to_string(&result.flake_path).unwrap();
         assert_eq!(written, result.flake_content);
-    }
-
-    #[tokio::test]
-    async fn ensure_dev_container_skips_onboarding_when_flake_exists() {
-        let dir = TempDir::new().unwrap();
-        write_file(&dir, "flake.nix", "{}");
-
-        struct NeverOnboarder;
-        #[async_trait]
-        impl Onboarder for NeverOnboarder {
-            async fn onboard(&self, _: &Path) -> Result<OnboardingResult, OnboardingError> {
-                panic!("onboard should not be called when flake.nix exists");
-            }
-        }
-
-        let result = ensure_dev_container(dir.path(), &NeverOnboarder).await;
-        assert!(result.is_err());
     }
 }


### PR DESCRIPTION
## Summary

Drop the `ensure_dev_container` helper and its sole test from `harness/src/onboarding/mod.rs`.

## Why

`ensure_dev_container` is dead code:

- The MCP `onboard_repo` handler calls `Onboarder::onboard` directly (`harness/src/mcp/handlers.rs:201`).
- The task scheduler in `harness/src/task.rs:192` calls `image_builder::build_dev_container` directly.
- No other code path uses `ensure_dev_container`. The only reference is the helper's own test.

```text
$ rg 'ensure_dev_container'
harness/src/onboarding/mod.rs: pub async fn ensure_dev_container(
harness/src/onboarding/mod.rs:     async fn ensure_dev_container_skips_onboarding_when_flake_exists() {
harness/src/onboarding/mod.rs:         let result = ensure_dev_container(dir.path(), &NeverOnboarder).await;
```

ARCHITECTURE.md's Container Topology shows `Harness Container -- Modifies --> Dev Container`, and the `onboard_repo` MCP tool is documented as "register a new repository with Nanna (clone, index entities, and prepare a reusable worktree pool)". The two responsibilities `ensure_dev_container` conflated — onboarding (writing a `flake.nix`) and building a dev container — are already exposed individually by `Onboarder::onboard` and `image_builder::build_dev_container`, and that is the surface the actual call sites use. The helper's "skip onboarding if flake.nix already exists" behavior is also a duplicate: `Onboarder::onboard` itself returns `OnboardingError::AlreadyOnboarded` in that case.

Per AGENTS.md guidance, dead helpers that no production code path exercises should be removed rather than carried.

## Change

Delete:

- `pub async fn ensure_dev_container(...)` in `harness/src/onboarding/mod.rs`
- `#[tokio::test] ensure_dev_container_skips_onboarding_when_flake_exists` (the only test, which exercises the deleted helper)

No other source files reference the helper, so no other edits are needed.

## Test plan

- [x] `cargo build --workspace` — clean
- [x] `cargo clippy --workspace --tests` — clean
- [x] `cargo test --workspace --lib` — 414 passing (vs 415 on `main`); the only delta is the deleted test. Same 2 pre-existing swebench tests fail in this sandbox because commit signing is enforced; 1 ignored.
- [ ] CI green on the PR

https://claude.ai/code/session_014QXNr53WUnK5g2bLJkyE5E

---
_Generated by [Claude Code](https://claude.ai/code/session_014QXNr53WUnK5g2bLJkyE5E)_