### PR TITLE
feat(score): canonicalize verify_dir + complete-only scorecard append

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,13 @@ result-*
 # produced on demand by `harness::eval::swebench::materialize`. Only the
 # `task.toml` files under swebench-*/ are checked in.
 evals/cases/swebench-*/repo/
+
+# `harness-score` per-run state (cloned repos, predictions, per-instance
+# state files, upstream report.json trees). Only the aggregated scorecard
+# at evals/scorecards/index.jsonl is checked in.
+evals/scorecards/state/
+
+# Locally-exported SWE-bench datasets. Pulled on demand from HuggingFace
+# via `~/.venvs/swebench/bin/python -c 'datasets.load_dataset(...)'`.
+evals/datasets/swebench-lite.jsonl
+evals/datasets/swebench-verified.jsonl

--- a/harness/src/bin/score.rs
+++ b/harness/src/bin/score.rs
@@ -250,6 +250,16 @@ async fn finalize(args: &Args, model: &str, run_id: &str) -> ExitCode {
             eprintln!("::error::failed to create verify dir: {e}");
             return ExitCode::from(2);
         }
+        // Canonicalise: the upstream Python harness sets its CWD to
+        // `work_dir` and then re-opens the predictions path relative to
+        // that CWD. If we pass a relative path, it double-nests.
+        let verify_dir = match verify_dir.canonicalize() {
+            Ok(p) => p,
+            Err(e) => {
+                eprintln!("::error::failed to canonicalize verify dir: {e}");
+                return ExitCode::from(2);
+            }
+        };
         let verify_config = VerifyConfig {
             dataset_name: args.dataset_name.clone(),
             model_name_or_path: format!("nanna__{}", sanitize_model_for_path(model)),
@@ -328,17 +338,22 @@ async fn finalize(args: &Args, model: &str, run_id: &str) -> ExitCode {
         }
     };
 
-    let index_path = std::path::Path::new("evals/scorecards/index.jsonl");
-    if let Err(e) = append_line(index_path, &line) {
-        eprintln!("::error::failed to append scorecard: {e}");
-        return ExitCode::from(2);
-    }
+    let appended = if card.is_complete {
+        let index_path = std::path::Path::new("evals/scorecards/index.jsonl");
+        if let Err(e) = append_line(index_path, &line) {
+            eprintln!("::error::failed to append scorecard: {e}");
+            return ExitCode::from(2);
+        }
+        true
+    } else {
+        false
+    };
 
-    print_summary(&card);
+    print_summary(&card, appended);
     ExitCode::SUCCESS
 }
 
-fn print_summary(card: &Scorecard) {
+fn print_summary(card: &Scorecard, appended: bool) {
     println!();
     println!("=== Scorecard ===");
     println!("dataset:    {}", card.dataset);
@@ -353,5 +368,15 @@ fn print_summary(card: &Scorecard) {
         card.is_complete
     );
     println!("commit:     {}", card.commit);
-    println!("appended to evals/scorecards/index.jsonl");
+    if appended {
+        println!("appended to evals/scorecards/index.jsonl");
+    } else {
+        println!(
+            "NOT appended to evals/scorecards/index.jsonl — \
+             {}/{} instances attempted; only full-dataset runs are \
+             leaderboard-comparable. Re-run without --max-instances \
+             until every instance reaches a terminal status, then re-finalize.",
+            card.instances_attempted, card.instances_total
+        );
+    }
 }


### PR DESCRIPTION
## Summary
Two related fixes to `harness-score` so the scorecard machinery survives real use, plus a couple of `.gitignore` entries:

1. **Canonicalise `verify_dir`** before handing it to the upstream Python harness. The harness sets its CWD to `verify_dir` and re-opens the predictions path relative to that CWD; with a relative input the path double-nests and the harness errors with `FileNotFoundError`. Caught attempting the first real finalize against `evals/scorecards/state/local-1`.

2. **Append the scorecard line iff `is_complete`.** Partial subdivisions of a curated leaderboard slice (Lite, Verified, ...) aren't comparable to anything published at swebench.com and just clutter the time-series file. No opt-in flag — the per-run state directory already retains everything needed for progress tracking. Per [reviewer feedback on the original PR diff](https://github.com/DominicBurkart/nanna-coder/pull/366#discussion_r3212790208).

3. `.gitignore` entries for `evals/scorecards/state/` (per-run cloned repos, predictions, upstream report.json trees) and locally-exported swebench JSONLs.

This PR no longer adds a row to `evals/scorecards/index.jsonl`. The metric file gets created by the bin's own `append_line` the first time a full-dataset run finalises (see #367 for the broader eval-architecture refactor that should follow).

## Test plan
- [x] \`cargo nextest run --features eval-runner -p harness eval::scoring\` — 23 tests pass (no scoring-module change).
- [x] \`cargo clippy --features eval-runner -p harness --all-targets -- -D warnings\` — clean.
- [x] Pre-commit hook (full workspace test suite + audit + deny + coverage) — passed locally.
- [x] Manual: \`harness-score --finalize\` against a 5-of-300 partial state-dir prints \"NOT appended to evals/scorecards/index.jsonl — 5/300 instances attempted; only full-dataset runs are leaderboard-comparable\" and exits 0; the metric file is *not* created.