### PR TITLE
fix(ci): tarpaulin --workspace --all-features for codecov visibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,8 +169,10 @@ jobs:
           echo "⚠️ Skipping cargo audit due to CVSS 4.0 incompatibility"
           echo "⚠️ Skipping cargo deny due to CVSS 4.0 incompatibility"
           # Increased timeout from 600s to 1800s (30 min) to accommodate E2E containerized tests
-          # which run slower under tarpaulin instrumentation
-          nix develop --command cargo tarpaulin --skip-clean --ignore-tests --out Lcov --output-dir . --timeout 1800
+          # which run slower under tarpaulin instrumentation. `--all-features` ensures
+          # feature-gated modules (e.g. `model::anthropic`) are compiled and exercised
+          # so codecov sees their tests; otherwise their diff coverage reads as 0%.
+          nix develop --command cargo tarpaulin --workspace --all-features --skip-clean --ignore-tests --out Lcov --output-dir . --timeout 1800
         else
           echo "⚠️ Security checks skipped on ${{ runner.os }}"
         fi


### PR DESCRIPTION
## Summary
The CI tarpaulin invocation runs without explicit features, so feature-gated modules like `model::anthropic` (behind `anthropic` feature) get 0% diff coverage even when local `cargo test --all-features` is green. Required `codecov/patch` then blocks any PR that adds feature-gated code.

This adds `--workspace --all-features` so coverage reflects what the test suite actually exercises. Unblocks PR #370 (AnthropicProvider) and any future PR that adds feature-gated modules.

## Diff
Single change in `.github/workflows/ci.yml`:
```
- nix develop --command cargo tarpaulin --skip-clean --ignore-tests --out Lcov --output-dir . --timeout 1800
+ nix develop --command cargo tarpaulin --workspace --all-features --skip-clean --ignore-tests --out Lcov --output-dir . --timeout 1800
```

## Test plan
- [x] Pre-commit gauntlet green (fmt, clippy, full workspace tests, deny)
- [ ] CI tarpaulin run on this PR succeeds with the new flags (verifies the change doesn't break the instrumented build)
- [ ] After merge: PR #370's codecov/patch flips green on rebase