### PR TITLE
test: add unit tests for TestEntity placeholder

### DIFF
--- a/harness/src/entities/test/types.rs
+++ b/harness/src/entities/test/types.rs
@@ -44,3 +44,45 @@ impl Default for TestEntity {
         Self::new()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_test_entity_new() {
+        let entity = TestEntity::new();
+        assert_eq!(entity.metadata().entity_type, EntityType::Test);
+        assert_eq!(entity.entity_type(), EntityType::Test);
+        assert!(!entity.id().is_empty());
+    }
+
+    #[test]
+    fn test_test_entity_default_matches_new() {
+        let from_new = TestEntity::new();
+        let from_default = TestEntity::default();
+        assert_eq!(from_new.entity_type(), from_default.entity_type());
+    }
+
+    #[test]
+    fn test_test_entity_to_json_roundtrip() {
+        let entity = TestEntity::new();
+        let json = entity.to_json().unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        // entity_type flattened from EntityMetadata should be "Test"
+        assert_eq!(parsed["entity_type"], "Test");
+    }
+
+    #[test]
+    fn test_test_entity_ids_are_unique() {
+        let e1 = TestEntity::new();
+        let e2 = TestEntity::new();
+        assert_ne!(e1.id(), e2.id());
+    }
+
+    #[test]
+    fn test_test_entity_metadata_version_starts_at_one() {
+        let entity = TestEntity::new();
+        assert_eq!(entity.metadata().version, 1);
+    }
+}


### PR DESCRIPTION
## Summary

`harness/src/entities/test/types.rs` was the only entity module in nanna-coder with zero test coverage. Every other entity module (git, ast, context, env, telemetry, and entities/mod.rs itself) already has comprehensive `#[cfg(test)]` coverage.

Added 5 tests covering the full public API surface of `TestEntity`:

- `test_test_entity_new` — `new()` produces an entity with `EntityType::Test` and a non-empty UUID id
- `test_test_entity_default_matches_new` — `Default` and `new()` produce the same entity type
- `test_test_entity_to_json_roundtrip` — `to_json()` succeeds and the `entity_type` field round-trips correctly
- `test_test_entity_ids_are_unique` — two `TestEntity::new()` calls produce distinct UUIDs
- `test_test_entity_metadata_version_starts_at_one` — initial version is 1 (consistent with other entity types)

## Test plan

- [ ] `cargo test -p harness` passes
- [ ] CI (tarpaulin + Codecov) green

---
_Generated by [Claude Code](https://claude.ai/code/session_01NpV9fMEdB4ePFStRi7NR8e)_