### PR TITLE
arch(tools): dedupe inline glob::Pattern compile+match into helper

### DIFF
--- a/harness/src/tools.rs
+++ b/harness/src/tools.rs
@@ -255,6 +255,18 @@ impl Tool for CalculatorTool {
     }
 }
 
+/// Compile a glob pattern and check whether `name` matches it, mapping
+/// compile errors to [`ToolError::InvalidArguments`]. Centralizes the
+/// pattern previously inlined in `list_directory` (recursive + flat) and
+/// `search` so future changes (e.g. pattern caching) live in one place.
+fn glob_pattern_matches(pattern: &str, name: &str) -> ToolResult<bool> {
+    Ok(glob::Pattern::new(pattern)
+        .map_err(|e| ToolError::InvalidArguments {
+            message: format!("Invalid glob pattern: {}", e),
+        })?
+        .matches(name))
+}
+
 fn validate_path_within_workspace(path: &Path, workspace_root: &Path) -> ToolResult<PathBuf> {
     let canonical_root =
         workspace_root
@@ -547,12 +559,7 @@ impl ListDirTool {
                 self.list_recursive(&path, root, pattern, entries)?;
             } else {
                 if let Some(pat) = pattern {
-                    if !glob::Pattern::new(pat)
-                        .map_err(|e| ToolError::InvalidArguments {
-                            message: format!("Invalid glob pattern: {}", e),
-                        })?
-                        .matches(&name)
-                    {
+                    if !glob_pattern_matches(pat, &name)? {
                         continue;
                     }
                 }
@@ -643,12 +650,7 @@ impl Tool for ListDirTool {
                 let name = entry.file_name().to_string_lossy().to_string();
 
                 if let Some(pat) = pattern {
-                    if !glob::Pattern::new(pat)
-                        .map_err(|e| ToolError::InvalidArguments {
-                            message: format!("Invalid glob pattern: {}", e),
-                        })?
-                        .matches(&name)
-                    {
+                    if !glob_pattern_matches(pat, &name)? {
                         continue;
                     }
                 }
@@ -709,12 +711,7 @@ impl SearchTool {
                 let name = entry.file_name().to_string_lossy().to_string();
 
                 if let Some(pat) = file_pattern {
-                    if !glob::Pattern::new(pat)
-                        .map_err(|e| ToolError::InvalidArguments {
-                            message: format!("Invalid glob pattern: {}", e),
-                        })?
-                        .matches(&name)
-                    {
+                    if !glob_pattern_matches(pat, &name)? {
                         continue;
                     }
                 }
@@ -1874,6 +1871,27 @@ pub fn create_container_tool_registry(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn glob_pattern_matches_returns_true_on_match() {
+        assert!(glob_pattern_matches("*.rs", "main.rs").unwrap());
+    }
+
+    #[test]
+    fn glob_pattern_matches_returns_false_on_no_match() {
+        assert!(!glob_pattern_matches("*.rs", "main.py").unwrap());
+    }
+
+    #[test]
+    fn glob_pattern_matches_returns_invalid_arguments_on_bad_pattern() {
+        let err = glob_pattern_matches("[", "anything").unwrap_err();
+        match err {
+            ToolError::InvalidArguments { message } => {
+                assert!(message.contains("Invalid glob pattern"));
+            }
+            other => panic!("expected InvalidArguments, got {:?}", other),
+        }
+    }
 
     #[tokio::test]
     async fn test_echo_tool() {


### PR DESCRIPTION
## Summary

Three call sites in `harness/src/tools.rs` inlined the exact same 6-line
`glob::Pattern::new(pat).map_err(...).matches(&name)` block:

- `ListDirTool::list_recursive` (line ~550)
- `ListDirTool::execute` flat-listing branch (line ~646)
- `SearchTool::search_recursive` (line ~712)

This PR extracts a single `glob_pattern_matches(pattern, name) -> ToolResult<bool>`
helper that owns the canonical mapping from `glob::PatternError` to
`ToolError::InvalidArguments`, leaving one ergonomic call site (`if !glob_pattern_matches(pat, &name)? { continue; }`)
at each former duplicate.

**Behavior, error messages, and public API are unchanged.** Net file diff is
+36/-18 lines (the additions are the helper definition plus three new tests
required by the 100% patch coverage gate; the deletions are 15 lines of pure
duplication). Future tweaks (pattern caching, alternate matcher) now live in
one place.

## Justification (tied to docs)

- TESTING.md §Principles: "Make control flow boring and obvious". The new helper
  makes the three filter branches read as one-line `if !match? { continue }` instead
  of a 6-line nested compile+match chain.
- TESTING.md §CI gate: 100% patch coverage retained — three tests added covering
  match, non-match, and the bad-pattern error path.

## Test plan

- [ ] `cargo nextest run --workspace --lib --all-features` (3 new tests + 33 existing tools::tests pass locally)
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings` (clean locally)
- [ ] `cargo fmt --all -- --check` (clean locally)
- [ ] Codecov patch coverage = 100%

https://claude.ai/code/session_01XpmLwG91zKyKJcoBg1nWjb

---
_Generated by [Claude Code](https://claude.ai/code/session_01XpmLwG91zKyKJcoBg1nWjb)_