### PR TITLE
docs(arch): correct CLI subcommand count and list swe-bench-report

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -53,7 +53,7 @@ flowchart TD
 
 # API
 
-The harness exposes six CLI subcommands: `chat`, `agent`, `mcp-serve`, `models`, `tools`, and `health`. The `mcp-serve` subcommand starts a JSON-RPC 2.0 server over stdio that implements the Model Context Protocol, exposing six MCP tools for task orchestration. External orchestrators connect to Nanna exclusively through this MCP interface.
+The harness exposes seven CLI subcommands: `chat`, `agent`, `mcp-serve`, `models`, `tools`, `health`, and `swe-bench-report`. The `mcp-serve` subcommand starts a JSON-RPC 2.0 server over stdio that implements the Model Context Protocol, exposing six MCP tools for task orchestration. External orchestrators connect to Nanna exclusively through this MCP interface. The `swe-bench-report` subcommand is an offline utility that renders a Markdown report from a SWE-bench JSON results file (optionally comparing two runs); it does not start a server or talk to a model.
 
 The six MCP tools form a complete task-delegation surface:
 
@@ -78,6 +78,7 @@ flowchart LR
         models
         tools
         health
+        swebenchreport["swe-bench-report"]
     end
     subgraph MCP["MCP (stdio, via mcp-serve)"]
         assign_task
@@ -90,7 +91,7 @@ flowchart LR
     mcpserve --> MCP
     classDef cli stroke:#46EDC8,fill:#DEFFF8,color:#378E7A
     classDef mcp stroke:#FFB703,fill:#FFE8B6,color:#8B4513
-    class chat,agent,mcpserve,models,tools,health cli
+    class chat,agent,mcpserve,models,tools,health,swebenchreport cli
     class assign_task,poll_task,get_result,list_tasks,cancel_task,onboard_repo mcp
 ```
 


### PR DESCRIPTION
## What changed

`ARCHITECTURE.md` claimed the harness exposes **six** CLI subcommands and listed `chat`, `agent`, `mcp-serve`, `models`, `tools`, `health`. The actual `Cli` / `Commands` enum in `harness/src/main.rs` defines **seven** subcommands — the docs were missing `swe-bench-report` (added by PR #273 / commit `a35e344`, "feat(eval): SWE-bench data model and report generator").

This PR aligns the doc with the code:

- Prose: "six CLI subcommands" -> "seven CLI subcommands", with `swe-bench-report` added to the inline list and a one-sentence description of what it does (offline report generator; no server, no model).
- Mermaid CLI diagram: adds a `swebenchreport["swe-bench-report"]` node inside the `CLI (harness)` subgraph and includes it in the `cli` classDef.
- The "six MCP tools" sentence and list are untouched — that count is still correct (assign_task, poll_task, get_result, list_tasks, cancel_task, onboard_repo).

## Why functionality is preserved

Documentation-only change. No Rust, Nix, CI, or script files are touched. The CLI surface, MCP surface, and all runtime behavior are unchanged; this PR only updates `ARCHITECTURE.md` to describe what the binary already does.

## Verification

- `harness/src/main.rs` `enum Commands { Chat, Models, Tools, Health, Agent, McpServe, SweBenchReport }` -> 7 variants.
- clap derives kebab-case so `SweBenchReport` is invoked as `harness swe-bench-report` (matches diagram label).
- `swe-bench-report` is dispatched via `generate_swebench_report` and writes a report (and optional comparison) to disk; it does not start a server or call a model, matching the added prose.

## Out of scope

- Default-model inconsistency across subcommands (`chat` defaults to `llama3.1:8b`, `agent`/`mcp-serve` to `qwen3:0.6b`, README/install scripts to `gemma4:e4b`) is a separate design question and intentionally not changed here.
- Other open `arch/` and `docs:` PRs (e.g. #341, #324, #374, #381) cover unrelated cleanup and are not duplicated.


---
_Generated by [Claude Code](https://claude.ai/code/session_01173Smn5AbVSYT2cT3QKuNN)_