### PR TITLE
test(telemetry,observability): cover previously-zero-coverage paths

### DIFF
--- a/harness/Cargo.toml
+++ b/harness/Cargo.toml
@@ -56,6 +56,8 @@ futures = "0.3"
 serial_test = "3.4"
 tempfile = "3.0"
 criterion = { version = "0.5", default-features = false, features = ["cargo_bench_support"] }
+chrono = { version = "0.4", features = ["serde"] }
+serde_json = "1.0"
 
 [[bench]]
 name = "agents_md_load"

--- a/harness/src/observability.rs
+++ b/harness/src/observability.rs
@@ -1006,6 +1006,7 @@ impl Default for ObservabilitySystem {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::monitoring::Alert;
 
     #[tokio::test]
     async fn test_observability_system_initialization() {
@@ -1096,5 +1097,361 @@ mod tests {
 
         let trends = system.analyze_current_trends(&metrics).unwrap();
         assert!(trends.performance_score >= 0.0 && trends.performance_score <= 100.0);
+    }
+
+    #[tokio::test]
+    async fn test_performance_trends_degrading_latency() {
+        let system = ObservabilitySystem::new();
+        let mut metrics = SystemMetrics {
+            timestamp: Utc::now(),
+            request_latencies: HashMap::new(),
+            cache_metrics: crate::monitoring::CacheMetrics {
+                hits: 80,
+                misses: 20,
+                hit_rate: 0.8,
+                size_bytes: 0,
+                item_count: 0,
+                evictions: 0,
+            },
+            container_metrics: Vec::new(),
+            system_resources: crate::monitoring::SystemResourceMetrics {
+                cpu_usage_percent: 10.0,
+                total_memory_bytes: 8_000_000_000,
+                used_memory_bytes: 1_000_000_000,
+                memory_usage_percent: 12.5,
+                available_disk_bytes: 100_000_000_000,
+                total_disk_bytes: 200_000_000_000,
+                disk_usage_percent: 50.0,
+                load_average: [0.1, 0.1, 0.1],
+            },
+            model_metrics: HashMap::new(),
+            error_metrics: crate::monitoring::ErrorMetrics {
+                total_errors: 0,
+                errors_by_type: HashMap::new(),
+                error_rate: 0.0,
+                recent_errors: Vec::new(),
+            },
+        };
+        metrics.request_latencies.insert(
+            "slow-svc".to_string(),
+            crate::monitoring::LatencyMetrics {
+                avg_latency_ms: 3000.0,
+                p95_latency_ms: 3500.0,
+                p99_latency_ms: 4000.0,
+                max_latency_ms: 5000.0,
+                min_latency_ms: 2500.0,
+                request_count: 10,
+                requests_per_second: 1.0,
+            },
+        );
+        let trends = system.analyze_current_trends(&metrics).unwrap();
+        assert_eq!(trends.latency_trend, TrendDirection::Degrading);
+        assert!(trends.performance_score <= 80.0);
+    }
+
+    #[tokio::test]
+    async fn test_performance_trends_degrading_error_rate() {
+        let system = ObservabilitySystem::new();
+        let metrics = SystemMetrics {
+            timestamp: Utc::now(),
+            request_latencies: HashMap::new(),
+            cache_metrics: crate::monitoring::CacheMetrics {
+                hits: 80,
+                misses: 20,
+                hit_rate: 0.8,
+                size_bytes: 0,
+                item_count: 0,
+                evictions: 0,
+            },
+            container_metrics: Vec::new(),
+            system_resources: crate::monitoring::SystemResourceMetrics {
+                cpu_usage_percent: 10.0,
+                total_memory_bytes: 8_000_000_000,
+                used_memory_bytes: 1_000_000_000,
+                memory_usage_percent: 12.5,
+                available_disk_bytes: 100_000_000_000,
+                total_disk_bytes: 200_000_000_000,
+                disk_usage_percent: 50.0,
+                load_average: [0.1, 0.1, 0.1],
+            },
+            model_metrics: HashMap::new(),
+            error_metrics: crate::monitoring::ErrorMetrics {
+                total_errors: 200,
+                errors_by_type: HashMap::new(),
+                error_rate: 0.2,
+                recent_errors: Vec::new(),
+            },
+        };
+        let trends = system.analyze_current_trends(&metrics).unwrap();
+        assert_eq!(trends.error_rate_trend, TrendDirection::Degrading);
+        assert!(trends.performance_score <= 75.0);
+    }
+
+    #[tokio::test]
+    async fn test_performance_trends_degrading_cache() {
+        let system = ObservabilitySystem::new();
+        let metrics = SystemMetrics {
+            timestamp: Utc::now(),
+            request_latencies: HashMap::new(),
+            cache_metrics: crate::monitoring::CacheMetrics {
+                hits: 10,
+                misses: 90,
+                hit_rate: 0.1,
+                size_bytes: 0,
+                item_count: 0,
+                evictions: 0,
+            },
+            container_metrics: Vec::new(),
+            system_resources: crate::monitoring::SystemResourceMetrics {
+                cpu_usage_percent: 10.0,
+                total_memory_bytes: 8_000_000_000,
+                used_memory_bytes: 1_000_000_000,
+                memory_usage_percent: 12.5,
+                available_disk_bytes: 100_000_000_000,
+                total_disk_bytes: 200_000_000_000,
+                disk_usage_percent: 50.0,
+                load_average: [0.1, 0.1, 0.1],
+            },
+            model_metrics: HashMap::new(),
+            error_metrics: crate::monitoring::ErrorMetrics {
+                total_errors: 0,
+                errors_by_type: HashMap::new(),
+                error_rate: 0.0,
+                recent_errors: Vec::new(),
+            },
+        };
+        let trends = system.analyze_current_trends(&metrics).unwrap();
+        assert_eq!(trends.cache_performance_trend, TrendDirection::Degrading);
+        assert!(trends.performance_score <= 85.0);
+    }
+
+    #[tokio::test]
+    async fn test_availability_metrics_sla_at_risk() {
+        let system = ObservabilitySystem::new();
+        let metrics = system.calculate_availability_metrics().unwrap();
+        assert_eq!(metrics.sla_compliance.status, SlaStatus::AtRisk);
+        assert_eq!(metrics.sla_compliance.target_availability, 99.9);
+        assert_eq!(metrics.sla_compliance.current_availability, 99.5);
+    }
+
+    #[tokio::test]
+    async fn test_alert_category_container() {
+        let system = ObservabilitySystem::new();
+        let alert = Alert {
+            id: "1".to_string(),
+            title: "Down".to_string(),
+            description: "Container stopped".to_string(),
+            severity: AlertSeverity::Critical,
+            component: "container-web".to_string(),
+            timestamp: Utc::now(),
+            context: HashMap::new(),
+            acknowledged: false,
+        };
+        assert_eq!(
+            system.determine_alert_category(&alert),
+            AlertCategory::ContainerHealth
+        );
+    }
+
+    #[tokio::test]
+    async fn test_alert_category_model() {
+        let system = ObservabilitySystem::new();
+        let alert = Alert {
+            id: "2".to_string(),
+            title: "Drift detected".to_string(),
+            description: "Quality drop".to_string(),
+            severity: AlertSeverity::Warning,
+            component: "model-qwen3".to_string(),
+            timestamp: Utc::now(),
+            context: HashMap::new(),
+            acknowledged: false,
+        };
+        assert_eq!(
+            system.determine_alert_category(&alert),
+            AlertCategory::ModelQuality
+        );
+    }
+
+    #[tokio::test]
+    async fn test_alert_category_performance() {
+        let system = ObservabilitySystem::new();
+        let alert = Alert {
+            id: "3".to_string(),
+            title: "Performance degradation detected".to_string(),
+            description: "Slow response".to_string(),
+            severity: AlertSeverity::Warning,
+            component: "api-gateway".to_string(),
+            timestamp: Utc::now(),
+            context: HashMap::new(),
+            acknowledged: false,
+        };
+        assert_eq!(
+            system.determine_alert_category(&alert),
+            AlertCategory::Performance
+        );
+    }
+
+    #[tokio::test]
+    async fn test_alert_category_resources() {
+        let system = ObservabilitySystem::new();
+        let alert = Alert {
+            id: "4".to_string(),
+            title: "Resource exhaustion imminent".to_string(),
+            description: "Low disk".to_string(),
+            severity: AlertSeverity::Warning,
+            component: "storage".to_string(),
+            timestamp: Utc::now(),
+            context: HashMap::new(),
+            acknowledged: false,
+        };
+        assert_eq!(
+            system.determine_alert_category(&alert),
+            AlertCategory::Resources
+        );
+    }
+
+    #[tokio::test]
+    async fn test_alert_category_default_availability() {
+        let system = ObservabilitySystem::new();
+        let alert = Alert {
+            id: "5".to_string(),
+            title: "Service unreachable".to_string(),
+            description: "Cannot connect".to_string(),
+            severity: AlertSeverity::Critical,
+            component: "network".to_string(),
+            timestamp: Utc::now(),
+            context: HashMap::new(),
+            acknowledged: false,
+        };
+        assert_eq!(
+            system.determine_alert_category(&alert),
+            AlertCategory::Availability
+        );
+    }
+
+    #[tokio::test]
+    async fn test_priority_score_critical_availability_capped() {
+        let system = ObservabilitySystem::new();
+        let alert = Alert {
+            id: "6".to_string(),
+            title: "Outage".to_string(),
+            description: "System down".to_string(),
+            severity: AlertSeverity::Critical,
+            component: "network".to_string(),
+            timestamp: Utc::now(),
+            context: HashMap::new(),
+            acknowledged: false,
+        };
+        // Critical (100) + Availability (+20) = 120, capped to 100
+        let score = system.calculate_priority_score(&alert, &AlertCategory::Availability);
+        assert_eq!(score, 100);
+    }
+
+    #[tokio::test]
+    async fn test_priority_score_warning_performance() {
+        let system = ObservabilitySystem::new();
+        let alert = Alert {
+            id: "7".to_string(),
+            title: "Slow".to_string(),
+            description: "High latency".to_string(),
+            severity: AlertSeverity::Warning,
+            component: "api".to_string(),
+            timestamp: Utc::now(),
+            context: HashMap::new(),
+            acknowledged: false,
+        };
+        // Warning (50) + Performance (+10) = 60
+        let score = system.calculate_priority_score(&alert, &AlertCategory::Performance);
+        assert_eq!(score, 60);
+    }
+
+    #[tokio::test]
+    async fn test_priority_score_info_config_no_adjustment() {
+        let system = ObservabilitySystem::new();
+        let alert = Alert {
+            id: "8".to_string(),
+            title: "Config changed".to_string(),
+            description: "Setting updated".to_string(),
+            severity: AlertSeverity::Info,
+            component: "config".to_string(),
+            timestamp: Utc::now(),
+            context: HashMap::new(),
+            acknowledged: false,
+        };
+        // Info (25) + Configuration (no adjustment) = 25
+        let score = system.calculate_priority_score(&alert, &AlertCategory::Configuration);
+        assert_eq!(score, 25);
+    }
+
+    #[tokio::test]
+    async fn test_recommended_actions_container_health() {
+        let system = ObservabilitySystem::new();
+        let alert = Alert {
+            id: "9".to_string(),
+            title: "Container down".to_string(),
+            description: "Stopped".to_string(),
+            severity: AlertSeverity::Critical,
+            component: "container-web".to_string(),
+            timestamp: Utc::now(),
+            context: HashMap::new(),
+            acknowledged: false,
+        };
+        let actions =
+            system.generate_recommended_actions(&alert, &AlertCategory::ContainerHealth);
+        assert!(!actions.is_empty());
+        assert!(actions.iter().any(|a| a.to_lowercase().contains("container")));
+    }
+
+    #[tokio::test]
+    async fn test_recommended_actions_performance() {
+        let system = ObservabilitySystem::new();
+        let alert = Alert {
+            id: "10".to_string(),
+            title: "Slow".to_string(),
+            description: "High latency".to_string(),
+            severity: AlertSeverity::Warning,
+            component: "api".to_string(),
+            timestamp: Utc::now(),
+            context: HashMap::new(),
+            acknowledged: false,
+        };
+        let actions = system.generate_recommended_actions(&alert, &AlertCategory::Performance);
+        assert!(!actions.is_empty());
+        assert!(actions.iter().any(|a| a.to_lowercase().contains("resource")));
+    }
+
+    #[tokio::test]
+    async fn test_recommended_actions_model_quality() {
+        let system = ObservabilitySystem::new();
+        let alert = Alert {
+            id: "11".to_string(),
+            title: "Quality drop".to_string(),
+            description: "Drift detected".to_string(),
+            severity: AlertSeverity::Error,
+            component: "model-llm".to_string(),
+            timestamp: Utc::now(),
+            context: HashMap::new(),
+            acknowledged: false,
+        };
+        let actions = system.generate_recommended_actions(&alert, &AlertCategory::ModelQuality);
+        assert!(!actions.is_empty());
+        assert!(actions.iter().any(|a| a.to_lowercase().contains("model")));
+    }
+
+    #[tokio::test]
+    async fn test_recommended_actions_default_category() {
+        let system = ObservabilitySystem::new();
+        let alert = Alert {
+            id: "12".to_string(),
+            title: "Outage".to_string(),
+            description: "System down".to_string(),
+            severity: AlertSeverity::Critical,
+            component: "network".to_string(),
+            timestamp: Utc::now(),
+            context: HashMap::new(),
+            acknowledged: false,
+        };
+        let actions = system.generate_recommended_actions(&alert, &AlertCategory::Availability);
+        assert!(!actions.is_empty());
     }
 }

--- a/harness/src/observability.rs
+++ b/harness/src/observability.rs
@@ -1396,8 +1396,7 @@ mod tests {
             context: HashMap::new(),
             acknowledged: false,
         };
-        let actions =
-            system.generate_recommended_actions(&alert, &AlertCategory::ContainerHealth);
+        let actions = system.generate_recommended_actions(&alert, &AlertCategory::ContainerHealth);
         assert!(!actions.is_empty());
         assert!(actions.iter().any(|a| a.to_lowercase().contains("container")));
     }

--- a/harness/tests/telemetry_coverage_tests.rs
+++ b/harness/tests/telemetry_coverage_tests.rs
@@ -1,0 +1,287 @@
+use chrono::Utc;
+use harness::{
+    CustomEvent, MetricPoint, MetricType, PrometheusExporter, SpanStatus, TelemetryExporter,
+    TelemetrySystem, TraceContext, TraceGuard,
+};
+use std::collections::HashMap;
+
+#[tokio::test]
+async fn trace_guard_drop_removes_from_active_traces() {
+    let system = TelemetrySystem::new();
+    let trace = system.start_trace("guarded_op");
+    assert_eq!(system.get_active_trace_count(), 1);
+    {
+        let _guard = TraceGuard::new(&system, trace);
+    }
+    assert_eq!(system.get_active_trace_count(), 0);
+}
+
+#[tokio::test]
+async fn trace_guard_trace_returns_context() {
+    let system = TelemetrySystem::new();
+    let trace = system.start_trace("my_op");
+    let guard = TraceGuard::new(&system, trace);
+    let ctx = guard.trace().unwrap();
+    assert_eq!(ctx.operation_name, "my_op");
+    assert_eq!(ctx.status, SpanStatus::InProgress);
+}
+
+#[tokio::test]
+async fn trace_guard_record_error() {
+    let system = TelemetrySystem::new();
+    let trace = system.start_trace("op");
+    let mut guard = TraceGuard::new(&system, trace);
+    guard.record_error("test error");
+    let ctx = guard.trace().unwrap();
+    assert_eq!(ctx.status, SpanStatus::Error);
+    assert_eq!(
+        ctx.attributes.get("error").map(|s| s.as_str()),
+        Some("test error")
+    );
+}
+
+#[tokio::test]
+async fn trace_guard_set_status_cancelled() {
+    let system = TelemetrySystem::new();
+    let trace = system.start_trace("op");
+    let mut guard = TraceGuard::new(&system, trace);
+    guard.set_status(SpanStatus::Cancelled);
+    assert_eq!(guard.trace().unwrap().status, SpanStatus::Cancelled);
+}
+
+#[tokio::test]
+async fn trace_guard_set_status_timeout() {
+    let system = TelemetrySystem::new();
+    let trace = system.start_trace("op");
+    let mut guard = TraceGuard::new(&system, trace);
+    guard.set_status(SpanStatus::Timeout);
+    assert_eq!(guard.trace().unwrap().status, SpanStatus::Timeout);
+}
+
+#[tokio::test]
+async fn span_finish_preserves_cancelled_status() {
+    let mut trace = TraceContext::new("op");
+    trace.set_status(SpanStatus::Cancelled);
+    trace.finish();
+    assert_eq!(trace.status, SpanStatus::Cancelled);
+}
+
+#[tokio::test]
+async fn span_finish_preserves_timeout_status() {
+    let mut trace = TraceContext::new("op");
+    trace.set_status(SpanStatus::Timeout);
+    trace.finish();
+    assert_eq!(trace.status, SpanStatus::Timeout);
+}
+
+#[tokio::test]
+async fn trace_context_with_attribute_chain() {
+    let trace = TraceContext::new("op")
+        .with_attribute("key1", "v1")
+        .with_attribute("key2", "v2");
+    assert_eq!(trace.attributes.get("key1").map(|s| s.as_str()), Some("v1"));
+    assert_eq!(trace.attributes.get("key2").map(|s| s.as_str()), Some("v2"));
+}
+
+#[tokio::test]
+async fn trace_context_create_child() {
+    let parent = TraceContext::new("parent");
+    let child = parent.create_child("child");
+    assert_eq!(child.trace_id, parent.trace_id);
+    assert_eq!(child.parent_span_id, Some(parent.span_id.clone()));
+    assert_ne!(child.span_id, parent.span_id);
+    assert_eq!(child.status, SpanStatus::InProgress);
+}
+
+#[tokio::test]
+async fn telemetry_global_attribute_propagates_to_trace() {
+    let system = TelemetrySystem::new().with_global_attribute("env", "prod");
+    let trace = system.start_trace("op");
+    assert_eq!(
+        trace.attributes.get("env").map(|s| s.as_str()),
+        Some("prod")
+    );
+    system.finish_trace(trace);
+}
+
+#[tokio::test]
+async fn telemetry_start_trace_includes_service_name() {
+    let system = TelemetrySystem::new().with_service_name("my-svc");
+    let trace = system.start_trace("op");
+    assert_eq!(
+        trace.attributes.get("service.name").map(|s| s.as_str()),
+        Some("my-svc")
+    );
+    system.finish_trace(trace);
+}
+
+#[tokio::test]
+async fn telemetry_export_all_clears_metrics_buffer() {
+    let system = TelemetrySystem::new();
+    system.record_counter("c1", 1.0, vec![]);
+    system.record_counter("c2", 2.0, vec![]);
+    assert_eq!(system.get_buffered_metrics_count(), 2);
+    system.export_all().await.unwrap();
+    assert_eq!(system.get_buffered_metrics_count(), 0);
+}
+
+#[tokio::test]
+async fn prometheus_export_traces_adds_histogram() {
+    let exporter = PrometheusExporter::new(None);
+    let mut trace = TraceContext::new("my_op");
+    trace.finish();
+    exporter.export_traces(vec![trace]).await.unwrap();
+    let output = exporter.export_prometheus().await.unwrap();
+    assert!(
+        output.contains("trace_duration_seconds"),
+        "output: {output}"
+    );
+    assert!(output.contains("histogram"), "output: {output}");
+    assert!(output.contains("operation=\"my_op\""), "output: {output}");
+}
+
+#[tokio::test]
+async fn prometheus_export_events_adds_counter() {
+    let exporter = PrometheusExporter::new(None);
+    let event = CustomEvent {
+        name: "user_login".to_string(),
+        timestamp: Utc::now(),
+        category: "auth".to_string(),
+        attributes: HashMap::new(),
+        data: serde_json::json!({}),
+        trace_context: None,
+    };
+    exporter.export_events(vec![event]).await.unwrap();
+    let output = exporter.export_prometheus().await.unwrap();
+    assert!(output.contains("custom_events_total"), "output: {output}");
+    assert!(output.contains("counter"), "output: {output}");
+    assert!(
+        output.contains("event_name=\"user_login\""),
+        "output: {output}"
+    );
+}
+
+#[tokio::test]
+async fn prometheus_export_system_metrics_adds_gauges() {
+    let exporter = PrometheusExporter::new(None);
+    let metrics = build_system_metrics();
+    exporter.export_system_metrics(metrics).await.unwrap();
+    let output = exporter.export_prometheus().await.unwrap();
+    assert!(output.contains("cache_hit_rate"), "output: {output}");
+    assert!(
+        output.contains("request_duration_seconds"),
+        "output: {output}"
+    );
+    assert!(output.contains("error_rate"), "output: {output}");
+}
+
+#[tokio::test]
+async fn prometheus_health_check_returns_ok() {
+    let exporter = PrometheusExporter::new(None);
+    let result = exporter.health_check().await.unwrap();
+    assert!(result);
+}
+
+#[tokio::test]
+async fn prometheus_clear_buffer_empties_output() {
+    let exporter = PrometheusExporter::new(None);
+    exporter.add_metric(MetricPoint {
+        name: "test".to_string(),
+        metric_type: MetricType::Counter,
+        value: 1.0,
+        timestamp: Utc::now(),
+        labels: HashMap::new(),
+        unit: None,
+        description: None,
+    });
+    let before = exporter.export_prometheus().await.unwrap();
+    assert!(!before.is_empty());
+    exporter.clear_buffer();
+    let after = exporter.export_prometheus().await.unwrap();
+    assert!(after.is_empty());
+}
+
+#[tokio::test]
+async fn prometheus_gauge_type_in_output() {
+    let exporter = PrometheusExporter::new(None);
+    exporter.add_metric(MetricPoint {
+        name: "my_gauge".to_string(),
+        metric_type: MetricType::Gauge,
+        value: 42.0,
+        timestamp: Utc::now(),
+        labels: HashMap::new(),
+        unit: None,
+        description: None,
+    });
+    let output = exporter.export_prometheus().await.unwrap();
+    assert!(
+        output.contains("# TYPE my_gauge gauge"),
+        "output: {output}"
+    );
+}
+
+#[tokio::test]
+async fn prometheus_summary_type_in_output() {
+    let exporter = PrometheusExporter::new(None);
+    exporter.add_metric(MetricPoint {
+        name: "my_summary".to_string(),
+        metric_type: MetricType::Summary,
+        value: 0.99,
+        timestamp: Utc::now(),
+        labels: HashMap::new(),
+        unit: None,
+        description: None,
+    });
+    let output = exporter.export_prometheus().await.unwrap();
+    assert!(
+        output.contains("# TYPE my_summary summary"),
+        "output: {output}"
+    );
+}
+
+fn build_system_metrics() -> harness::monitoring::SystemMetrics {
+    use harness::monitoring::*;
+    let mut latencies = HashMap::new();
+    latencies.insert(
+        "api".to_string(),
+        LatencyMetrics {
+            avg_latency_ms: 100.0,
+            p95_latency_ms: 150.0,
+            p99_latency_ms: 200.0,
+            max_latency_ms: 300.0,
+            min_latency_ms: 20.0,
+            request_count: 50,
+            requests_per_second: 5.0,
+        },
+    );
+    SystemMetrics {
+        timestamp: Utc::now(),
+        request_latencies: latencies,
+        cache_metrics: CacheMetrics {
+            hits: 80,
+            misses: 20,
+            hit_rate: 0.8,
+            size_bytes: 0,
+            item_count: 0,
+            evictions: 0,
+        },
+        container_metrics: vec![],
+        system_resources: SystemResourceMetrics {
+            cpu_usage_percent: 30.0,
+            total_memory_bytes: 8_000_000_000,
+            used_memory_bytes: 2_000_000_000,
+            memory_usage_percent: 25.0,
+            available_disk_bytes: 100_000_000_000,
+            total_disk_bytes: 200_000_000_000,
+            disk_usage_percent: 50.0,
+            load_average: [0.5, 0.6, 0.7],
+        },
+        model_metrics: HashMap::new(),
+        error_metrics: ErrorMetrics {
+            total_errors: 0,
+            errors_by_type: HashMap::new(),
+            error_rate: 0.0,
+            recent_errors: vec![],
+        },
+    }
+}


### PR DESCRIPTION
## Summary

Adds test coverage for the two largest gaps identified by Codecov: `harness/src/telemetry.rs` and `harness/src/observability.rs`.

### harness/tests/telemetry_coverage_tests.rs (new file)
Covers previously-zero paths in `telemetry.rs`:
- `TraceGuard`: `new`, `trace()`, `record_error`, `set_status`, and Drop (verifies active-trace count goes to 0)
- `SpanStatus::Cancelled` and `Timeout`: `finish()` must not override non-`InProgress` status
- `TraceContext::with_attribute` chaining and `create_child` parent-ID wiring
- `TelemetrySystem::with_global_attribute` propagates to trace attributes; `start_trace` embeds `service.name`
- `TelemetrySystem::export_all` empties the metrics buffer
- `PrometheusExporter::export_traces` → histogram output with `operation=` label
- `PrometheusExporter::export_events` → counter output with `event_name=` label
- `PrometheusExporter::export_system_metrics` → `cache_hit_rate`, `request_duration_seconds`, `error_rate` gauges
- `PrometheusExporter::health_check`, `clear_buffer`
- `MetricType::Gauge` and `MetricType::Summary` branches in Prometheus type-line output

### harness/src/observability.rs (inline tests added)
Covers previously-zero private-method branches (only reachable from inline `mod tests`):
- `analyze_current_trends`: `TrendDirection::Degrading` for latency > 2000 ms, error rate > 5%, cache hit rate < 80%
- `calculate_availability_metrics`: hardcoded 99.5% availability → `SlaStatus::AtRisk`
- `determine_alert_category`: all five branches (ContainerHealth, ModelQuality, Performance, Resources, Availability default)
- `calculate_priority_score`: Critical+Availability capped to 100, Warning+Performance = 60, Info+Configuration = 25
- `generate_recommended_actions`: ContainerHealth, Performance, ModelQuality, and default arms

### harness/Cargo.toml
Added `chrono` and `serde_json` to `[dev-dependencies]` so the new integration-test file can construct `CustomEvent` and `MetricPoint` directly (both were already in `[dependencies]`; this just makes them explicit for the test binary).

---
_Generated by [Claude Code](https://claude.ai/code/session_01UGXms74FqDQHNiDBCTP6eQ)_