### PR TITLE
test(harness): add unit tests for monitoring and observability pure functions

### DIFF
--- a/harness/src/monitoring.rs
+++ b/harness/src/monitoring.rs
@@ -1242,4 +1242,106 @@ mod tests {
         let csv_export = collector.export_metrics(MetricsFormat::Csv).await.unwrap();
         assert!(csv_export.contains("timestamp,metric_type,service,value"));
     }
+
+    #[test]
+    fn test_health_status_is_healthy() {
+        assert!(HealthStatus::Healthy.is_healthy());
+        assert!(!HealthStatus::Warning.is_healthy());
+        assert!(!HealthStatus::Degraded.is_healthy());
+        assert!(!HealthStatus::Unhealthy.is_healthy());
+        assert!(!HealthStatus::Unknown.is_healthy());
+    }
+
+    #[test]
+    fn test_health_status_requires_attention() {
+        assert!(!HealthStatus::Healthy.requires_attention());
+        assert!(HealthStatus::Warning.requires_attention());
+        assert!(HealthStatus::Degraded.requires_attention());
+        assert!(HealthStatus::Unhealthy.requires_attention());
+        assert!(!HealthStatus::Unknown.requires_attention());
+    }
+
+    #[test]
+    fn test_alert_thresholds_default() {
+        let t = AlertThresholds::default();
+        assert_eq!(t.max_latency_ms, 5000);
+        assert!((t.min_cache_hit_rate - 0.8).abs() < 1e-10);
+        assert!((t.max_error_rate - 0.05).abs() < 1e-10);
+        assert!((t.max_cpu_usage - 0.9).abs() < 1e-10);
+        assert!((t.max_memory_usage - 0.9).abs() < 1e-10);
+        assert_eq!(t.health_check_timeout, Duration::from_secs(30));
+    }
+
+    #[test]
+    fn test_calculate_latency_metrics_empty() {
+        let collector = DefaultMetricsCollector::new();
+        let m = collector.calculate_latency_metrics(&[]);
+        assert_eq!(m.request_count, 0);
+        assert_eq!(m.avg_latency_ms, 0.0);
+        assert_eq!(m.max_latency_ms, 0.0);
+        assert_eq!(m.min_latency_ms, 0.0);
+    }
+
+    #[test]
+    fn test_calculate_latency_metrics_single() {
+        let collector = DefaultMetricsCollector::new();
+        let m = collector.calculate_latency_metrics(&[Duration::from_millis(100)]);
+        assert_eq!(m.request_count, 1);
+        assert_eq!(m.avg_latency_ms, 100.0);
+        assert_eq!(m.max_latency_ms, 100.0);
+        assert_eq!(m.min_latency_ms, 100.0);
+    }
+
+    #[test]
+    fn test_calculate_latency_metrics_multiple_sorted() {
+        let collector = DefaultMetricsCollector::new();
+        let durations = vec![
+            Duration::from_millis(100),
+            Duration::from_millis(200),
+            Duration::from_millis(300),
+        ];
+        let m = collector.calculate_latency_metrics(&durations);
+        assert_eq!(m.request_count, 3);
+        assert_eq!(m.avg_latency_ms, 200.0);
+        assert_eq!(m.max_latency_ms, 300.0);
+        assert_eq!(m.min_latency_ms, 100.0);
+    }
+
+    #[tokio::test]
+    async fn test_cache_metrics_all_hits() {
+        let mut collector = DefaultMetricsCollector::new();
+        for _ in 0..5 {
+            collector.record_cache_hit("k").await;
+        }
+        let m = collector.get_current_metrics().await.unwrap();
+        assert_eq!(m.cache_metrics.hits, 5);
+        assert_eq!(m.cache_metrics.misses, 0);
+        assert_eq!(m.cache_metrics.hit_rate, 1.0);
+    }
+
+    #[tokio::test]
+    async fn test_cache_metrics_all_misses() {
+        let mut collector = DefaultMetricsCollector::new();
+        for _ in 0..3 {
+            collector.record_cache_miss("k").await;
+        }
+        let m = collector.get_current_metrics().await.unwrap();
+        assert_eq!(m.cache_metrics.hits, 0);
+        assert_eq!(m.cache_metrics.misses, 3);
+        assert_eq!(m.cache_metrics.hit_rate, 0.0);
+    }
+
+    #[tokio::test]
+    async fn test_cache_metrics_mixed() {
+        let mut collector = DefaultMetricsCollector::new();
+        collector.record_cache_hit("a").await;
+        collector.record_cache_hit("b").await;
+        collector.record_cache_hit("c").await;
+        collector.record_cache_miss("d").await;
+        collector.record_cache_miss("e").await;
+        let m = collector.get_current_metrics().await.unwrap();
+        assert_eq!(m.cache_metrics.hits, 3);
+        assert_eq!(m.cache_metrics.misses, 2);
+        assert!((m.cache_metrics.hit_rate - 0.6).abs() < 1e-10);
+    }
 }

--- a/harness/src/observability.rs
+++ b/harness/src/observability.rs
@@ -1134,70 +1134,104 @@ mod tests {
     fn test_determine_alert_category_container() {
         let sys = ObservabilitySystem::new();
         let alert = make_test_alert("some alert", "my-container-01", AlertSeverity::Warning);
-        assert_eq!(sys.determine_alert_category(&alert), AlertCategory::ContainerHealth);
+        assert_eq!(
+            sys.determine_alert_category(&alert),
+            AlertCategory::ContainerHealth
+        );
     }
 
     #[test]
     fn test_determine_alert_category_model() {
         let sys = ObservabilitySystem::new();
         let alert = make_test_alert("some alert", "model:qwen3", AlertSeverity::Warning);
-        assert_eq!(sys.determine_alert_category(&alert), AlertCategory::ModelQuality);
+        assert_eq!(
+            sys.determine_alert_category(&alert),
+            AlertCategory::ModelQuality
+        );
     }
 
     #[test]
     fn test_determine_alert_category_performance_from_title() {
         let sys = ObservabilitySystem::new();
         let alert = make_test_alert("Performance degraded", "system", AlertSeverity::Warning);
-        assert_eq!(sys.determine_alert_category(&alert), AlertCategory::Performance);
+        assert_eq!(
+            sys.determine_alert_category(&alert),
+            AlertCategory::Performance
+        );
     }
 
     #[test]
     fn test_determine_alert_category_resource_from_title() {
         let sys = ObservabilitySystem::new();
-        let alert = make_test_alert("Resource exhaustion detected", "system", AlertSeverity::Error);
-        assert_eq!(sys.determine_alert_category(&alert), AlertCategory::Resources);
+        let alert = make_test_alert(
+            "Resource exhaustion detected",
+            "system",
+            AlertSeverity::Error,
+        );
+        assert_eq!(
+            sys.determine_alert_category(&alert),
+            AlertCategory::Resources
+        );
     }
 
     #[test]
     fn test_determine_alert_category_availability_fallback() {
         let sys = ObservabilitySystem::new();
         let alert = make_test_alert("Some unknown issue", "system", AlertSeverity::Info);
-        assert_eq!(sys.determine_alert_category(&alert), AlertCategory::Availability);
+        assert_eq!(
+            sys.determine_alert_category(&alert),
+            AlertCategory::Availability
+        );
     }
 
     #[test]
     fn test_calculate_priority_score_critical_availability() {
         let sys = ObservabilitySystem::new();
         let alert = make_test_alert("t", "s", AlertSeverity::Critical);
-        assert_eq!(sys.calculate_priority_score(&alert, &AlertCategory::Availability), 100);
+        assert_eq!(
+            sys.calculate_priority_score(&alert, &AlertCategory::Availability),
+            100
+        );
     }
 
     #[test]
     fn test_calculate_priority_score_warning_availability() {
         let sys = ObservabilitySystem::new();
         let alert = make_test_alert("t", "s", AlertSeverity::Warning);
-        assert_eq!(sys.calculate_priority_score(&alert, &AlertCategory::Availability), 70);
+        assert_eq!(
+            sys.calculate_priority_score(&alert, &AlertCategory::Availability),
+            70
+        );
     }
 
     #[test]
     fn test_calculate_priority_score_info_performance() {
         let sys = ObservabilitySystem::new();
         let alert = make_test_alert("t", "s", AlertSeverity::Info);
-        assert_eq!(sys.calculate_priority_score(&alert, &AlertCategory::Performance), 35);
+        assert_eq!(
+            sys.calculate_priority_score(&alert, &AlertCategory::Performance),
+            35
+        );
     }
 
     #[test]
     fn test_calculate_priority_score_error_resources() {
         let sys = ObservabilitySystem::new();
         let alert = make_test_alert("t", "s", AlertSeverity::Error);
-        assert_eq!(sys.calculate_priority_score(&alert, &AlertCategory::Resources), 75);
+        assert_eq!(
+            sys.calculate_priority_score(&alert, &AlertCategory::Resources),
+            75
+        );
     }
 
     #[test]
     fn test_calculate_priority_score_security_bonus() {
         let sys = ObservabilitySystem::new();
         let alert = make_test_alert("t", "s", AlertSeverity::Warning);
-        assert_eq!(sys.calculate_priority_score(&alert, &AlertCategory::Security), 80);
+        assert_eq!(
+            sys.calculate_priority_score(&alert, &AlertCategory::Security),
+            80
+        );
     }
 
     #[test]

--- a/harness/src/observability.rs
+++ b/harness/src/observability.rs
@@ -1097,4 +1097,168 @@ mod tests {
         let trends = system.analyze_current_trends(&metrics).unwrap();
         assert!(trends.performance_score >= 0.0 && trends.performance_score <= 100.0);
     }
+
+    fn make_test_alert(
+        title: &str,
+        component: &str,
+        severity: AlertSeverity,
+    ) -> crate::monitoring::Alert {
+        crate::monitoring::Alert {
+            id: "test-id".to_string(),
+            title: title.to_string(),
+            description: "test description".to_string(),
+            severity,
+            component: component.to_string(),
+            timestamp: Utc::now(),
+            context: HashMap::new(),
+            acknowledged: false,
+        }
+    }
+
+    fn make_sla_compliance(availability: f64) -> SlaCompliance {
+        SlaCompliance {
+            target_availability: 99.9,
+            current_availability: availability,
+            status: if availability >= 99.9 {
+                SlaStatus::Compliant
+            } else if availability >= 99.0 {
+                SlaStatus::AtRisk
+            } else {
+                SlaStatus::Breached
+            },
+            time_to_breach: None,
+        }
+    }
+
+    #[test]
+    fn test_determine_alert_category_container() {
+        let sys = ObservabilitySystem::new();
+        let alert = make_test_alert("some alert", "my-container-01", AlertSeverity::Warning);
+        assert_eq!(sys.determine_alert_category(&alert), AlertCategory::ContainerHealth);
+    }
+
+    #[test]
+    fn test_determine_alert_category_model() {
+        let sys = ObservabilitySystem::new();
+        let alert = make_test_alert("some alert", "model:qwen3", AlertSeverity::Warning);
+        assert_eq!(sys.determine_alert_category(&alert), AlertCategory::ModelQuality);
+    }
+
+    #[test]
+    fn test_determine_alert_category_performance_from_title() {
+        let sys = ObservabilitySystem::new();
+        let alert = make_test_alert("Performance degraded", "system", AlertSeverity::Warning);
+        assert_eq!(sys.determine_alert_category(&alert), AlertCategory::Performance);
+    }
+
+    #[test]
+    fn test_determine_alert_category_resource_from_title() {
+        let sys = ObservabilitySystem::new();
+        let alert = make_test_alert("Resource exhaustion detected", "system", AlertSeverity::Error);
+        assert_eq!(sys.determine_alert_category(&alert), AlertCategory::Resources);
+    }
+
+    #[test]
+    fn test_determine_alert_category_availability_fallback() {
+        let sys = ObservabilitySystem::new();
+        let alert = make_test_alert("Some unknown issue", "system", AlertSeverity::Info);
+        assert_eq!(sys.determine_alert_category(&alert), AlertCategory::Availability);
+    }
+
+    #[test]
+    fn test_calculate_priority_score_critical_availability() {
+        let sys = ObservabilitySystem::new();
+        let alert = make_test_alert("t", "s", AlertSeverity::Critical);
+        assert_eq!(sys.calculate_priority_score(&alert, &AlertCategory::Availability), 100);
+    }
+
+    #[test]
+    fn test_calculate_priority_score_warning_availability() {
+        let sys = ObservabilitySystem::new();
+        let alert = make_test_alert("t", "s", AlertSeverity::Warning);
+        assert_eq!(sys.calculate_priority_score(&alert, &AlertCategory::Availability), 70);
+    }
+
+    #[test]
+    fn test_calculate_priority_score_info_performance() {
+        let sys = ObservabilitySystem::new();
+        let alert = make_test_alert("t", "s", AlertSeverity::Info);
+        assert_eq!(sys.calculate_priority_score(&alert, &AlertCategory::Performance), 35);
+    }
+
+    #[test]
+    fn test_calculate_priority_score_error_resources() {
+        let sys = ObservabilitySystem::new();
+        let alert = make_test_alert("t", "s", AlertSeverity::Error);
+        assert_eq!(sys.calculate_priority_score(&alert, &AlertCategory::Resources), 75);
+    }
+
+    #[test]
+    fn test_calculate_priority_score_security_bonus() {
+        let sys = ObservabilitySystem::new();
+        let alert = make_test_alert("t", "s", AlertSeverity::Warning);
+        assert_eq!(sys.calculate_priority_score(&alert, &AlertCategory::Security), 80);
+    }
+
+    #[test]
+    fn test_generate_recommended_actions_container_health() {
+        let sys = ObservabilitySystem::new();
+        let alert = make_test_alert("t", "s", AlertSeverity::Warning);
+        let actions = sys.generate_recommended_actions(&alert, &AlertCategory::ContainerHealth);
+        assert_eq!(actions.len(), 3);
+        assert!(actions[0].contains("logs"));
+    }
+
+    #[test]
+    fn test_generate_recommended_actions_performance() {
+        let sys = ObservabilitySystem::new();
+        let alert = make_test_alert("t", "s", AlertSeverity::Warning);
+        let actions = sys.generate_recommended_actions(&alert, &AlertCategory::Performance);
+        assert_eq!(actions.len(), 3);
+        assert!(actions[0].contains("resource"));
+    }
+
+    #[test]
+    fn test_generate_recommended_actions_model_quality() {
+        let sys = ObservabilitySystem::new();
+        let alert = make_test_alert("t", "s", AlertSeverity::Warning);
+        let actions = sys.generate_recommended_actions(&alert, &AlertCategory::ModelQuality);
+        assert_eq!(actions.len(), 3);
+        assert!(actions[0].contains("model"));
+    }
+
+    #[test]
+    fn test_generate_recommended_actions_availability_default() {
+        let sys = ObservabilitySystem::new();
+        let alert = make_test_alert("t", "s", AlertSeverity::Warning);
+        let actions = sys.generate_recommended_actions(&alert, &AlertCategory::Availability);
+        assert_eq!(actions.len(), 3);
+        assert!(actions[0].contains("Investigate"));
+    }
+
+    #[test]
+    fn test_calculate_availability_metrics_returns_at_risk() {
+        let sys = ObservabilitySystem::new();
+        let metrics = sys.calculate_availability_metrics().unwrap();
+        assert_eq!(metrics.sla_compliance.status, SlaStatus::AtRisk);
+        assert!((metrics.availability_percentage - 99.5).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_get_uptime_is_small_at_creation() {
+        let sys = ObservabilitySystem::new();
+        assert!(sys.get_uptime() < Duration::from_secs(1));
+    }
+
+    #[test]
+    fn test_sla_status_compliant_threshold() {
+        let c = make_sla_compliance(99.95);
+        assert_eq!(c.status, SlaStatus::Compliant);
+    }
+
+    #[test]
+    fn test_sla_status_breached_threshold() {
+        let c = make_sla_compliance(98.5);
+        assert_eq!(c.status, SlaStatus::Breached);
+    }
 }


### PR DESCRIPTION
## Summary

Targets the two largest untested surfaces in the `harness` crate — the pure/deterministic methods that weren't reached by the existing async integration tests.

**`harness/src/monitoring.rs`** — 9 new `#[test]` / `#[tokio::test]` tests:
- `HealthStatus::is_healthy` and `requires_attention` for all 5 variants
- `AlertThresholds::default` field values
- `calculate_latency_metrics` for empty slice, single duration, and multi-value sort/avg/min/max
- Cache hit-rate logic: all-hits, all-misses, mixed 3/2 split

**`harness/src/observability.rs`** — 18 new tests + 2 helper functions:
- `determine_alert_category` — all 5 branches (container, model, performance title, resource title, fallback)
- `calculate_priority_score` — Critical+Availability cap, Warning+Availability, Info+Performance, Error+Resources, Warning+Security bonus
- `generate_recommended_actions` — ContainerHealth, Performance, ModelQuality, Availability default
- `calculate_availability_metrics` — verifies AtRisk SLA status and 99.5% availability
- `get_uptime` — sub-second at construction
- `SlaStatus` boundary: Compliant (≥99.9%) and Breached (<99.0%)

## Test plan

- [ ] `cargo nextest run -p harness` (or `cargo test -p harness`) passes all new tests
- [ ] Codecov shows increased line coverage on `monitoring.rs` and `observability.rs`
- [ ] No regressions in existing tests

---
_Generated by [Claude Code](https://claude.ai/code/session_014rAnEPRyTAhuy7WWowYbbi)_