### PR TITLE
maintenance: workspace dedup, blocklist coverage, docs URL/link cleanup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,15 +4,15 @@ Thank you for your interest in contributing!
 
 ## Dev Setup
 
-See [README.md](./README.md#quick-start). Detailed contributor setup is tracked in [#175](https://github.com/DominicBurkart/nanna-coder/issues/175).
+See [README.md](README.md#quick-start). Detailed contributor setup is tracked in [#175](https://github.com/dominicburkart/nanna-coder/issues/175).
 
 ## Testing
 
-See [TESTING.md](./TESTING.md).
+See [TESTING.md](TESTING.md).
 
 ## License
 
-All contributions fall under the [project license](./LICENSE).
+All contributions fall under the project licenses: [MIT](LICENSE-MIT) or [Apache 2.0](LICENSE-APACHE).
 
 ## GitHub Issues
 
@@ -20,4 +20,4 @@ If a PR *entirely* completes an issue, include `Closes #<issue number>` in the P
 
 ## Architectural Changes
 
-Changes to the architecture documented in [ARCHITECTURE.md](./ARCHITECTURE.md) must be introduced via an approved GitHub Issue. Incidental architectural changes (for example, to unblock a feature PR) should be flagged during review.
+Changes to the architecture documented in [ARCHITECTURE.md](ARCHITECTURE.md) must be introduced via an approved GitHub Issue. Incidental architectural changes (for example, to unblock a feature PR) should be flagged during review.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Nanna pod, and pulls the Gemma 4 model. The script prints a clear notification
 before each step that requires `sudo`.
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/DominicBurkart/nanna-coder/main/scripts/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/dominicburkart/nanna-coder/main/scripts/install.sh | bash
 ```
 
 Useful flags (pass after `bash -s --` for the curl form):
@@ -52,7 +52,7 @@ curl http://localhost:11434/api/tags   # ollama API
 Prerequisites: Nix with flakes enabled, optionally Cachix for faster builds.
 
 ```bash
-git clone https://github.com/DominicBurkart/nanna-coder.git
+git clone https://github.com/dominicburkart/nanna-coder.git
 cd nanna-coder
 
 # Enter development environment

--- a/docs/CACHE_STRATEGY.md
+++ b/docs/CACHE_STRATEGY.md
@@ -368,4 +368,4 @@ If issues arise with Cachix:
 - [Cachix GitHub Action](https://github.com/cachix/cachix-action)
 - [Nanna Coder Cachix Dashboard](https://nanna-coder.cachix.org)
 - [GitHub Actions Cache Documentation](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows)
-- [Issue #18: Cache Strategy Evaluation](https://github.com/DominicBurkart/nanna-coder/issues/18)
+- [Issue #18: Cache Strategy Evaluation](https://github.com/dominicburkart/nanna-coder/issues/18)

--- a/harness/src/onboarding/profile.rs
+++ b/harness/src/onboarding/profile.rs
@@ -109,6 +109,77 @@ mod tests {
         .is_err());
     }
 
+    /// Every token in `COMMAND_BLOCKLIST` must be rejected. The earlier
+    /// regression only covered `publish`/`deploy`/`push`/`rm -rf`, leaving
+    /// `drop`/`delete`/`destroy` untested even though they are the highest-risk
+    /// entries (data-loss verbs). A typo in any blocklist literal would silently
+    /// pass through.
+    ///
+    /// The invariant under test: for every entry in `COMMAND_BLOCKLIST`, a
+    /// command whose whitespace-tokenized form contains that entry as a
+    /// contiguous window must produce a `BlocklistedCommand` error.
+    #[test]
+    fn tool_spec_rejects_every_blocklist_entry() {
+        for blocked in COMMAND_BLOCKLIST {
+            // Pad with a benign prefix so we exercise the windowing logic
+            // (not just exact-string equality).
+            let command = format!("sh -c {blocked} target");
+            let result = ToolSpec::new(
+                "dangerous",
+                &command,
+                "should be rejected",
+                ToolCategory::Build,
+            );
+            match result {
+                Err(ProfileError::BlocklistedCommand(c)) => {
+                    assert_eq!(c, command, "error must echo the offending command");
+                }
+                other => panic!("expected BlocklistedCommand for entry {blocked:?}, got {other:?}"),
+            }
+        }
+    }
+
+    /// The destructive verbs `drop`, `delete`, `destroy` are the most
+    /// dangerous entries and historically had no targeted coverage. Pin them
+    /// in their own test so a future blocklist edit that drops them
+    /// (deliberately or accidentally) fails loudly with the specific token.
+    #[test]
+    fn tool_spec_rejects_destructive_verbs_individually() {
+        for verb in ["drop", "delete", "destroy"] {
+            let command = format!("db {verb} --all");
+            assert!(
+                matches!(
+                    ToolSpec::new("danger", &command, "destructive", ToolCategory::Build),
+                    Err(ProfileError::BlocklistedCommand(_))
+                ),
+                "blocklist must reject destructive verb {verb:?}"
+            );
+        }
+    }
+
+    /// `rm -rf` is a *multi-token* blocklist entry: the windowing logic must
+    /// match it as two consecutive tokens, not as the single-word substring
+    /// `"rm-rf"`. This pins the multi-token branch of `windows(window_size)`
+    /// which the existing `tool_spec_allows_blocklist_substring_within_word`
+    /// only covers for single-token entries.
+    #[test]
+    fn tool_spec_multi_token_blocklist_requires_adjacent_tokens() {
+        // Two-token match: must reject.
+        assert!(matches!(
+            ToolSpec::new("nuke", "rm -rf /tmp/x", "nuke tmp", ToolCategory::Build),
+            Err(ProfileError::BlocklistedCommand(_))
+        ));
+        // Same tokens but separated by an unrelated token: must NOT match
+        // `rm -rf` because the window is non-adjacent.
+        assert!(ToolSpec::new(
+            "safer",
+            "rm --interactive -rf /tmp/x",
+            "interactive remove",
+            ToolCategory::Build
+        )
+        .is_ok());
+    }
+
     #[test]
     fn tool_spec_accepts_valid_commands() {
         assert!(ToolSpec::new(

--- a/harness/src/workspace.rs
+++ b/harness/src/workspace.rs
@@ -55,8 +55,21 @@ pub struct TaskWorkspace {
 }
 
 impl TaskWorkspace {
-    pub fn create(source_repo: &Path, task_id: &str, branch: &str) -> Result<Self, WorkspaceError> {
-        let workspace_path = std::env::temp_dir().join(format!("nanna-task-{}", task_id));
+    /// Compute the temp-dir worktree path used for a given `task_id`. Centralised
+    /// here so `create`, `create_with_container_using`, and tests stay in sync.
+    fn worktree_path_for(task_id: &str) -> PathBuf {
+        std::env::temp_dir().join(format!("nanna-task-{}", task_id))
+    }
+
+    /// Run `git worktree add <workspace_path> <branch>` from `source_repo`,
+    /// returning a `GitWorktreeCreateFailed` error if git rejects it. Shared by
+    /// both the bare and containerised constructors so their worktree
+    /// invocation cannot drift.
+    fn add_worktree(
+        source_repo: &Path,
+        workspace_path: &Path,
+        branch: &str,
+    ) -> Result<(), WorkspaceError> {
         let output = git_cmd(source_repo)
             .args([
                 "worktree",
@@ -69,6 +82,12 @@ impl TaskWorkspace {
             let stderr = String::from_utf8_lossy(&output.stderr).to_string();
             return Err(WorkspaceError::GitWorktreeCreateFailed(stderr));
         }
+        Ok(())
+    }
+
+    pub fn create(source_repo: &Path, task_id: &str, branch: &str) -> Result<Self, WorkspaceError> {
+        let workspace_path = Self::worktree_path_for(task_id);
+        Self::add_worktree(source_repo, &workspace_path, branch)?;
         Ok(Self {
             workspace_path,
             source_repo: source_repo.to_path_buf(),
@@ -117,19 +136,8 @@ impl TaskWorkspace {
                 .all(|c| c.is_ascii_alphanumeric() || c == '-'),
             "task_id must be alphanumeric+hyphen to avoid path traversal, got: {task_id:?}"
         );
-        let workspace_path = std::env::temp_dir().join(format!("nanna-task-{}", task_id));
-        let output = git_cmd(source_repo)
-            .args([
-                "worktree",
-                "add",
-                workspace_path.to_str().expect("non-UTF8 path"),
-                branch,
-            ])
-            .output()?;
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr).to_string();
-            return Err(WorkspaceError::GitWorktreeCreateFailed(stderr));
-        }
+        let workspace_path = Self::worktree_path_for(task_id);
+        Self::add_worktree(source_repo, &workspace_path, branch)?;
 
         let cleanup_worktree = || {
             let _ = git_cmd(source_repo)


### PR DESCRIPTION
Three small, focused commits — one per workstream. Every commit is reversible in isolation and builds + lints cleanly (`cargo fmt --check`, `cargo clippy --all-features --all-targets -- -D warnings`, `cargo test --workspace --lib --all-features`). The only failing tests in `cargo test` (`eval::swebench::tests::materialize_from_url_*`) also fail on `main` — they hit GitHub over the network and the sandbox here has no DNS — so they are not introduced by this PR.

## Workstream 1 — Architecture (`arch: deduplicate TaskWorkspace worktree-add logic`)

`harness/src/workspace.rs:58-178` had `TaskWorkspace::create` and `TaskWorkspace::create_with_container_using` independently computing `std::env::temp_dir().join(format!("nanna-task-{task_id}"))` and running an identical `git worktree add` invocation with the same stderr-to-`GitWorktreeCreateFailed` mapping. If one constructor's path format or failure surface ever drifted, the other would silently disagree.

Extracted both into private helpers:

- `worktree_path_for(task_id)` — single source of truth for the temp path.
- `add_worktree(source_repo, workspace_path, branch)` — single source of truth for the git invocation and the error mapping.

No behavior change. All 13 existing workspace unit tests pass unchanged. No new tests needed — the helpers are exercised end-to-end by every existing test that calls `create` or `create_with_container_using`.

## Workstream 2 — Testing (`test: cover every COMMAND_BLOCKLIST entry in ToolSpec::new`)

**Component under test:** `harness/src/onboarding/profile.rs` — `ToolSpec::new`'s command blocklist, which is the agent's first line of defense against onboarded repos requesting destructive operations.

**Current disposition:** `tool_spec_rejects_blocklisted_commands` exercised only 4 of the 7 blocklist entries (`publish`, `deploy`, `push`, `rm -rf`). The destructive verbs `drop`, `delete`, and `destroy` — the *highest-risk* entries — were entirely uncovered. A typo or accidental deletion of any of them would silently weaken the safety guarantee.

**Strategy chosen:** **data-driven unit tests** over the actual `COMMAND_BLOCKLIST` constant. Unit tests fit because the function is pure, the invariant is small, and we want the test suite to scale automatically as the blocklist grows. Proptest would over-engineer for a 7-element constant; integration tests would couple the safety contract to onboarding orchestration we don't need to exercise here.

Three new tests:

- `tool_spec_rejects_every_blocklist_entry` — iterates `COMMAND_BLOCKLIST` directly so adding an entry is automatically covered.
- `tool_spec_rejects_destructive_verbs_individually` — pins the three destructive verbs by name with bespoke error messages, so a deletion produces a *named* failure rather than a count-mismatch.
- `tool_spec_multi_token_blocklist_requires_adjacent_tokens` — completes the multi-token branch coverage: positive (`rm -rf /tmp/x` rejected) and negative (`rm --interactive -rf /tmp/x` accepted because the tokens are non-adjacent).

**Invariants pinned:**
1. Every entry in `COMMAND_BLOCKLIST` produces `ProfileError::BlocklistedCommand`.
2. Multi-token entries match only on adjacent tokens.
3. Single-token entries are matched by exact token equality, not substring (already covered by the existing `tool_spec_allows_blocklist_substring_within_word`).

7 tests pass in `onboarding::profile::tests` (was 4 — net +3, +71 LoC of test code).

## Workstream 3 — Clarity (`docs: standardize repo URL casing and relative-link style`)

Three small consistency fixes across user-facing docs (no information lost):

1. **Lowercase `dominicburkart/nanna-coder`** in URLs in `README.md`, `CONTRIBUTING.md`, and `docs/CACHE_STRATEGY.md`. The actual git remote uses lowercase; the previous mixed casing implied two separate repositories.
2. **Drop the `./` prefix on intra-repo links in `CONTRIBUTING.md`** (`./README.md` → `README.md`, etc.) to match the bare-relative style already used in `README.md` and `ARCHITECTURE.md`.
3. **Fix the broken `[project license](./LICENSE)` link** — no `LICENSE` file exists, only `LICENSE-MIT` and `LICENSE-APACHE`. Now links to both, matching the workspace `license = "MIT OR Apache-2.0"` declaration.

Source references inside Rust code (entity doctests, `Cargo.toml` `repository`, `CODEOWNERS`) are deliberately untouched — they are not user-facing markdown and changing them would touch published artifacts / GitHub usernames.

## Test plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --workspace --all-features --all-targets -- -D warnings` — clean
- [x] `cargo test --package harness --lib --all-features workspace::` — 13 pass
- [x] `cargo test --package harness --lib --all-features onboarding::profile::` — 7 pass (was 4)
- [x] `cargo test --workspace --lib --all-features` — 539 pass / 3 pre-existing failures on main / 1 ignored
- [ ] Codecov: `harness/src/workspace.rs` should stay at 100% on the patched lines (logic is unchanged); `harness/src/onboarding/profile.rs` should increase on patch coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MQyYkAKbmXmojRkaxGZLJ7)_