### PR TITLE
test: expand coverage for monitoring and tools modules

### DIFF
--- a/harness/tests/monitoring_coverage_tests.rs
+++ b/harness/tests/monitoring_coverage_tests.rs
@@ -1,0 +1,285 @@
+//! Tests covering gaps in harness/src/monitoring.rs.
+//!
+//! Coverage added:
+//! - `HealthStatus::is_healthy` and `requires_attention` for all five variants
+//! - `AlertSeverity` and `ErrorSeverity` ordering (PartialOrd / Ord)
+//! - `DefaultMetricsCollector::reset_metrics` clears all counters
+//! - `MetricsFormat::Custom` returns `MetricsCollectionFailed`
+//! - `DefaultAlertManager::get_alert_history` (limit + acknowledged inclusion)
+//! - `DefaultAlertManager::configure_thresholds` succeeds without error
+//! - `MonitoringSystem::start_monitoring` / `stop_monitoring` lifecycle
+//! - `DefaultMetricsCollector::record_error` grouping and `recent_errors` cap at 10
+
+use chrono::Utc;
+use harness::monitoring::{
+    AlertManager, AlertSeverity, AlertThresholds, DefaultAlertManager, DefaultMetricsCollector,
+    ErrorEvent, ErrorSeverity, HealthStatus, MetricsCollector, MetricsFormat, MonitoringSystem,
+};
+use std::time::Duration;
+
+// --- HealthStatus::is_healthy -----------------------------------------------
+
+#[test]
+fn health_status_healthy_is_healthy() {
+    assert!(HealthStatus::Healthy.is_healthy());
+}
+
+#[test]
+fn health_status_non_healthy_variants_are_not_healthy() {
+    assert!(!HealthStatus::Warning.is_healthy());
+    assert!(!HealthStatus::Degraded.is_healthy());
+    assert!(!HealthStatus::Unhealthy.is_healthy());
+    assert!(!HealthStatus::Unknown.is_healthy());
+}
+
+// --- HealthStatus::requires_attention ----------------------------------------
+
+#[test]
+fn health_status_degraded_states_require_attention() {
+    assert!(HealthStatus::Warning.requires_attention());
+    assert!(HealthStatus::Degraded.requires_attention());
+    assert!(HealthStatus::Unhealthy.requires_attention());
+}
+
+#[test]
+fn health_status_healthy_and_unknown_do_not_require_attention() {
+    assert!(!HealthStatus::Healthy.requires_attention());
+    assert!(!HealthStatus::Unknown.requires_attention());
+}
+
+// --- AlertSeverity ordering --------------------------------------------------
+
+#[test]
+fn alert_severity_ordering_is_increasing() {
+    assert!(AlertSeverity::Info < AlertSeverity::Warning);
+    assert!(AlertSeverity::Warning < AlertSeverity::Error);
+    assert!(AlertSeverity::Error < AlertSeverity::Critical);
+    assert!(AlertSeverity::Info < AlertSeverity::Critical);
+}
+
+#[test]
+fn alert_severity_sort_places_critical_last() {
+    let mut severities = vec![
+        AlertSeverity::Critical,
+        AlertSeverity::Info,
+        AlertSeverity::Warning,
+        AlertSeverity::Error,
+    ];
+    severities.sort();
+    assert_eq!(severities.last().unwrap(), &AlertSeverity::Critical);
+    assert_eq!(severities.first().unwrap(), &AlertSeverity::Info);
+}
+
+// --- ErrorSeverity ordering --------------------------------------------------
+
+#[test]
+fn error_severity_ordering_is_increasing() {
+    assert!(ErrorSeverity::Info < ErrorSeverity::Warning);
+    assert!(ErrorSeverity::Warning < ErrorSeverity::Error);
+    assert!(ErrorSeverity::Error < ErrorSeverity::Critical);
+}
+
+// --- DefaultMetricsCollector::reset_metrics ----------------------------------
+
+#[tokio::test]
+async fn reset_metrics_clears_all_recorded_data() {
+    let mut collector = DefaultMetricsCollector::new();
+
+    collector
+        .record_request_latency("svc", Duration::from_millis(100))
+        .await;
+    collector.record_cache_hit("k").await;
+    collector.record_cache_miss("k2").await;
+    collector
+        .record_error(ErrorEvent {
+            timestamp: Utc::now(),
+            error_type: "TestError".to_string(),
+            message: "test".to_string(),
+            component: "test".to_string(),
+            severity: ErrorSeverity::Error,
+        })
+        .await;
+
+    let before = collector.get_current_metrics().await.unwrap();
+    assert_eq!(before.cache_metrics.hits, 1);
+    assert!(!before.request_latencies.is_empty());
+    assert_eq!(before.error_metrics.total_errors, 1);
+
+    collector.reset_metrics().await;
+
+    let after = collector.get_current_metrics().await.unwrap();
+    assert_eq!(after.cache_metrics.hits, 0);
+    assert_eq!(after.cache_metrics.misses, 0);
+    assert!(
+        after.request_latencies.is_empty(),
+        "request_latencies should be empty after reset"
+    );
+    assert_eq!(after.error_metrics.total_errors, 0);
+}
+
+// --- MetricsFormat::Custom error path ----------------------------------------
+
+#[tokio::test]
+async fn export_metrics_custom_format_returns_error_with_format_name() {
+    let collector = DefaultMetricsCollector::new();
+    let result = collector
+        .export_metrics(MetricsFormat::Custom("ndjson".to_string()))
+        .await;
+
+    assert!(
+        result.is_err(),
+        "MetricsFormat::Custom should return an error"
+    );
+    let err_msg = result.unwrap_err().to_string();
+    assert!(
+        err_msg.contains("ndjson"),
+        "error message should include the format name, got: {err_msg}"
+    );
+}
+
+// --- DefaultAlertManager::get_alert_history ----------------------------------
+
+#[tokio::test]
+async fn alert_history_includes_acknowledged_alerts() {
+    let manager = DefaultAlertManager::new();
+    let id = manager
+        .send_alert("Test", "description", AlertSeverity::Warning)
+        .await
+        .unwrap();
+    manager.acknowledge_alert(&id).await.unwrap();
+
+    let active = manager.get_active_alerts().await.unwrap();
+    assert_eq!(active.len(), 0, "acknowledged alert should not be active");
+
+    let history = manager.get_alert_history(10).await.unwrap();
+    assert_eq!(history.len(), 1, "history should include acknowledged alert");
+    assert!(history[0].acknowledged);
+}
+
+#[tokio::test]
+async fn alert_history_respects_limit_returning_most_recent() {
+    let manager = DefaultAlertManager::new();
+
+    for i in 0..7 {
+        manager
+            .send_alert(&format!("Alert {i}"), "desc", AlertSeverity::Info)
+            .await
+            .unwrap();
+    }
+
+    let history_3 = manager.get_alert_history(3).await.unwrap();
+    assert_eq!(history_3.len(), 3, "should return exactly 3 alerts");
+
+    let history_all = manager.get_alert_history(100).await.unwrap();
+    assert_eq!(history_all.len(), 7, "should return all 7 alerts");
+}
+
+// --- DefaultAlertManager::configure_thresholds --------------------------------
+
+#[tokio::test]
+async fn configure_thresholds_succeeds() {
+    let mut manager = DefaultAlertManager::new();
+    let thresholds = AlertThresholds {
+        max_latency_ms: 2000,
+        min_cache_hit_rate: 0.6,
+        max_error_rate: 0.02,
+        max_cpu_usage: 0.75,
+        max_memory_usage: 0.80,
+        health_check_timeout: Duration::from_secs(15),
+    };
+    let result = manager.configure_thresholds(thresholds).await;
+    assert!(
+        result.is_ok(),
+        "configure_thresholds should succeed, got: {:?}",
+        result.err()
+    );
+}
+
+// --- MonitoringSystem start/stop lifecycle -----------------------------------
+
+#[tokio::test]
+async fn monitoring_system_start_and_stop_lifecycle() {
+    let mut system = MonitoringSystem::new();
+
+    system.start_monitoring().await.unwrap();
+
+    tokio::time::sleep(Duration::from_millis(10)).await;
+
+    // stop_monitoring aborts the background task
+    system.stop_monitoring().await;
+
+    // calling stop again when no task is running must be a no-op (no panic)
+    system.stop_monitoring().await;
+}
+
+// --- DefaultMetricsCollector::record_error grouping --------------------------
+
+#[tokio::test]
+async fn record_error_groups_by_error_type() {
+    let mut collector = DefaultMetricsCollector::new();
+
+    for _ in 0..3 {
+        collector
+            .record_error(ErrorEvent {
+                timestamp: Utc::now(),
+                error_type: "NetworkError".to_string(),
+                message: "connection refused".to_string(),
+                component: "http".to_string(),
+                severity: ErrorSeverity::Error,
+            })
+            .await;
+    }
+    for _ in 0..2 {
+        collector
+            .record_error(ErrorEvent {
+                timestamp: Utc::now(),
+                error_type: "TimeoutError".to_string(),
+                message: "deadline exceeded".to_string(),
+                component: "rpc".to_string(),
+                severity: ErrorSeverity::Warning,
+            })
+            .await;
+    }
+
+    let metrics = collector.get_current_metrics().await.unwrap();
+    assert_eq!(metrics.error_metrics.total_errors, 5);
+    assert_eq!(
+        metrics.error_metrics.errors_by_type["NetworkError"],
+        3,
+        "NetworkError count should be 3"
+    );
+    assert_eq!(
+        metrics.error_metrics.errors_by_type["TimeoutError"],
+        2,
+        "TimeoutError count should be 2"
+    );
+}
+
+#[tokio::test]
+async fn record_error_recent_errors_capped_at_ten() {
+    let mut collector = DefaultMetricsCollector::new();
+
+    for i in 0..15u32 {
+        collector
+            .record_error(ErrorEvent {
+                timestamp: Utc::now(),
+                error_type: "BulkError".to_string(),
+                message: format!("error #{i}"),
+                component: "bulk".to_string(),
+                severity: ErrorSeverity::Info,
+            })
+            .await;
+    }
+
+    let metrics = collector.get_current_metrics().await.unwrap();
+    assert_eq!(
+        metrics.error_metrics.total_errors,
+        15,
+        "total_errors should count all 15"
+    );
+    assert!(
+        metrics.error_metrics.recent_errors.len() <= 10,
+        "recent_errors must be capped at 10, got {}",
+        metrics.error_metrics.recent_errors.len()
+    );
+}

--- a/harness/tests/tool_additional_coverage.rs
+++ b/harness/tests/tool_additional_coverage.rs
@@ -1,0 +1,258 @@
+//! Additional unit tests covering gaps in harness/src/tools.rs.
+//!
+//! Coverage added:
+//! - `CalculatorTool::divide` happy path (non-zero divisor)
+//! - `WriteFileTool`: successful write + content verification; overwrite
+//! - `ReadFileTool`: `end_line` parameter (range read)
+//! - `ListDirTool`: basic listing; glob-pattern filter
+//! - `SearchTool`: pattern match; no-match empty results; file/line metadata
+
+use harness::tools::{CalculatorTool, ListDirTool, ReadFileTool, SearchTool, Tool, WriteFileTool};
+use serde_json::json;
+
+// --- CalculatorTool::divide (non-zero) ---------------------------------------
+
+#[tokio::test]
+async fn calculator_divide_nonzero_returns_correct_quotient() {
+    let tool = CalculatorTool::new();
+    let result = tool
+        .execute(json!({ "operation": "divide", "a": 10.0, "b": 4.0 }))
+        .await
+        .expect("divide with non-zero divisor should succeed");
+    let quotient = result["result"].as_f64().unwrap();
+    assert!(
+        (quotient - 2.5).abs() < 1e-10,
+        "10 / 4 should be 2.5, got {quotient}"
+    );
+    assert_eq!(result["operation"], "divide");
+}
+
+// --- WriteFileTool happy path ------------------------------------------------
+
+#[tokio::test]
+async fn write_file_creates_file_with_correct_content() {
+    let temp_dir = tempfile::tempdir().expect("tempdir");
+    let tool = WriteFileTool::new(temp_dir.path().to_path_buf());
+
+    let result = tool
+        .execute(json!({ "path": "hello.txt", "content": "hello world\nline 2" }))
+        .await
+        .expect("write_file should succeed");
+
+    assert_eq!(result["success"], true);
+    assert_eq!(result["path"], "hello.txt");
+
+    let written = std::fs::read_to_string(temp_dir.path().join("hello.txt"))
+        .expect("file should exist after write");
+    assert_eq!(written, "hello world\nline 2");
+}
+
+#[tokio::test]
+async fn write_file_overwrites_existing_content() {
+    let temp_dir = tempfile::tempdir().expect("tempdir");
+    let path = temp_dir.path().join("overwrite.txt");
+    std::fs::write(&path, "old content").unwrap();
+
+    let tool = WriteFileTool::new(temp_dir.path().to_path_buf());
+    tool.execute(json!({ "path": "overwrite.txt", "content": "new content" }))
+        .await
+        .expect("overwrite should succeed");
+
+    let content = std::fs::read_to_string(&path).unwrap();
+    assert_eq!(content, "new content");
+}
+
+#[tokio::test]
+async fn write_file_reports_bytes_written() {
+    let temp_dir = tempfile::tempdir().expect("tempdir");
+    let tool = WriteFileTool::new(temp_dir.path().to_path_buf());
+
+    let content = "12345"; // 5 bytes
+    let result = tool
+        .execute(json!({ "path": "bytes.txt", "content": content }))
+        .await
+        .expect("write_file should succeed");
+
+    assert_eq!(
+        result["bytes_written"].as_u64().unwrap(),
+        5,
+        "bytes_written should match content length"
+    );
+}
+
+// --- ReadFileTool end_line parameter -----------------------------------------
+
+#[tokio::test]
+async fn read_file_start_and_end_line_returns_exact_range() {
+    let temp_dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(
+        temp_dir.path().join("lines.txt"),
+        "line1\nline2\nline3\nline4\nline5",
+    )
+    .unwrap();
+
+    let tool = ReadFileTool::new(temp_dir.path().to_path_buf());
+    let result = tool
+        .execute(json!({ "path": "lines.txt", "start_line": 2, "end_line": 4 }))
+        .await
+        .expect("range read must succeed");
+
+    assert_eq!(
+        result["lines_shown"],
+        3,
+        "lines 2-4 inclusive = 3 lines"
+    );
+    let content = result["content"].as_str().unwrap();
+    assert!(content.contains("line2"), "should contain line2");
+    assert!(content.contains("line3"), "should contain line3");
+    assert!(content.contains("line4"), "should contain line4");
+    assert!(!content.contains("line1"), "should not contain line1");
+    assert!(!content.contains("line5"), "should not contain line5");
+}
+
+#[tokio::test]
+async fn read_file_end_line_without_start_line_reads_from_beginning() {
+    let temp_dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(temp_dir.path().join("file.txt"), "a\nb\nc\nd").unwrap();
+
+    let tool = ReadFileTool::new(temp_dir.path().to_path_buf());
+    let result = tool
+        .execute(json!({ "path": "file.txt", "end_line": 2 }))
+        .await
+        .expect("end_line without start_line must succeed");
+
+    assert_eq!(
+        result["lines_shown"],
+        2,
+        "end_line=2 from start should give 2 lines"
+    );
+    let content = result["content"].as_str().unwrap();
+    assert!(content.contains('a'), "first line should be included");
+    assert!(content.contains('b'), "second line should be included");
+    assert!(!content.contains('c'), "third line should be excluded");
+}
+
+// --- ListDirTool -------------------------------------------------------------
+
+#[tokio::test]
+async fn list_dir_returns_files_in_workspace_root() {
+    let temp_dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(temp_dir.path().join("alpha.txt"), "a").unwrap();
+    std::fs::write(temp_dir.path().join("beta.rs"), "b").unwrap();
+
+    let tool = ListDirTool::new(temp_dir.path().to_path_buf());
+    let result = tool
+        .execute(json!({ "path": "." }))
+        .await
+        .expect("list_dir should succeed");
+
+    let entries = result["entries"].as_array().expect("entries should be array");
+    let names: Vec<&str> = entries
+        .iter()
+        .filter_map(|e| e["name"].as_str())
+        .collect();
+
+    assert!(names.contains(&"alpha.txt"), "alpha.txt should be listed");
+    assert!(names.contains(&"beta.rs"), "beta.rs should be listed");
+    assert_eq!(result["count"].as_u64().unwrap(), 2);
+}
+
+#[tokio::test]
+async fn list_dir_with_glob_pattern_filters_by_extension() {
+    let temp_dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(temp_dir.path().join("main.rs"), "fn main() {}").unwrap();
+    std::fs::write(temp_dir.path().join("readme.md"), "# doc").unwrap();
+    std::fs::write(temp_dir.path().join("lib.rs"), "pub mod lib;").unwrap();
+
+    let tool = ListDirTool::new(temp_dir.path().to_path_buf());
+    let result = tool
+        .execute(json!({ "path": ".", "pattern": "*.rs" }))
+        .await
+        .expect("pattern-filtered list_dir should succeed");
+
+    let entries = result["entries"].as_array().expect("entries array");
+    assert_eq!(entries.len(), 2, "only .rs files should be listed");
+    for entry in entries {
+        assert!(
+            entry["name"].as_str().unwrap().ends_with(".rs"),
+            "all entries should be .rs files"
+        );
+    }
+}
+
+// --- SearchTool --------------------------------------------------------------
+
+#[tokio::test]
+async fn search_tool_finds_pattern_matches_in_files() {
+    let temp_dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(
+        temp_dir.path().join("code.rs"),
+        "fn hello() {}\nfn world() {}\nconst FOO: i32 = 42;\n",
+    )
+    .unwrap();
+
+    let tool = SearchTool::new(temp_dir.path().to_path_buf());
+    let result = tool
+        .execute(json!({ "pattern": "fn " }))
+        .await
+        .expect("search should succeed");
+
+    let results = result["results"].as_array().expect("results should be array");
+    assert_eq!(results.len(), 2, "should find 2 fn declarations");
+    let contents: Vec<&str> = results
+        .iter()
+        .filter_map(|m| m["content"].as_str())
+        .collect();
+    assert!(
+        contents.iter().any(|c| c.contains("hello")),
+        "hello fn should be found"
+    );
+    assert!(
+        contents.iter().any(|c| c.contains("world")),
+        "world fn should be found"
+    );
+}
+
+#[tokio::test]
+async fn search_tool_returns_empty_results_when_no_match() {
+    let temp_dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(temp_dir.path().join("data.txt"), "nothing here").unwrap();
+
+    let tool = SearchTool::new(temp_dir.path().to_path_buf());
+    let result = tool
+        .execute(json!({ "pattern": "NONEXISTENT_PATTERN_XYZ_12345" }))
+        .await
+        .expect("search with no matches should succeed (not error)");
+
+    let results = result["results"].as_array().expect("results should be array");
+    assert!(
+        results.is_empty(),
+        "should have no results when pattern does not match"
+    );
+    assert_eq!(result["count"], 0);
+}
+
+#[tokio::test]
+async fn search_tool_result_includes_file_and_line_number() {
+    let temp_dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(
+        temp_dir.path().join("target.txt"),
+        "first line\nSEARCH_ME\nthird line",
+    )
+    .unwrap();
+
+    let tool = SearchTool::new(temp_dir.path().to_path_buf());
+    let result = tool
+        .execute(json!({ "pattern": "SEARCH_ME" }))
+        .await
+        .expect("search should succeed");
+
+    let results = result["results"].as_array().unwrap();
+    assert_eq!(results.len(), 1);
+    let hit = &results[0];
+    assert_eq!(hit["line"].as_u64().unwrap(), 2, "SEARCH_ME is on line 2");
+    assert!(
+        hit["file"].as_str().unwrap().contains("target.txt"),
+        "file path should reference target.txt"
+    );
+}


### PR DESCRIPTION
## Summary

Adds two new integration test files targeting the largest code-coverage gaps identified via Codecov:

**`harness/tests/monitoring_coverage_tests.rs`** — covers `monitoring.rs` gaps:
- `HealthStatus::is_healthy` and `requires_attention` for all five variants
- `AlertSeverity` and `ErrorSeverity` `PartialOrd`/`Ord` ordering
- `DefaultMetricsCollector::reset_metrics` — verifies all counters are cleared
- `MetricsFormat::Custom` error branch in `export_metrics`
- `DefaultAlertManager::get_alert_history` — limit and acknowledged-alert inclusion
- `DefaultAlertManager::configure_thresholds` — succeeds without error
- `MonitoringSystem::start_monitoring` / `stop_monitoring` lifecycle
- `record_error` grouping into `errors_by_type` and `recent_errors` cap at 10

**`harness/tests/tool_additional_coverage.rs`** — covers `tools.rs` gaps:
- `CalculatorTool::divide` non-zero happy path
- `WriteFileTool` successful write + content verification + overwrite + `bytes_written`
- `ReadFileTool` `end_line` parameter (range read) and `end_line`-without-`start_line`
- `ListDirTool` basic listing and glob-pattern filtering
- `SearchTool` pattern matching, no-match empty results, file/line metadata in results

## Test plan
- [ ] `unit` job: `cargo nextest run --workspace --lib --all-features` (inline tests unchanged)
- [ ] `integration` job: `cargo nextest run --workspace --test '*' --all-features` (new files)
- [ ] `security` job: `cargo tarpaulin --workspace --all-features` + Codecov upload
- [ ] `lint` job: `cargo clippy --all-targets --all-features` passes; `cargo fmt --check` passes

---
_Generated by [Claude Code](https://claude.ai/code/session_013UXTgLWeBkKNkc5X4Lo5db)_