### PR TITLE
test: add execute() coverage for RunCommandTool

### DIFF
--- a/harness/src/tools.rs
+++ b/harness/src/tools.rs
@@ -2484,6 +2484,36 @@ mod tests {
         let registry = create_tool_registry(&cwd);
         assert!(registry.get_tool("github_pr_status").is_some());
     }
+
+    #[tokio::test]
+    async fn test_run_command_tool_missing_command_via_registry() {
+        use std::sync::Arc;
+        let temp_dir = tempfile::tempdir().unwrap();
+        let handle = Arc::new(crate::container::ContainerHandle {
+            name: "test".to_string(),
+            runtime: crate::container::ContainerRuntime::None,
+            port: None,
+            needs_cleanup: false,
+        });
+        let registry = create_container_tool_registry(temp_dir.path(), handle, CONTAINER_WORKSPACE_DIR);
+        let result = registry.execute("run_command", json!({})).await;
+        assert!(matches!(result, Err(ToolError::InvalidArguments { .. })));
+    }
+
+    #[tokio::test]
+    async fn test_run_command_tool_no_runtime_via_registry() {
+        use std::sync::Arc;
+        let temp_dir = tempfile::tempdir().unwrap();
+        let handle = Arc::new(crate::container::ContainerHandle {
+            name: "test".to_string(),
+            runtime: crate::container::ContainerRuntime::None,
+            port: None,
+            needs_cleanup: false,
+        });
+        let registry = create_container_tool_registry(temp_dir.path(), handle, CONTAINER_WORKSPACE_DIR);
+        let result = registry.execute("run_command", json!({ "command": "echo hello" })).await;
+        assert!(matches!(result, Err(ToolError::ExecutionFailed { .. })));
+    }
 }
 
 #[cfg(kani)]


### PR DESCRIPTION
## Summary

Codecov showed `RunCommandTool::execute()` had no test coverage — the tool was only verified to exist in the registry, not to behave correctly. This PR adds two tests that exercise the two previously-untested error paths via the public `create_container_tool_registry` API.

### Changes

- **`harness/src/tools.rs`** — 2 new `#[tokio::test]` tests:
  - `test_run_command_tool_missing_command_via_registry`: calling `run_command` with no `command` argument returns `ToolError::InvalidArguments`
  - `test_run_command_tool_no_runtime_via_registry`: calling `run_command` with a valid command but `ContainerRuntime::None` returns `ToolError::ExecutionFailed`

Both tests construct a `ContainerHandle` with `ContainerRuntime::None` and go through `create_container_tool_registry`, keeping the test surface purely against the public API.

## Test plan

- [ ] `cargo test` (or `cargo nextest run`) passes in CI
- [ ] No regressions in existing tool tests

---
_Generated by [Claude Code](https://claude.ai/code/session_01BkdJysfja7KhCKTDxCzkQy)_