### PR TITLE
test(harness): expand unit-test coverage for monitoring, telemetry, and observability

### DIFF
--- a/harness/src/monitoring.rs
+++ b/harness/src/monitoring.rs
@@ -1342,10 +1342,7 @@ mod tests {
 
         let metrics = collector.get_current_metrics().await.unwrap();
         assert!(metrics.model_metrics.contains_key("test-model"));
-        assert_eq!(
-            metrics.model_metrics["test-model"].inference_count,
-            10
-        );
+        assert_eq!(metrics.model_metrics["test-model"].inference_count, 10);
     }
 
     #[tokio::test]

--- a/harness/src/monitoring.rs
+++ b/harness/src/monitoring.rs
@@ -1242,4 +1242,194 @@ mod tests {
         let csv_export = collector.export_metrics(MetricsFormat::Csv).await.unwrap();
         assert!(csv_export.contains("timestamp,metric_type,service,value"));
     }
+
+    #[tokio::test]
+    async fn test_health_status_methods() {
+        assert!(HealthStatus::Healthy.is_healthy());
+        assert!(!HealthStatus::Warning.is_healthy());
+        assert!(!HealthStatus::Degraded.is_healthy());
+        assert!(!HealthStatus::Unhealthy.is_healthy());
+        assert!(!HealthStatus::Unknown.is_healthy());
+
+        assert!(!HealthStatus::Healthy.requires_attention());
+        assert!(HealthStatus::Warning.requires_attention());
+        assert!(HealthStatus::Degraded.requires_attention());
+        assert!(HealthStatus::Unhealthy.requires_attention());
+        assert!(!HealthStatus::Unknown.requires_attention());
+    }
+
+    #[tokio::test]
+    async fn test_reset_metrics() {
+        let mut collector = DefaultMetricsCollector::new();
+        collector.record_cache_hit("key1").await;
+        collector.record_cache_miss("key2").await;
+
+        let before = collector.get_current_metrics().await.unwrap();
+        assert_eq!(before.cache_metrics.hits, 1);
+        assert_eq!(before.cache_metrics.misses, 1);
+
+        collector.reset_metrics().await;
+
+        let after = collector.get_current_metrics().await.unwrap();
+        assert_eq!(after.cache_metrics.hits, 0);
+        assert_eq!(after.cache_metrics.misses, 0);
+    }
+
+    #[tokio::test]
+    async fn test_export_metrics_custom_format_returns_error() {
+        let collector = DefaultMetricsCollector::new();
+        let result = collector
+            .export_metrics(MetricsFormat::Custom("my_format".to_string()))
+            .await;
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(err_msg.contains("my_format"));
+    }
+
+    #[tokio::test]
+    async fn test_monitoring_system_start_stop() {
+        let mut system = MonitoringSystem::new();
+        system.start_monitoring().await.unwrap();
+        system.stop_monitoring().await;
+    }
+
+    #[tokio::test]
+    async fn test_record_error() {
+        use chrono::Utc;
+        let mut collector = DefaultMetricsCollector::new();
+        let error = ErrorEvent {
+            timestamp: Utc::now(),
+            error_type: "network_error".to_string(),
+            message: "Connection refused".to_string(),
+            component: "api_gateway".to_string(),
+            severity: ErrorSeverity::Error,
+        };
+        collector.record_error(error).await;
+
+        let metrics = collector.get_current_metrics().await.unwrap();
+        assert_eq!(metrics.error_metrics.total_errors, 1);
+        assert!(metrics
+            .error_metrics
+            .errors_by_type
+            .contains_key("network_error"));
+        assert_eq!(metrics.error_metrics.recent_errors.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_record_model_inference() {
+        let mut collector = DefaultMetricsCollector::new();
+        let model_metrics = ModelMetrics {
+            model_name: "test-model".to_string(),
+            inference_count: 10,
+            avg_inference_time_ms: 150.0,
+            tokens_per_second: 100.0,
+            success_rate: 0.99,
+            quality_scores: QualityMetrics {
+                avg_coherence: 0.9,
+                avg_relevance: 0.85,
+                consistency: 0.88,
+                accuracy_rate: 0.92,
+            },
+            resource_usage: ModelResourceUsage {
+                peak_memory_mb: 256.0,
+                avg_cpu_percent: 25.0,
+                gpu_utilization_percent: Some(80.0),
+            },
+        };
+        collector
+            .record_model_inference("test-model", model_metrics)
+            .await;
+
+        let metrics = collector.get_current_metrics().await.unwrap();
+        assert!(metrics.model_metrics.contains_key("test-model"));
+        assert_eq!(
+            metrics.model_metrics["test-model"].inference_count,
+            10
+        );
+    }
+
+    #[tokio::test]
+    async fn test_health_monitor_check_model_health() {
+        let monitor = DefaultHealthMonitor::new(Duration::from_secs(30));
+        let result = monitor.check_model_health("qwen3:0.6b").await.unwrap();
+        assert_eq!(result.status, HealthStatus::Healthy);
+        assert!(result.message.contains("qwen3:0.6b"));
+    }
+
+    #[tokio::test]
+    async fn test_health_monitor_comprehensive_health_check() {
+        let monitor = DefaultHealthMonitor::new(Duration::from_secs(30));
+        let results = monitor.comprehensive_health_check().await.unwrap();
+        assert!(!results.is_empty());
+        assert!(results.iter().any(|r| r.component == "system"));
+    }
+
+    #[tokio::test]
+    async fn test_health_monitor_set_check_interval() {
+        let mut monitor = DefaultHealthMonitor::new(Duration::from_secs(30));
+        monitor.set_check_interval(Duration::from_secs(120));
+        // Interval should be updated without panic
+    }
+
+    #[tokio::test]
+    async fn test_alert_manager_get_alert_history() {
+        let manager = DefaultAlertManager::new();
+
+        manager
+            .send_alert("Alert 1", "Desc 1", AlertSeverity::Info)
+            .await
+            .unwrap();
+        manager
+            .send_alert("Alert 2", "Desc 2", AlertSeverity::Critical)
+            .await
+            .unwrap();
+
+        let full_history = manager.get_alert_history(10).await.unwrap();
+        assert_eq!(full_history.len(), 2);
+
+        let limited = manager.get_alert_history(1).await.unwrap();
+        assert_eq!(limited.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_alert_manager_configure_thresholds() {
+        let mut manager = DefaultAlertManager::new();
+        let thresholds = AlertThresholds {
+            max_latency_ms: 1000,
+            min_cache_hit_rate: 0.7,
+            max_error_rate: 0.1,
+            max_cpu_usage: 0.8,
+            max_memory_usage: 0.8,
+            health_check_timeout: Duration::from_secs(15),
+        };
+        manager.configure_thresholds(thresholds).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_alert_manager_acknowledge_nonexistent_fails() {
+        let manager = DefaultAlertManager::new();
+        let result = manager.acknowledge_alert("nonexistent-alert-id").await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_alert_manager_all_severity_levels() {
+        let manager = DefaultAlertManager::new();
+
+        manager
+            .send_alert("Info Alert", "Desc", AlertSeverity::Info)
+            .await
+            .unwrap();
+        manager
+            .send_alert("Error Alert", "Desc", AlertSeverity::Error)
+            .await
+            .unwrap();
+        manager
+            .send_alert("Critical Alert", "Desc", AlertSeverity::Critical)
+            .await
+            .unwrap();
+
+        let history = manager.get_alert_history(10).await.unwrap();
+        assert_eq!(history.len(), 3);
+    }
 }

--- a/harness/src/observability.rs
+++ b/harness/src/observability.rs
@@ -1097,4 +1097,84 @@ mod tests {
         let trends = system.analyze_current_trends(&metrics).unwrap();
         assert!(trends.performance_score >= 0.0 && trends.performance_score <= 100.0);
     }
+
+    #[tokio::test]
+    async fn test_observability_system_get_uptime() {
+        let system = ObservabilitySystem::new();
+        let uptime = system.get_uptime();
+        assert!(uptime.as_nanos() >= 0);
+    }
+
+    #[tokio::test]
+    async fn test_observability_system_stop_monitoring_when_not_started() {
+        let mut system = ObservabilitySystem::new();
+        // Stopping when not started must not panic.
+        system.stop_monitoring().await;
+    }
+
+    #[tokio::test]
+    async fn test_observability_start_then_stop() {
+        let mut system = ObservabilitySystem::new();
+        system.start_monitoring().await.unwrap();
+        system.stop_monitoring().await;
+    }
+
+    #[tokio::test]
+    async fn test_performance_trends_degraded() {
+        // Drive trends into degraded state by exceeding every threshold.
+        let system = ObservabilitySystem::new().with_health_thresholds(HealthThreshold {
+            max_latency_ms: 10,       // very tight — any latency above 10 ms degrades
+            min_cache_hit_rate: 0.99, // almost impossible to satisfy
+            max_error_rate: 0.001,    // very tight
+            ..HealthThreshold::default()
+        });
+
+        let latency = crate::monitoring::LatencyMetrics {
+            avg_latency_ms: 9999.0, // way above threshold
+            p95_latency_ms: 9999.0,
+            p99_latency_ms: 9999.0,
+            max_latency_ms: 9999.0,
+            min_latency_ms: 100.0,
+            request_count: 100,
+            requests_per_second: 10.0,
+        };
+
+        let metrics = SystemMetrics {
+            timestamp: Utc::now(),
+            request_latencies: HashMap::from([("svc".to_string(), latency)]),
+            cache_metrics: crate::monitoring::CacheMetrics {
+                hits: 1,
+                misses: 99,
+                hit_rate: 0.01, // well below threshold
+                size_bytes: 0,
+                item_count: 0,
+                evictions: 0,
+            },
+            container_metrics: Vec::new(),
+            system_resources: crate::monitoring::SystemResourceMetrics {
+                cpu_usage_percent: 95.0,
+                total_memory_bytes: 8589934592,
+                used_memory_bytes: 8589934592,
+                memory_usage_percent: 100.0,
+                available_disk_bytes: 0,
+                total_disk_bytes: 214748364800,
+                disk_usage_percent: 100.0,
+                load_average: [15.0, 15.0, 15.0],
+            },
+            model_metrics: HashMap::new(),
+            error_metrics: crate::monitoring::ErrorMetrics {
+                total_errors: 50,
+                errors_by_type: HashMap::new(),
+                error_rate: 0.5, // well above threshold
+                recent_errors: Vec::new(),
+            },
+        };
+
+        let trends = system.analyze_current_trends(&metrics).unwrap();
+        assert_eq!(trends.latency_trend, TrendDirection::Degrading);
+        assert_eq!(trends.error_rate_trend, TrendDirection::Degrading);
+        assert_eq!(trends.cache_performance_trend, TrendDirection::Degrading);
+        // Score should be reduced from 100 due to degraded trends.
+        assert!(trends.performance_score < 100.0);
+    }
 }

--- a/harness/src/observability.rs
+++ b/harness/src/observability.rs
@@ -1102,7 +1102,7 @@ mod tests {
     async fn test_observability_system_get_uptime() {
         let system = ObservabilitySystem::new();
         let uptime = system.get_uptime();
-        assert!(uptime.as_nanos() >= 0);
+        let _ = uptime; // uptime is a Duration; just verify it doesn't panic
     }
 
     #[tokio::test]

--- a/harness/src/telemetry.rs
+++ b/harness/src/telemetry.rs
@@ -1195,8 +1195,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_export_all_with_metrics_and_events() {
-        let telemetry = TelemetrySystem::new()
-            .add_exporter(Box::new(PrometheusExporter::new(None)));
+        let telemetry =
+            TelemetrySystem::new().add_exporter(Box::new(PrometheusExporter::new(None)));
 
         telemetry.record_counter("requests_total", 5.0, vec![("service", "api")]);
         telemetry.record_event(

--- a/harness/src/telemetry.rs
+++ b/harness/src/telemetry.rs
@@ -1044,4 +1044,268 @@ mod tests {
             Some(&"Something went wrong".to_string())
         );
     }
+
+    #[tokio::test]
+    async fn test_prometheus_exporter_export_traces() {
+        let exporter = PrometheusExporter::new(None);
+
+        // A finished trace (with duration) should produce a metric.
+        let mut trace = TraceContext::new("test_operation");
+        trace.finish();
+        exporter.export_traces(vec![trace]).await.unwrap();
+
+        let output = exporter.export_prometheus().await.unwrap();
+        assert!(output.contains("trace_duration_seconds"));
+
+        // A trace without finish() has no duration — no metric should be added.
+        exporter.clear_buffer();
+        let pending_trace = TraceContext::new("pending_op");
+        exporter.export_traces(vec![pending_trace]).await.unwrap();
+        let output2 = exporter.export_prometheus().await.unwrap();
+        assert!(output2.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_prometheus_exporter_export_metrics() {
+        let exporter = PrometheusExporter::new(None);
+        let metric = MetricPoint {
+            name: "exported_gauge".to_string(),
+            metric_type: MetricType::Gauge,
+            value: 77.0,
+            timestamp: Utc::now(),
+            labels: HashMap::new(),
+            unit: Some("bytes".to_string()),
+            description: None,
+        };
+
+        exporter.export_metrics(vec![metric]).await.unwrap();
+
+        let output = exporter.export_prometheus().await.unwrap();
+        assert!(output.contains("exported_gauge 77"));
+    }
+
+    #[tokio::test]
+    async fn test_prometheus_exporter_export_events() {
+        let exporter = PrometheusExporter::new(None);
+        let event = CustomEvent {
+            name: "user_action".to_string(),
+            timestamp: Utc::now(),
+            category: "user_interaction".to_string(),
+            attributes: HashMap::new(),
+            data: serde_json::json!({"key": "value"}),
+            trace_context: None,
+        };
+
+        exporter.export_events(vec![event]).await.unwrap();
+
+        let output = exporter.export_prometheus().await.unwrap();
+        assert!(output.contains("custom_events_total"));
+        assert!(output.contains("user_action"));
+    }
+
+    #[tokio::test]
+    async fn test_prometheus_exporter_export_system_metrics() {
+        use crate::monitoring::{
+            CacheMetrics, ErrorMetrics, LatencyMetrics, SystemMetrics, SystemResourceMetrics,
+        };
+
+        let exporter = PrometheusExporter::new(None);
+        let metrics = SystemMetrics {
+            timestamp: Utc::now(),
+            request_latencies: HashMap::from([(
+                "test_service".to_string(),
+                LatencyMetrics {
+                    avg_latency_ms: 100.0,
+                    p95_latency_ms: 200.0,
+                    p99_latency_ms: 300.0,
+                    max_latency_ms: 500.0,
+                    min_latency_ms: 50.0,
+                    request_count: 10,
+                    requests_per_second: 2.5,
+                },
+            )]),
+            cache_metrics: CacheMetrics {
+                hits: 80,
+                misses: 20,
+                hit_rate: 0.8,
+                size_bytes: 1024,
+                item_count: 100,
+                evictions: 5,
+            },
+            container_metrics: vec![],
+            system_resources: SystemResourceMetrics {
+                cpu_usage_percent: 50.0,
+                total_memory_bytes: 8589934592,
+                used_memory_bytes: 4294967296,
+                memory_usage_percent: 50.0,
+                available_disk_bytes: 107374182400,
+                total_disk_bytes: 214748364800,
+                disk_usage_percent: 50.0,
+                load_average: [1.0, 1.2, 1.1],
+            },
+            model_metrics: HashMap::new(),
+            error_metrics: ErrorMetrics {
+                total_errors: 0,
+                errors_by_type: HashMap::new(),
+                error_rate: 0.0,
+                recent_errors: vec![],
+            },
+        };
+
+        exporter.export_system_metrics(metrics).await.unwrap();
+
+        let output = exporter.export_prometheus().await.unwrap();
+        assert!(output.contains("cache_hit_rate"));
+        assert!(output.contains("request_duration_seconds"));
+        assert!(output.contains("requests_per_second"));
+        assert!(output.contains("error_rate"));
+    }
+
+    #[tokio::test]
+    async fn test_prometheus_exporter_health_check() {
+        let exporter = PrometheusExporter::new(None);
+        assert!(exporter.health_check().await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_prometheus_exporter_clear_buffer() {
+        let exporter = PrometheusExporter::new(None);
+
+        let metric = MetricPoint {
+            name: "temp_metric".to_string(),
+            metric_type: MetricType::Counter,
+            value: 1.0,
+            timestamp: Utc::now(),
+            labels: HashMap::new(),
+            unit: None,
+            description: None,
+        };
+        exporter.add_metric(metric);
+        exporter.clear_buffer();
+
+        let output = exporter.export_prometheus().await.unwrap();
+        assert!(output.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_export_all_with_no_data() {
+        let telemetry = TelemetrySystem::new();
+        telemetry.export_all().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_export_all_with_metrics_and_events() {
+        let telemetry = TelemetrySystem::new()
+            .add_exporter(Box::new(PrometheusExporter::new(None)));
+
+        telemetry.record_counter("requests_total", 5.0, vec![("service", "api")]);
+        telemetry.record_event(
+            "deploy",
+            "lifecycle",
+            serde_json::json!({"version": "1.2.3"}),
+        );
+
+        telemetry.export_all().await.unwrap();
+
+        // After export_all the metrics buffer should be drained.
+        assert_eq!(telemetry.get_buffered_metrics_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_telemetry_get_prometheus_exporter_returns_none() {
+        let telemetry = TelemetrySystem::new();
+        // Default implementation returns None (no Prometheus exporter configured).
+        assert!(telemetry.get_prometheus_exporter().is_none());
+    }
+
+    #[tokio::test]
+    async fn test_trace_guard_methods() {
+        let telemetry = TelemetrySystem::new();
+
+        let trace = telemetry.start_trace("guarded_op");
+        let mut guard = TraceGuard::new(&telemetry, trace);
+
+        assert!(guard.trace().is_some());
+        guard.record_error("something failed");
+        guard.set_status(SpanStatus::Timeout);
+
+        // Drop automatically finishes and removes the trace.
+        drop(guard);
+
+        assert_eq!(telemetry.get_active_trace_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_telemetry_with_global_attribute() {
+        let telemetry = TelemetrySystem::new()
+            .with_global_attribute("environment", "test")
+            .with_global_attribute("region", "us-east-1");
+
+        let trace = telemetry.start_trace("attributed_op");
+        assert_eq!(
+            trace.attributes.get("environment"),
+            Some(&"test".to_string())
+        );
+        assert_eq!(
+            trace.attributes.get("region"),
+            Some(&"us-east-1".to_string())
+        );
+        telemetry.finish_trace(trace);
+    }
+
+    #[tokio::test]
+    async fn test_telemetry_with_config() {
+        let config = TelemetryConfig {
+            service: ServiceInfo {
+                name: "custom-service".to_string(),
+                version: "2.0.0".to_string(),
+                environment: "staging".to_string(),
+                instance_id: "i-123".to_string(),
+                metadata: HashMap::new(),
+            },
+            log_level: "debug".to_string(),
+            ..TelemetryConfig::default()
+        };
+
+        let telemetry = TelemetrySystem::new().with_config(config);
+        assert!(telemetry.get_uptime().as_nanos() > 0);
+        assert_eq!(telemetry.config.service.name, "custom-service");
+    }
+
+    #[tokio::test]
+    async fn test_trace_context_set_status() {
+        let mut trace = TraceContext::new("test");
+        trace.set_status(SpanStatus::Cancelled);
+        assert_eq!(trace.status, SpanStatus::Cancelled);
+
+        trace.set_status(SpanStatus::Timeout);
+        assert_eq!(trace.status, SpanStatus::Timeout);
+    }
+
+    #[tokio::test]
+    async fn test_telemetry_get_uptime() {
+        let telemetry = TelemetrySystem::new();
+        assert!(telemetry.get_uptime().as_nanos() > 0);
+    }
+
+    #[tokio::test]
+    async fn test_prometheus_exporter_with_no_labels() {
+        // Exercises the empty-labels path in export_prometheus.
+        let exporter = PrometheusExporter::new(None);
+        let metric = MetricPoint {
+            name: "no_labels_metric".to_string(),
+            metric_type: MetricType::Summary,
+            value: 1.5,
+            timestamp: Utc::now(),
+            labels: HashMap::new(),
+            unit: None,
+            description: None,
+        };
+        exporter.add_metric(metric);
+
+        let output = exporter.export_prometheus().await.unwrap();
+        // Should format as `no_labels_metric 1.5` (no braces).
+        assert!(output.contains("no_labels_metric 1.5"));
+        assert!(!output.contains('{'));
+    }
 }


### PR DESCRIPTION
## Summary

Identified the largest codecov coverage gaps in nanna-coder by reviewing all source files in `harness/src/`. The three modules with the most uncovered public-facing functions were **monitoring.rs**, **telemetry.rs**, and **observability.rs** — together holding hundreds of lines with no unit tests, which causes the `target: 100%` patch coverage check to fail on PRs that touch those modules.

This PR adds 534 lines of new tests (zero production-code changes) targeting only the previously-uncovered paths.

## Coverage gaps addressed

### `monitoring.rs` (13 new tests)
| Function | Status before |
|---|---|
| `HealthStatus::is_healthy()` / `requires_attention()` | ❌ uncovered |
| `DefaultMetricsCollector::reset_metrics()` | ❌ uncovered |
| `MetricsFormat::Custom` export (error path) | ❌ uncovered |
| `MonitoringSystem::start_monitoring()` / `stop_monitoring()` | ❌ uncovered |
| `record_error()` / `record_model_inference()` | ❌ uncovered |
| `DefaultHealthMonitor::check_model_health()` | ❌ uncovered |
| `DefaultHealthMonitor::comprehensive_health_check()` | ❌ uncovered |
| `DefaultHealthMonitor::set_check_interval()` | ❌ uncovered |
| `DefaultAlertManager::get_alert_history()` | ❌ uncovered |
| `DefaultAlertManager::configure_thresholds()` | ❌ uncovered |
| `DefaultAlertManager::acknowledge_alert()` (not-found error path) | ❌ uncovered |
| All `AlertSeverity` variants in `send_alert()` | ❌ uncovered |

### `telemetry.rs` (15 new tests)
| Function | Status before |
|---|---|
| `PrometheusExporter::export_traces()` (with and without duration) | ❌ uncovered |
| `PrometheusExporter::export_metrics()` (as `TelemetryExporter`) | ❌ uncovered |
| `PrometheusExporter::export_events()` | ❌ uncovered |
| `PrometheusExporter::export_system_metrics()` | ❌ uncovered |
| `PrometheusExporter::health_check()` | ❌ uncovered |
| `PrometheusExporter::clear_buffer()` | ❌ uncovered |
| Empty-labels path in `export_prometheus()` | ❌ uncovered |
| `TelemetrySystem::export_all()` (empty + with data) | ❌ uncovered |
| `TelemetrySystem::get_prometheus_exporter()` | ❌ uncovered |
| `TelemetrySystem::with_global_attribute()` | ❌ uncovered |
| `TelemetrySystem::with_config()` / `get_uptime()` | ❌ uncovered |
| `TelemetrySystem::add_exporter()` | ❌ uncovered |
| `TraceGuard::new()`, `trace()`, `record_error()`, `set_status()`, `Drop` | ❌ uncovered |
| `TraceContext::set_status()` | ❌ uncovered |

### `observability.rs` (4 new tests)
| Function | Status before |
|---|---|
| `ObservabilitySystem::get_uptime()` | ❌ uncovered |
| `ObservabilitySystem::stop_monitoring()` (not started) | ❌ uncovered |
| Start → stop lifecycle | ❌ uncovered |
| `analyze_current_trends()` with all thresholds exceeded (degraded path) | ❌ uncovered |

## Testing strategy

All new tests are pure unit tests using `#[tokio::test]`. No network, container, or external service dependencies — every test runs offline. The strategy per module:

- **monitoring.rs**: Construct default implementations, drive them through every public method, assert on observable state (metric counts, alert lists, status enums).
- **telemetry.rs**: Test each `TelemetryExporter` method on `PrometheusExporter` directly; verify `TelemetrySystem` builder methods propagate configuration; test `TraceGuard` RAII lifecycle.
- **observability.rs**: Test `get_uptime()`, `stop_monitoring()` idempotency, and the degraded performance-trend code path by setting very tight thresholds.

https://claude.ai/code/session_01YAvu2VRbBugURj1Sa7QMPX

---
_Generated by [Claude Code](https://claude.ai/code/session_01YAvu2VRbBugURj1Sa7QMPX)_