### PR TITLE
test(coverage): close gaps in monitoring start/stop and TestEntity

### DIFF
--- a/harness/src/entities/test/types.rs
+++ b/harness/src/entities/test/types.rs
@@ -44,3 +44,43 @@ impl Default for TestEntity {
         Self::new()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::entities::{Entity, EntityType};
+
+    #[test]
+    fn test_entity_new_has_test_kind() {
+        let entity = TestEntity::new();
+        assert_eq!(entity.metadata().entity_type, EntityType::Test);
+    }
+
+    #[test]
+    fn test_entity_default_matches_new() {
+        let from_new = TestEntity::new();
+        let from_default = TestEntity::default();
+        assert_eq!(
+            from_new.metadata().entity_type,
+            from_default.metadata().entity_type
+        );
+    }
+
+    #[test]
+    fn test_entity_to_json_is_valid_json() {
+        let entity = TestEntity::new();
+        let json_str = entity.to_json().expect("to_json must succeed");
+        let parsed: serde_json::Value =
+            serde_json::from_str(&json_str).expect("output must be valid JSON");
+        assert!(parsed.is_object(), "JSON output should be an object");
+    }
+
+    #[test]
+    fn test_entity_metadata_mut_allows_update() {
+        let mut entity = TestEntity::new();
+        let id_before = entity.metadata().id.clone();
+        // Mutate via metadata_mut to confirm the method is reachable
+        entity.metadata_mut().entity_type = EntityType::Test;
+        assert_eq!(entity.metadata().id, id_before);
+    }
+}

--- a/harness/src/monitoring.rs
+++ b/harness/src/monitoring.rs
@@ -1242,4 +1242,32 @@ mod tests {
         let csv_export = collector.export_metrics(MetricsFormat::Csv).await.unwrap();
         assert!(csv_export.contains("timestamp,metric_type,service,value"));
     }
+
+    #[tokio::test]
+    async fn test_start_stop_monitoring() {
+        let mut system = MonitoringSystem::new();
+
+        system
+            .start_monitoring()
+            .await
+            .expect("start_monitoring should succeed");
+        assert!(
+            system.monitoring_task.is_some(),
+            "background task should be running after start"
+        );
+
+        system.stop_monitoring().await;
+        assert!(
+            system.monitoring_task.is_none(),
+            "background task should be gone after stop"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_stop_monitoring_noop_when_not_started() {
+        let mut system = MonitoringSystem::new();
+        // Stopping a system that was never started must not panic
+        system.stop_monitoring().await;
+        assert!(system.monitoring_task.is_none());
+    }
 }

--- a/harness/src/observability.rs
+++ b/harness/src/observability.rs
@@ -1097,4 +1097,31 @@ mod tests {
         let trends = system.analyze_current_trends(&metrics).unwrap();
         assert!(trends.performance_score >= 0.0 && trends.performance_score <= 100.0);
     }
+
+    #[tokio::test]
+    async fn test_start_stop_monitoring() {
+        let mut system = ObservabilitySystem::new();
+
+        system
+            .start_monitoring()
+            .await
+            .expect("start_monitoring should succeed");
+        assert!(
+            system.monitoring_task.is_some(),
+            "background task should be running after start"
+        );
+
+        system.stop_monitoring().await;
+        assert!(
+            system.monitoring_task.is_none(),
+            "background task should be gone after stop"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_stop_monitoring_noop_when_not_started() {
+        let mut system = ObservabilitySystem::new();
+        system.stop_monitoring().await;
+        assert!(system.monitoring_task.is_none());
+    }
 }


### PR DESCRIPTION
## Summary

Identified the three largest Codecov coverage gaps in `harness/` and added targeted unit tests:

- **`monitoring.rs`** – `MonitoringSystem::start_monitoring` and `stop_monitoring` were completely dark (the background-task lifecycle was never exercised). Added `test_start_stop_monitoring` (verifies the `JoinHandle` is present after start and gone after stop) and `test_stop_monitoring_noop_when_not_started` (must not panic when no task is running).

- **`observability.rs`** – Same gap exists on `ObservabilitySystem`; added the same two tests.

- **`entities/test/types.rs`** – `TestEntity::new`, `Default`, `to_json`, and `metadata_mut` had zero coverage (entire file was uncovered). Added four tests covering every public method.

## Coverage impact

| File | Previously uncovered | Now covered |
|------|----------------------|-------------|
| `monitoring.rs` | `start_monitoring`, `stop_monitoring` | ✅ |
| `observability.rs` | `start_monitoring`, `stop_monitoring` | ✅ |
| `entities/test/types.rs` | entire file | ✅ |

## Test plan

- [ ] `cargo test -p harness --lib test_start_stop` → 2 tests pass
- [ ] `cargo test -p harness --lib test_stop_monitoring_noop` → 2 tests pass
- [ ] `cargo test -p harness --lib entities::test::types::tests` → 4 tests pass
- [ ] Full CI (`cargo nextest run --workspace --lib --all-features`) green

https://claude.ai/code/session_015Rj244ezNfrAcRSMzXxEm4

---
_Generated by [Claude Code](https://claude.ai/code/session_015Rj244ezNfrAcRSMzXxEm4)_