### PR TITLE
test(monitoring,image-builder): cover untested methods and branches

### DIFF
--- a/harness/src/monitoring.rs
+++ b/harness/src/monitoring.rs
@@ -1242,4 +1242,186 @@ mod tests {
         let csv_export = collector.export_metrics(MetricsFormat::Csv).await.unwrap();
         assert!(csv_export.contains("timestamp,metric_type,service,value"));
     }
+
+    #[test]
+    fn test_health_status_is_healthy() {
+        assert!(HealthStatus::Healthy.is_healthy());
+        assert!(!HealthStatus::Warning.is_healthy());
+        assert!(!HealthStatus::Degraded.is_healthy());
+        assert!(!HealthStatus::Unhealthy.is_healthy());
+        assert!(!HealthStatus::Unknown.is_healthy());
+    }
+
+    #[test]
+    fn test_health_status_requires_attention() {
+        assert!(!HealthStatus::Healthy.requires_attention());
+        assert!(HealthStatus::Warning.requires_attention());
+        assert!(HealthStatus::Degraded.requires_attention());
+        assert!(HealthStatus::Unhealthy.requires_attention());
+        assert!(!HealthStatus::Unknown.requires_attention());
+    }
+
+    #[test]
+    fn test_error_severity_ordering() {
+        assert!(ErrorSeverity::Info < ErrorSeverity::Warning);
+        assert!(ErrorSeverity::Warning < ErrorSeverity::Error);
+        assert!(ErrorSeverity::Error < ErrorSeverity::Critical);
+    }
+
+    #[test]
+    fn test_alert_severity_ordering() {
+        assert!(AlertSeverity::Info < AlertSeverity::Warning);
+        assert!(AlertSeverity::Warning < AlertSeverity::Error);
+        assert!(AlertSeverity::Error < AlertSeverity::Critical);
+    }
+
+    #[test]
+    fn test_alert_thresholds_default() {
+        let thresholds = AlertThresholds::default();
+        assert_eq!(thresholds.max_latency_ms, 5000);
+        assert!((thresholds.min_cache_hit_rate - 0.8).abs() < f64::EPSILON);
+        assert!((thresholds.max_error_rate - 0.05).abs() < f64::EPSILON);
+        assert!((thresholds.max_cpu_usage - 0.9).abs() < f64::EPSILON);
+        assert!((thresholds.max_memory_usage - 0.9).abs() < f64::EPSILON);
+        assert_eq!(thresholds.health_check_timeout, Duration::from_secs(30));
+    }
+
+    #[test]
+    fn test_calculate_latency_metrics_empty() {
+        let collector = DefaultMetricsCollector::new();
+        let result = collector.calculate_latency_metrics(&[]);
+        assert_eq!(result.avg_latency_ms, 0.0);
+        assert_eq!(result.request_count, 0);
+        assert_eq!(result.requests_per_second, 0.0);
+    }
+
+    #[tokio::test]
+    async fn test_empty_cache_hit_rate() {
+        let collector = DefaultMetricsCollector::new();
+        let metrics = collector.get_current_metrics().await.unwrap();
+        assert_eq!(metrics.cache_metrics.hit_rate, 0.0);
+        assert_eq!(metrics.cache_metrics.hits, 0);
+        assert_eq!(metrics.cache_metrics.misses, 0);
+    }
+
+    #[tokio::test]
+    async fn test_record_error() {
+        let mut collector = DefaultMetricsCollector::new();
+        let error_event = ErrorEvent {
+            timestamp: chrono::Utc::now(),
+            error_type: "TestError".to_string(),
+            message: "test error message".to_string(),
+            component: "test_component".to_string(),
+            severity: ErrorSeverity::Warning,
+        };
+        collector.record_error(error_event).await;
+        let metrics = collector.get_current_metrics().await.unwrap();
+        assert_eq!(metrics.error_metrics.total_errors, 1);
+        assert!(metrics.error_metrics.errors_by_type.contains_key("TestError"));
+    }
+
+    #[tokio::test]
+    async fn test_record_model_inference() {
+        let mut collector = DefaultMetricsCollector::new();
+        let model_metrics = ModelMetrics {
+            model_name: "test-model".to_string(),
+            inference_count: 10,
+            avg_inference_time_ms: 150.0,
+            tokens_per_second: 50.0,
+            success_rate: 0.99,
+            quality_scores: QualityMetrics {
+                avg_coherence: 0.9,
+                avg_relevance: 0.85,
+                consistency: 0.88,
+                accuracy_rate: 0.92,
+            },
+            resource_usage: ModelResourceUsage {
+                peak_memory_mb: 512.0,
+                avg_cpu_percent: 45.0,
+                gpu_utilization_percent: None,
+            },
+        };
+        collector.record_model_inference("test-model", model_metrics).await;
+        let metrics = collector.get_current_metrics().await.unwrap();
+        assert!(metrics.model_metrics.contains_key("test-model"));
+    }
+
+    #[tokio::test]
+    async fn test_reset_metrics() {
+        let mut collector = DefaultMetricsCollector::new();
+        collector.record_cache_hit("key").await;
+        collector.record_request_latency("svc", Duration::from_millis(100)).await;
+        collector.reset_metrics().await;
+        let metrics = collector.get_current_metrics().await.unwrap();
+        assert_eq!(metrics.cache_metrics.hits, 0);
+        assert!(metrics.request_latencies.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_export_metrics_custom_format() {
+        let collector = DefaultMetricsCollector::new();
+        let result = collector
+            .export_metrics(MetricsFormat::Custom("myformat".to_string()))
+            .await;
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("myformat"));
+    }
+
+    #[tokio::test]
+    async fn test_get_alert_history() {
+        let manager = DefaultAlertManager::new();
+        manager.send_alert("Alert 1", "desc 1", AlertSeverity::Info).await.unwrap();
+        manager.send_alert("Alert 2", "desc 2", AlertSeverity::Error).await.unwrap();
+        let history = manager.get_alert_history(10).await.unwrap();
+        assert_eq!(history.len(), 2);
+        assert_eq!(history[0].title, "Alert 2");
+    }
+
+    #[tokio::test]
+    async fn test_configure_thresholds() {
+        let mut manager = DefaultAlertManager::new();
+        let new_thresholds = AlertThresholds {
+            max_latency_ms: 1000,
+            ..AlertThresholds::default()
+        };
+        manager.configure_thresholds(new_thresholds).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_acknowledge_alert_not_found() {
+        let manager = DefaultAlertManager::new();
+        let result = manager.acknowledge_alert("nonexistent_id").await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_check_model_health() {
+        let monitor = DefaultHealthMonitor::new(Duration::from_secs(30));
+        let result = monitor.check_model_health("test-model").await.unwrap();
+        assert_eq!(result.status, HealthStatus::Healthy);
+        assert_eq!(result.component, "model:test-model");
+    }
+
+    #[tokio::test]
+    async fn test_comprehensive_health_check() {
+        let monitor = DefaultHealthMonitor::new(Duration::from_secs(30));
+        let results = monitor.comprehensive_health_check().await.unwrap();
+        assert!(!results.is_empty());
+        assert_eq!(results[0].component, "system");
+    }
+
+    #[test]
+    fn test_set_check_interval() {
+        let mut monitor = DefaultHealthMonitor::new(Duration::from_secs(30));
+        monitor.set_check_interval(Duration::from_secs(60));
+        assert_eq!(monitor.check_interval, Duration::from_secs(60));
+    }
+
+    #[tokio::test]
+    async fn test_monitoring_system_start_stop() {
+        let mut system = MonitoringSystem::new();
+        system.start_monitoring().await.unwrap();
+        system.stop_monitoring().await;
+    }
 }

--- a/image-builder/src/lib.rs
+++ b/image-builder/src/lib.rs
@@ -212,4 +212,19 @@ mod tests {
         let result = validate_image(f.path());
         assert!(result.unwrap());
     }
+
+    #[test]
+    fn test_validate_image_empty_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let result = validate_image(dir.path());
+        assert!(!result.unwrap());
+    }
+
+    #[test]
+    fn test_validate_image_non_empty_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("image.json"), b"{}").unwrap();
+        let result = validate_image(dir.path());
+        assert!(result.unwrap());
+    }
 }


### PR DESCRIPTION
## Summary

**`harness/src/monitoring.rs`** — the file with the worst test density (1245 lines / 5 tests). Adds 15 new tests covering:
- `HealthStatus::is_healthy()` and `requires_attention()` for all five variants
- `ErrorSeverity` and `AlertSeverity` `PartialOrd`/`Ord` ordering
- `AlertThresholds::default()` field values
- Empty-slice path in `calculate_latency_metrics` (zero-latency collector)
- Zero-total cache `hit_rate = 0.0` branch in `get_cache_metrics`
- `record_error`, `record_model_inference`, `reset_metrics`
- `MetricsFormat::Custom` error path in `export_metrics`
- `get_alert_history`, `configure_thresholds`, not-found `acknowledge_alert` error
- `check_model_health`, `comprehensive_health_check`, `set_check_interval`
- `MonitoringSystem::start_monitoring` / `stop_monitoring` lifecycle

**`image-builder/src/lib.rs`** — adds two tests for the `validate_image` directory branch (lines 131–133) which was completely uncovered: one for an empty directory (returns false) and one for a non-empty directory (returns true).

## Test plan

- [ ] `cargo test --workspace --all-features` passes locally
- [ ] CI tarpaulin run reports ≥ previous coverage
- [ ] Codecov patch coverage 100%

---
_Generated by [Claude Code](https://claude.ai/code/session_01XV49njeAaAhcSSJcuLfKdT)_