### PR TITLE
test(monitoring): cover 14 untested code paths in monitoring.rs

### DIFF
--- a/harness/src/monitoring.rs
+++ b/harness/src/monitoring.rs
@@ -1242,4 +1242,214 @@ mod tests {
         let csv_export = collector.export_metrics(MetricsFormat::Csv).await.unwrap();
         assert!(csv_export.contains("timestamp,metric_type,service,value"));
     }
+
+    #[test]
+    fn test_health_status_methods() {
+        assert!(HealthStatus::Healthy.is_healthy());
+        assert!(!HealthStatus::Warning.is_healthy());
+        assert!(!HealthStatus::Degraded.is_healthy());
+        assert!(!HealthStatus::Unhealthy.is_healthy());
+        assert!(!HealthStatus::Unknown.is_healthy());
+
+        assert!(!HealthStatus::Healthy.requires_attention());
+        assert!(HealthStatus::Warning.requires_attention());
+        assert!(HealthStatus::Degraded.requires_attention());
+        assert!(HealthStatus::Unhealthy.requires_attention());
+        assert!(!HealthStatus::Unknown.requires_attention());
+    }
+
+    #[test]
+    fn test_error_severity_ordering() {
+        assert!(ErrorSeverity::Info < ErrorSeverity::Warning);
+        assert!(ErrorSeverity::Warning < ErrorSeverity::Error);
+        assert!(ErrorSeverity::Error < ErrorSeverity::Critical);
+        assert!(ErrorSeverity::Critical > ErrorSeverity::Info);
+    }
+
+    #[test]
+    fn test_alert_thresholds_default() {
+        let thresholds = AlertThresholds::default();
+        assert!(thresholds.max_latency_ms > 0);
+        assert!(thresholds.min_cache_hit_rate > 0.0);
+        assert!(thresholds.max_error_rate > 0.0);
+        assert!(thresholds.max_cpu_usage > 0.0);
+        assert!(thresholds.max_memory_usage > 0.0);
+    }
+
+    #[tokio::test]
+    async fn test_configure_thresholds() {
+        let mut manager = DefaultAlertManager::new();
+        let thresholds = AlertThresholds {
+            max_latency_ms: 1000,
+            min_cache_hit_rate: 0.5,
+            max_error_rate: 0.1,
+            max_cpu_usage: 0.7,
+            max_memory_usage: 0.8,
+            health_check_timeout: Duration::from_secs(10),
+        };
+        manager.configure_thresholds(thresholds).await.unwrap();
+    }
+
+    #[test]
+    fn test_set_check_interval() {
+        let mut monitor = DefaultHealthMonitor::new(Duration::from_secs(30));
+        monitor.set_check_interval(Duration::from_secs(60));
+    }
+
+    #[tokio::test]
+    async fn test_alert_history_returns_most_recent_first() {
+        let manager = DefaultAlertManager::new();
+        manager
+            .send_alert("First", "desc1", AlertSeverity::Info)
+            .await
+            .unwrap();
+        manager
+            .send_alert("Second", "desc2", AlertSeverity::Warning)
+            .await
+            .unwrap();
+        manager
+            .send_alert("Third", "desc3", AlertSeverity::Error)
+            .await
+            .unwrap();
+
+        let history = manager.get_alert_history(2).await.unwrap();
+        assert_eq!(history.len(), 2);
+        assert_eq!(history[0].title, "Third");
+        assert_eq!(history[1].title, "Second");
+
+        let all_history = manager.get_alert_history(100).await.unwrap();
+        assert_eq!(all_history.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn test_acknowledge_nonexistent_alert_returns_error() {
+        let manager = DefaultAlertManager::new();
+        let result = manager.acknowledge_alert("nonexistent-id").await;
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            MonitoringError::AlertSendFailed { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_metrics_export_custom_format_returns_error() {
+        let collector = DefaultMetricsCollector::new();
+        let result = collector
+            .export_metrics(MetricsFormat::Custom("myformat".to_string()))
+            .await;
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            MonitoringError::MetricsCollectionFailed { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_record_error_appears_in_metrics() {
+        let mut collector = DefaultMetricsCollector::new();
+        let error_event = ErrorEvent {
+            timestamp: Utc::now(),
+            error_type: "TestError".to_string(),
+            message: "A test error".to_string(),
+            component: "test-component".to_string(),
+            severity: ErrorSeverity::Error,
+        };
+        collector.record_error(error_event).await;
+
+        let metrics = collector.get_current_metrics().await.unwrap();
+        assert_eq!(metrics.error_metrics.total_errors, 1);
+        assert!(
+            metrics
+                .error_metrics
+                .errors_by_type
+                .contains_key("TestError")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_reset_metrics_clears_state() {
+        let mut collector = DefaultMetricsCollector::new();
+        collector.record_cache_hit("key").await;
+        collector.record_cache_miss("key2").await;
+
+        let metrics = collector.get_current_metrics().await.unwrap();
+        assert_eq!(metrics.cache_metrics.hits, 1);
+
+        collector.reset_metrics().await;
+
+        let metrics = collector.get_current_metrics().await.unwrap();
+        assert_eq!(metrics.cache_metrics.hits, 0);
+        assert_eq!(metrics.cache_metrics.misses, 0);
+    }
+
+    #[tokio::test]
+    async fn test_record_model_inference_appears_in_metrics() {
+        let mut collector = DefaultMetricsCollector::new();
+        let model_metrics = ModelMetrics {
+            model_name: "test-model".to_string(),
+            inference_count: 10,
+            avg_inference_time_ms: 100.0,
+            tokens_per_second: 20.0,
+            success_rate: 0.95,
+            quality_scores: QualityMetrics {
+                avg_coherence: 0.8,
+                avg_relevance: 0.85,
+                consistency: 0.9,
+                accuracy_rate: 0.92,
+            },
+            resource_usage: ModelResourceUsage {
+                peak_memory_mb: 256.0,
+                avg_cpu_percent: 30.0,
+                gpu_utilization_percent: None,
+            },
+        };
+        collector
+            .record_model_inference("test-model", model_metrics)
+            .await;
+
+        let metrics = collector.get_current_metrics().await.unwrap();
+        assert!(metrics.model_metrics.contains_key("test-model"));
+    }
+
+    #[tokio::test]
+    async fn test_monitoring_start_stop() {
+        let mut system = MonitoringSystem::new();
+        system.start_monitoring().await.unwrap();
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        system.stop_monitoring().await;
+        system.stop_monitoring().await;
+    }
+
+    #[tokio::test]
+    async fn test_send_alert_all_severity_variants() {
+        let manager = DefaultAlertManager::new();
+        manager
+            .send_alert("Info", "msg", AlertSeverity::Info)
+            .await
+            .unwrap();
+        manager
+            .send_alert("Warning", "msg", AlertSeverity::Warning)
+            .await
+            .unwrap();
+        manager
+            .send_alert("Error", "msg", AlertSeverity::Error)
+            .await
+            .unwrap();
+        manager
+            .send_alert("Critical", "msg", AlertSeverity::Critical)
+            .await
+            .unwrap();
+
+        let alerts = manager.get_active_alerts().await.unwrap();
+        assert_eq!(alerts.len(), 4);
+    }
+
+    #[tokio::test]
+    async fn test_check_model_health_returns_healthy() {
+        let monitor = DefaultHealthMonitor::new(Duration::from_secs(30));
+        let result = monitor.check_model_health("qwen3:0.6b").await.unwrap();
+        assert_eq!(result.status, HealthStatus::Healthy);
+        assert!(result.message.contains("qwen3:0.6b"));
+    }
 }


### PR DESCRIPTION
## Summary

- `harness/src/monitoring.rs` had the largest coverage gap in nanna-coder: ~15 methods and enum variants reachable at test time but never exercised by the existing test suite.
- Adds 14 new `#[tokio::test]` / `#[test]` cases directly in the `#[cfg(test)] mod tests` block, targeting every identified uncovered path.
- All 19 tests in the monitoring module pass locally (`cargo test --package harness --lib monitoring`).

## Coverage gaps closed

| Previously untested path | New test |
|---|---|
| `HealthStatus::is_healthy()` for all 5 variants | `test_health_status_methods` |
| `HealthStatus::requires_attention()` for all 5 variants | `test_health_status_methods` |
| `ErrorSeverity` derived `Ord` / `PartialOrd` | `test_error_severity_ordering` |
| `AlertThresholds::default()` field assertions | `test_alert_thresholds_default` |
| `DefaultAlertManager::configure_thresholds()` | `test_configure_thresholds` |
| `DefaultHealthMonitor::set_check_interval()` | `test_set_check_interval` |
| `get_alert_history()` with limit and order | `test_alert_history_returns_most_recent_first` |
| `acknowledge_alert` error path (ID not found) | `test_acknowledge_nonexistent_alert_returns_error` |
| `MetricsFormat::Custom` error return | `test_metrics_export_custom_format_returns_error` |
| `MetricsCollector::record_error()` | `test_record_error_appears_in_metrics` |
| `MetricsCollector::reset_metrics()` | `test_reset_metrics_clears_state` |
| `MetricsCollector::record_model_inference()` | `test_record_model_inference_appears_in_metrics` |
| `MonitoringSystem::start_monitoring()` + `stop_monitoring()` | `test_monitoring_start_stop` |
| `AlertSeverity::Critical` / `::Error` / `::Info` arms in `send_alert` | `test_send_alert_all_severity_variants` |
| `DefaultHealthMonitor::check_model_health()` direct call | `test_check_model_health_returns_healthy` |

## Test plan

- [x] Run locally: `cargo test --package harness --lib monitoring` → 19/19 pass
- [x] All new tests use only already-available dependencies (no new deps added)
- [x] No new production code added — patch coverage self-covers (test bodies execute on run)


---
_Generated by [Claude Code](https://claude.ai/code/session_01JxvMGrZykG1cA77FQsXRwV)_