### PR TITLE
test(monitoring): cover all previously-untested code paths

### DIFF
--- a/harness/src/monitoring.rs
+++ b/harness/src/monitoring.rs
@@ -1352,7 +1352,10 @@ mod tests {
 
         let metrics = collector.get_current_metrics().await.unwrap();
         assert_eq!(metrics.error_metrics.total_errors, 1);
-        assert!(metrics.error_metrics.errors_by_type.contains_key("TestError"));
+        assert!(metrics
+            .error_metrics
+            .errors_by_type
+            .contains_key("TestError"));
         assert_eq!(metrics.error_metrics.recent_errors.len(), 1);
     }
 

--- a/harness/src/monitoring.rs
+++ b/harness/src/monitoring.rs
@@ -1242,4 +1242,196 @@ mod tests {
         let csv_export = collector.export_metrics(MetricsFormat::Csv).await.unwrap();
         assert!(csv_export.contains("timestamp,metric_type,service,value"));
     }
+
+    #[tokio::test]
+    async fn test_reset_metrics() {
+        let mut collector = DefaultMetricsCollector::new();
+        collector
+            .record_request_latency("svc", Duration::from_millis(100))
+            .await;
+        collector.record_cache_hit("key").await;
+        collector.record_cache_miss("other").await;
+
+        collector.reset_metrics().await;
+
+        let metrics = collector.get_current_metrics().await.unwrap();
+        assert!(metrics.request_latencies.is_empty());
+        assert_eq!(metrics.cache_metrics.hits, 0);
+        assert_eq!(metrics.cache_metrics.misses, 0);
+    }
+
+    #[tokio::test]
+    async fn test_export_metrics_custom_format_errors() {
+        let collector = DefaultMetricsCollector::new();
+        let result = collector
+            .export_metrics(MetricsFormat::Custom("myformat".to_string()))
+            .await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_start_and_stop_monitoring() {
+        let mut system = MonitoringSystem::new();
+        system.start_monitoring().await.unwrap();
+        system.stop_monitoring().await;
+        // Calling stop again when no task is running must be a no-op.
+        system.stop_monitoring().await;
+    }
+
+    #[test]
+    fn test_health_status_is_healthy() {
+        assert!(HealthStatus::Healthy.is_healthy());
+        assert!(!HealthStatus::Warning.is_healthy());
+        assert!(!HealthStatus::Degraded.is_healthy());
+        assert!(!HealthStatus::Unhealthy.is_healthy());
+        assert!(!HealthStatus::Unknown.is_healthy());
+    }
+
+    #[test]
+    fn test_health_status_requires_attention() {
+        assert!(!HealthStatus::Healthy.requires_attention());
+        assert!(HealthStatus::Warning.requires_attention());
+        assert!(HealthStatus::Degraded.requires_attention());
+        assert!(HealthStatus::Unhealthy.requires_attention());
+        assert!(!HealthStatus::Unknown.requires_attention());
+    }
+
+    #[tokio::test]
+    async fn test_configure_thresholds() {
+        let mut manager = DefaultAlertManager::new();
+        let thresholds = AlertThresholds {
+            max_latency_ms: 1000,
+            min_cache_hit_rate: 0.5,
+            max_error_rate: 0.1,
+            max_cpu_usage: 0.8,
+            max_memory_usage: 0.8,
+            health_check_timeout: Duration::from_secs(10),
+        };
+        manager.configure_thresholds(thresholds).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_get_alert_history() {
+        let manager = DefaultAlertManager::new();
+
+        manager
+            .send_alert("Alert 1", "desc 1", AlertSeverity::Info)
+            .await
+            .unwrap();
+        manager
+            .send_alert("Alert 2", "desc 2", AlertSeverity::Warning)
+            .await
+            .unwrap();
+        manager
+            .send_alert("Alert 3", "desc 3", AlertSeverity::Error)
+            .await
+            .unwrap();
+
+        let limited = manager.get_alert_history(2).await.unwrap();
+        assert_eq!(limited.len(), 2);
+
+        let all = manager.get_alert_history(100).await.unwrap();
+        assert_eq!(all.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn test_record_error() {
+        use chrono::Utc;
+
+        let mut collector = DefaultMetricsCollector::new();
+
+        let error = ErrorEvent {
+            timestamp: Utc::now(),
+            error_type: "TestError".to_string(),
+            message: "Something went wrong".to_string(),
+            component: "test-component".to_string(),
+            severity: ErrorSeverity::Warning,
+        };
+
+        collector.record_error(error).await;
+
+        let metrics = collector.get_current_metrics().await.unwrap();
+        assert_eq!(metrics.error_metrics.total_errors, 1);
+        assert!(metrics.error_metrics.errors_by_type.contains_key("TestError"));
+        assert_eq!(metrics.error_metrics.recent_errors.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_record_model_inference() {
+        let mut collector = DefaultMetricsCollector::new();
+
+        let model_metrics = ModelMetrics {
+            model_name: "qwen3:0.6b".to_string(),
+            inference_count: 10,
+            avg_inference_time_ms: 250.0,
+            tokens_per_second: 50.0,
+            success_rate: 0.95,
+            quality_scores: QualityMetrics {
+                avg_coherence: 0.9,
+                avg_relevance: 0.85,
+                consistency: 0.88,
+                accuracy_rate: 0.92,
+            },
+            resource_usage: ModelResourceUsage {
+                peak_memory_mb: 512.0,
+                avg_cpu_percent: 75.0,
+                gpu_utilization_percent: None,
+            },
+        };
+
+        collector
+            .record_model_inference("qwen3:0.6b", model_metrics)
+            .await;
+
+        let metrics = collector.get_current_metrics().await.unwrap();
+        assert!(metrics.model_metrics.contains_key("qwen3:0.6b"));
+        assert_eq!(metrics.model_metrics["qwen3:0.6b"].inference_count, 10);
+    }
+
+    #[tokio::test]
+    async fn test_acknowledge_nonexistent_alert_errors() {
+        let manager = DefaultAlertManager::new();
+        let result = manager.acknowledge_alert("nonexistent_alert_id").await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_error_rate_with_requests_and_errors() {
+        use chrono::Utc;
+
+        let mut collector = DefaultMetricsCollector::new();
+
+        collector
+            .record_request_latency("svc", Duration::from_millis(100))
+            .await;
+        collector
+            .record_request_latency("svc", Duration::from_millis(200))
+            .await;
+
+        let error = ErrorEvent {
+            timestamp: Utc::now(),
+            error_type: "NetworkError".to_string(),
+            message: "Connection failed".to_string(),
+            component: "svc".to_string(),
+            severity: ErrorSeverity::Error,
+        };
+        collector.record_error(error).await;
+
+        let metrics = collector.get_current_metrics().await.unwrap();
+        assert_eq!(metrics.error_metrics.total_errors, 1);
+        assert!((metrics.error_metrics.error_rate - 0.5).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_calculate_latency_metrics_empty() {
+        let collector = DefaultMetricsCollector::new();
+        let result = collector.calculate_latency_metrics(&[]);
+        assert_eq!(result.avg_latency_ms, 0.0);
+        assert_eq!(result.p95_latency_ms, 0.0);
+        assert_eq!(result.p99_latency_ms, 0.0);
+        assert_eq!(result.max_latency_ms, 0.0);
+        assert_eq!(result.min_latency_ms, 0.0);
+        assert_eq!(result.request_count, 0);
+        assert_eq!(result.requests_per_second, 0.0);
+    }
 }


### PR DESCRIPTION
## Summary

Largest coverage gap identified: `harness/src/monitoring.rs` had ~12 untested code paths despite being a 1 246-line file with a test module. Every production-code branch that was unreachable from the existing 5 tests is now exercised.

### New tests added (11 + 1)

| Test | What it covers |
|---|---|
| `test_reset_metrics` | `DefaultMetricsCollector::reset_metrics` — counters zeroed |
| `test_export_metrics_custom_format_errors` | `MetricsFormat::Custom(…)` → `Err(MetricsCollectionFailed)` |
| `test_start_and_stop_monitoring` | `MonitoringSystem::start_monitoring` / `stop_monitoring`; double-stop is a no-op |
| `test_health_status_is_healthy` | `HealthStatus::is_healthy()` for all 5 variants |
| `test_health_status_requires_attention` | `HealthStatus::requires_attention()` for all 5 variants |
| `test_configure_thresholds` | `DefaultAlertManager::configure_thresholds` |
| `test_get_alert_history` | `get_alert_history` with a limit parameter |
| `test_record_error` | `record_error` → verified in `get_current_metrics` output |
| `test_record_model_inference` | `record_model_inference` → verified via `model_metrics` map |
| `test_acknowledge_nonexistent_alert_errors` | `acknowledge_alert` error path |
| `test_error_rate_with_requests_and_errors` | error-rate calculation when both requests and errors exist |
| `test_calculate_latency_metrics_empty` | private `calculate_latency_metrics(&[])` early-return branch |

## Test plan

- [x] `cargo test -p harness --lib monitoring` — all 17 tests pass (12 new + 5 pre-existing)
- [x] `cargo test --lib` — full lib suite green
- [x] `cargo clippy -p harness --lib -- -D warnings` — clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01Eq2aHT7YTUbSAswz5bPEXC)_