### PR TITLE
test(monitoring): expand unit test coverage for monitoring module

### DIFF
--- a/harness/src/monitoring.rs
+++ b/harness/src/monitoring.rs
@@ -1242,4 +1242,232 @@ mod tests {
         let csv_export = collector.export_metrics(MetricsFormat::Csv).await.unwrap();
         assert!(csv_export.contains("timestamp,metric_type,service,value"));
     }
+
+    #[tokio::test]
+    async fn test_latency_percentiles() {
+        let mut collector = DefaultMetricsCollector::new();
+        // Record 20 samples to exercise p95/p99 index calculation
+        for i in 1..=20u64 {
+            collector
+                .record_request_latency("svc", Duration::from_millis(i * 10))
+                .await;
+        }
+        let metrics = collector.get_current_metrics().await.unwrap();
+        let latency = &metrics.request_latencies["svc"];
+        assert_eq!(latency.request_count, 20);
+        assert!(latency.p95_latency_ms >= latency.avg_latency_ms);
+        assert!(latency.p99_latency_ms >= latency.p95_latency_ms);
+        assert!(latency.max_latency_ms >= latency.p99_latency_ms);
+        assert!(latency.min_latency_ms <= latency.avg_latency_ms);
+        assert!(latency.requests_per_second > 0.0);
+    }
+
+    #[tokio::test]
+    async fn test_record_error_and_model_inference() {
+        let mut collector = DefaultMetricsCollector::new();
+
+        let error_event = ErrorEvent {
+            timestamp: Utc::now(),
+            error_type: "timeout".to_string(),
+            message: "Connection timed out".to_string(),
+            component: "ollama".to_string(),
+            severity: ErrorSeverity::Error,
+        };
+        collector.record_error(error_event).await;
+
+        let model_metrics = ModelMetrics {
+            model_name: "qwen3:0.6b".to_string(),
+            inference_count: 10,
+            avg_inference_time_ms: 120.0,
+            tokens_per_second: 50.0,
+            success_rate: 0.95,
+            quality_scores: QualityMetrics {
+                avg_coherence: 0.8,
+                avg_relevance: 0.85,
+                consistency: 0.9,
+                accuracy_rate: 0.88,
+            },
+            resource_usage: ModelResourceUsage {
+                peak_memory_mb: 256.0,
+                avg_cpu_percent: 45.0,
+                gpu_utilization_percent: None,
+            },
+        };
+        collector
+            .record_model_inference("qwen3:0.6b", model_metrics)
+            .await;
+
+        let metrics = collector.get_current_metrics().await.unwrap();
+        assert_eq!(metrics.error_metrics.total_errors, 1);
+        assert_eq!(
+            metrics.error_metrics.errors_by_type.get("timeout").copied(),
+            Some(1)
+        );
+        assert!(metrics.model_metrics.contains_key("qwen3:0.6b"));
+    }
+
+    #[tokio::test]
+    async fn test_error_rate_calculation() {
+        let mut collector = DefaultMetricsCollector::new();
+        collector
+            .record_request_latency("api", Duration::from_millis(50))
+            .await;
+        collector
+            .record_request_latency("api", Duration::from_millis(60))
+            .await;
+        collector
+            .record_error(ErrorEvent {
+                timestamp: Utc::now(),
+                error_type: "server_error".to_string(),
+                message: "Internal server error".to_string(),
+                component: "api".to_string(),
+                severity: ErrorSeverity::Warning,
+            })
+            .await;
+
+        let metrics = collector.get_current_metrics().await.unwrap();
+        // 1 error / 2 requests = 0.5
+        assert!((metrics.error_metrics.error_rate - 0.5).abs() < f64::EPSILON);
+        assert!(!metrics.error_metrics.recent_errors.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_reset_metrics() {
+        let mut collector = DefaultMetricsCollector::new();
+        collector
+            .record_request_latency("svc", Duration::from_millis(100))
+            .await;
+        collector.record_cache_hit("k").await;
+
+        collector.reset_metrics().await;
+
+        let metrics = collector.get_current_metrics().await.unwrap();
+        assert!(metrics.request_latencies.is_empty());
+        assert_eq!(metrics.cache_metrics.hits, 0);
+        assert_eq!(metrics.cache_metrics.misses, 0);
+    }
+
+    #[tokio::test]
+    async fn test_export_custom_format_errors() {
+        let collector = DefaultMetricsCollector::new();
+        let result = collector
+            .export_metrics(MetricsFormat::Custom("myformat".to_string()))
+            .await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_alert_history_and_configure_thresholds() {
+        let mut manager = DefaultAlertManager::new();
+
+        manager
+            .send_alert("Alert 1", "desc1", AlertSeverity::Info)
+            .await
+            .unwrap();
+        manager
+            .send_alert("Alert 2", "desc2", AlertSeverity::Critical)
+            .await
+            .unwrap();
+
+        let history = manager.get_alert_history(10).await.unwrap();
+        assert_eq!(history.len(), 2);
+
+        let limited = manager.get_alert_history(1).await.unwrap();
+        assert_eq!(limited.len(), 1);
+
+        let thresholds = AlertThresholds {
+            max_latency_ms: 1000,
+            min_cache_hit_rate: 0.5,
+            max_error_rate: 0.1,
+            max_cpu_usage: 0.8,
+            max_memory_usage: 0.85,
+            health_check_timeout: Duration::from_secs(10),
+        };
+        manager.configure_thresholds(thresholds).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_acknowledge_nonexistent_alert_errors() {
+        let manager = DefaultAlertManager::new();
+        let result = manager.acknowledge_alert("alert_999").await;
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_health_status_methods() {
+        assert!(HealthStatus::Healthy.is_healthy());
+        assert!(!HealthStatus::Warning.is_healthy());
+        assert!(!HealthStatus::Degraded.is_healthy());
+        assert!(!HealthStatus::Unhealthy.is_healthy());
+        assert!(!HealthStatus::Unknown.is_healthy());
+
+        assert!(!HealthStatus::Healthy.requires_attention());
+        assert!(HealthStatus::Warning.requires_attention());
+        assert!(HealthStatus::Degraded.requires_attention());
+        assert!(HealthStatus::Unhealthy.requires_attention());
+        assert!(!HealthStatus::Unknown.requires_attention());
+    }
+
+    #[test]
+    fn test_alert_severity_ordering() {
+        assert!(AlertSeverity::Info < AlertSeverity::Warning);
+        assert!(AlertSeverity::Warning < AlertSeverity::Error);
+        assert!(AlertSeverity::Error < AlertSeverity::Critical);
+    }
+
+    #[test]
+    fn test_error_severity_ordering() {
+        assert!(ErrorSeverity::Info < ErrorSeverity::Warning);
+        assert!(ErrorSeverity::Warning < ErrorSeverity::Error);
+        assert!(ErrorSeverity::Error < ErrorSeverity::Critical);
+    }
+
+    #[test]
+    fn test_alert_thresholds_default() {
+        let t = AlertThresholds::default();
+        assert_eq!(t.max_latency_ms, 5000);
+        assert!((t.min_cache_hit_rate - 0.8).abs() < f64::EPSILON);
+        assert!((t.max_error_rate - 0.05).abs() < f64::EPSILON);
+        assert!((t.max_cpu_usage - 0.9).abs() < f64::EPSILON);
+        assert!((t.max_memory_usage - 0.9).abs() < f64::EPSILON);
+        assert_eq!(t.health_check_timeout, Duration::from_secs(30));
+    }
+
+    #[tokio::test]
+    async fn test_monitoring_system_start_stop() {
+        let mut system = MonitoringSystem::new();
+        system.start_monitoring().await.unwrap();
+        assert!(system.monitoring_task.is_some());
+        system.stop_monitoring().await;
+        assert!(system.monitoring_task.is_none());
+        // stop when already stopped is a no-op
+        system.stop_monitoring().await;
+    }
+
+    #[tokio::test]
+    async fn test_health_monitor_model_and_interval() {
+        let mut monitor = DefaultHealthMonitor::new(Duration::from_secs(30));
+        monitor.set_check_interval(Duration::from_secs(60));
+
+        let result = monitor.check_model_health("qwen3:0.6b").await.unwrap();
+        assert_eq!(result.status, HealthStatus::Healthy);
+        assert!(result.details.contains_key("model"));
+    }
+
+    #[tokio::test]
+    async fn test_comprehensive_health_check() {
+        let monitor = DefaultHealthMonitor::new(Duration::from_secs(30));
+        let results = monitor.comprehensive_health_check().await.unwrap();
+        // At minimum the system health check is returned
+        assert!(!results.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_empty_latency_metrics() {
+        let collector = DefaultMetricsCollector::new();
+        let metrics = collector.get_current_metrics().await.unwrap();
+        // No latencies recorded, cache hit rate should be 0
+        assert_eq!(metrics.cache_metrics.hit_rate, 0.0);
+        assert_eq!(metrics.error_metrics.error_rate, 0.0);
+    }
 }


### PR DESCRIPTION
## Summary

- Identified `harness/src/monitoring.rs` as the largest coverage gap: 1,200+ lines with only 5 tests covering basic happy paths
- Added 15 new unit tests targeting previously uncovered code paths

## Coverage gaps addressed

| Path | What was missing |
|------|-----------------|
| `calculate_latency_metrics` | p95/p99 percentile index math, rps calculation |
| `record_error` / `record_model_inference` | never exercised → error rate calculation also untested |
| `reset_metrics` | uncalled |
| `export_metrics(Custom)` | error branch unreachable |
| `get_alert_history` / `configure_thresholds` | never called |
| `acknowledge_alert` with bad ID | error path |
| `HealthStatus::is_healthy` / `requires_attention` | helper methods unused in tests |
| `AlertSeverity` / `ErrorSeverity` `PartialOrd` | derived ordering never asserted |
| `AlertThresholds::default` | defaults never verified |
| `MonitoringSystem::start_monitoring` + `stop_monitoring` | async lifecycle untested |
| `DefaultHealthMonitor::check_model_health` / `comprehensive_health_check` | uncalled |
| empty-state edge cases | zero latencies, zero requests → no divide-by-zero |

## Test plan

- [x] `cargo test -p harness --lib monitoring` — all 20 tests pass locally
- [ ] CI unit test matrix (ubuntu/macOS/Windows)
- [ ] Codecov patch coverage ≥ 100%

https://claude.ai/code/session_018EVy2KLETsmnAUJVH2ZJUu

---
_Generated by [Claude Code](https://claude.ai/code/session_018EVy2KLETsmnAUJVH2ZJUu)_