### PR TITLE
test(harness): add integration tests for monitoring and telemetry coverage gaps

### DIFF
--- a/harness/tests/monitoring_coverage_tests.rs
+++ b/harness/tests/monitoring_coverage_tests.rs
@@ -1,0 +1,196 @@
+//! Tests for code paths in `harness::monitoring` that aren't exercised by the
+//! existing inline tests.  Each test targets a specific function that showed
+//! zero coverage in prior runs, giving the patch 100% coverage on the new
+//! test lines.
+
+use chrono::Utc;
+use harness::monitoring::{
+    ErrorEvent, ErrorSeverity, ModelMetrics, ModelResourceUsage, QualityMetrics,
+};
+use harness::{
+    AlertManager, AlertSeverity, AlertThresholds, DefaultAlertManager, DefaultMetricsCollector,
+    HealthStatus, MetricsCollector, MetricsFormat, MonitoringSystem,
+};
+use std::time::Duration;
+
+// ── HealthStatus helper methods ────────────────────────────────────────────
+
+#[test]
+fn health_status_is_healthy_only_for_healthy() {
+    assert!(HealthStatus::Healthy.is_healthy());
+    assert!(!HealthStatus::Warning.is_healthy());
+    assert!(!HealthStatus::Degraded.is_healthy());
+    assert!(!HealthStatus::Unhealthy.is_healthy());
+    assert!(!HealthStatus::Unknown.is_healthy());
+}
+
+#[test]
+fn health_status_requires_attention_for_non_healthy_non_unknown() {
+    assert!(!HealthStatus::Healthy.requires_attention());
+    assert!(HealthStatus::Warning.requires_attention());
+    assert!(HealthStatus::Degraded.requires_attention());
+    assert!(HealthStatus::Unhealthy.requires_attention());
+    assert!(!HealthStatus::Unknown.requires_attention());
+}
+
+// ── Severity ordering ──────────────────────────────────────────────────────
+
+#[test]
+fn error_severity_ordering() {
+    assert!(ErrorSeverity::Info < ErrorSeverity::Warning);
+    assert!(ErrorSeverity::Warning < ErrorSeverity::Error);
+    assert!(ErrorSeverity::Error < ErrorSeverity::Critical);
+}
+
+#[test]
+fn alert_severity_ordering() {
+    assert!(AlertSeverity::Info < AlertSeverity::Warning);
+    assert!(AlertSeverity::Warning < AlertSeverity::Error);
+    assert!(AlertSeverity::Error < AlertSeverity::Critical);
+}
+
+// ── DefaultMetricsCollector uncovered methods ──────────────────────────────
+
+#[tokio::test]
+async fn record_error_increments_error_count() {
+    let mut collector = DefaultMetricsCollector::new();
+
+    let error = ErrorEvent {
+        timestamp: Utc::now(),
+        error_type: "network_error".to_string(),
+        message: "Connection refused".to_string(),
+        component: "ollama".to_string(),
+        severity: ErrorSeverity::Error,
+    };
+
+    collector.record_error(error).await;
+
+    let metrics = collector.get_current_metrics().await.unwrap();
+    assert_eq!(metrics.error_metrics.total_errors, 1);
+    assert!(
+        metrics
+            .error_metrics
+            .errors_by_type
+            .contains_key("network_error")
+    );
+}
+
+#[tokio::test]
+async fn record_model_inference_stores_model_metrics() {
+    let mut collector = DefaultMetricsCollector::new();
+
+    let model_metrics = ModelMetrics {
+        model_name: "qwen3:0.6b".to_string(),
+        inference_count: 100,
+        avg_inference_time_ms: 250.0,
+        tokens_per_second: 40.0,
+        success_rate: 0.99,
+        quality_scores: QualityMetrics {
+            avg_coherence: 0.85,
+            avg_relevance: 0.90,
+            consistency: 0.88,
+            accuracy_rate: 0.92,
+        },
+        resource_usage: ModelResourceUsage {
+            peak_memory_mb: 512.0,
+            avg_cpu_percent: 45.0,
+            gpu_utilization_percent: None,
+        },
+    };
+
+    collector
+        .record_model_inference("qwen3:0.6b", model_metrics)
+        .await;
+
+    let metrics = collector.get_current_metrics().await.unwrap();
+    assert!(metrics.model_metrics.contains_key("qwen3:0.6b"));
+}
+
+#[tokio::test]
+async fn reset_metrics_clears_all_counters() {
+    let mut collector = DefaultMetricsCollector::new();
+
+    collector
+        .record_request_latency("svc", Duration::from_millis(100))
+        .await;
+    collector.record_cache_hit("k1").await;
+    collector.record_cache_miss("k2").await;
+
+    let before = collector.get_current_metrics().await.unwrap();
+    assert!(!before.request_latencies.is_empty());
+    assert_eq!(before.cache_metrics.hits, 1);
+
+    collector.reset_metrics().await;
+
+    let after = collector.get_current_metrics().await.unwrap();
+    assert!(after.request_latencies.is_empty());
+    assert_eq!(after.cache_metrics.hits, 0);
+    assert_eq!(after.cache_metrics.misses, 0);
+}
+
+#[tokio::test]
+async fn export_metrics_custom_format_returns_error() {
+    let collector = DefaultMetricsCollector::new();
+    let result = collector
+        .export_metrics(MetricsFormat::Custom("unsupported".to_string()))
+        .await;
+    assert!(result.is_err());
+}
+
+// ── DefaultAlertManager uncovered methods ─────────────────────────────────
+
+#[tokio::test]
+async fn get_alert_history_returns_most_recent_in_reverse_order() {
+    let manager = DefaultAlertManager::new();
+
+    manager
+        .send_alert("Alert 1", "first", AlertSeverity::Info)
+        .await
+        .unwrap();
+    manager
+        .send_alert("Alert 2", "second", AlertSeverity::Warning)
+        .await
+        .unwrap();
+    manager
+        .send_alert("Alert 3", "third", AlertSeverity::Error)
+        .await
+        .unwrap();
+
+    let limited = manager.get_alert_history(2).await.unwrap();
+    assert_eq!(limited.len(), 2);
+
+    let all = manager.get_alert_history(10).await.unwrap();
+    assert_eq!(all.len(), 3);
+}
+
+#[tokio::test]
+async fn configure_thresholds_succeeds() {
+    let mut manager = DefaultAlertManager::new();
+
+    let thresholds = AlertThresholds {
+        max_latency_ms: 1000,
+        min_cache_hit_rate: 0.9,
+        max_error_rate: 0.01,
+        max_cpu_usage: 0.8,
+        max_memory_usage: 0.8,
+        health_check_timeout: Duration::from_secs(10),
+    };
+
+    manager.configure_thresholds(thresholds).await.unwrap();
+}
+
+#[tokio::test]
+async fn acknowledge_alert_missing_id_returns_error() {
+    let manager = DefaultAlertManager::new();
+    let result = manager.acknowledge_alert("nonexistent_id").await;
+    assert!(result.is_err());
+}
+
+// ── MonitoringSystem start / stop ─────────────────────────────────────────
+
+#[tokio::test]
+async fn monitoring_system_start_and_stop() {
+    let mut system = MonitoringSystem::new();
+    system.start_monitoring().await.unwrap();
+    system.stop_monitoring().await;
+}

--- a/harness/tests/telemetry_coverage_tests.rs
+++ b/harness/tests/telemetry_coverage_tests.rs
@@ -1,0 +1,143 @@
+//! Tests for code paths in `harness::telemetry` that aren't exercised by the
+//! existing inline tests.
+
+use chrono::Utc;
+use harness::telemetry::{MetricPoint, MetricType};
+use harness::{PrometheusExporter, SpanStatus, TelemetryConfig, TelemetrySystem, TraceContext, TraceGuard};
+use std::collections::HashMap;
+use std::time::Duration;
+
+// ── TraceContext builder / mutator methods ─────────────────────────────────
+
+#[test]
+fn trace_context_with_attribute_stores_values() {
+    let trace = TraceContext::new("op")
+        .with_attribute("key1", "val1")
+        .with_attribute("key2", "val2");
+
+    assert_eq!(trace.attributes.get("key1"), Some(&"val1".to_string()));
+    assert_eq!(trace.attributes.get("key2"), Some(&"val2".to_string()));
+}
+
+#[test]
+fn trace_context_set_status_updates_status() {
+    let mut trace = TraceContext::new("op");
+    assert_eq!(trace.status, SpanStatus::InProgress);
+
+    trace.set_status(SpanStatus::Ok);
+    assert_eq!(trace.status, SpanStatus::Ok);
+
+    trace.set_status(SpanStatus::Error);
+    assert_eq!(trace.status, SpanStatus::Error);
+
+    trace.set_status(SpanStatus::Cancelled);
+    assert_eq!(trace.status, SpanStatus::Cancelled);
+}
+
+// ── PrometheusExporter: clear_buffer ──────────────────────────────────────
+
+#[tokio::test]
+async fn prometheus_exporter_clear_buffer_empties_metrics() {
+    let exporter = PrometheusExporter::new(None);
+
+    let metric = MetricPoint {
+        name: "test_metric".to_string(),
+        metric_type: MetricType::Counter,
+        value: 42.0,
+        timestamp: Utc::now(),
+        labels: HashMap::new(),
+        unit: None,
+        description: Some("Test".to_string()),
+    };
+    exporter.add_metric(metric);
+
+    let before = exporter.export_prometheus().await.unwrap();
+    assert!(before.contains("test_metric"));
+
+    exporter.clear_buffer();
+
+    let after = exporter.export_prometheus().await.unwrap();
+    assert!(!after.contains("test_metric"));
+}
+
+// ── TelemetrySystem builder methods ───────────────────────────────────────
+
+#[test]
+fn telemetry_system_builder_chain_does_not_panic() {
+    let config = TelemetryConfig {
+        trace_sample_rate: 0.5,
+        ..Default::default()
+    };
+
+    let _sys = TelemetrySystem::new()
+        .with_service_name("test-svc")
+        .with_version("1.2.3")
+        .with_environment("staging")
+        .with_global_attribute("region", "eu-west-1")
+        .with_config(config);
+}
+
+#[test]
+fn telemetry_system_get_uptime_is_small_for_new_instance() {
+    let sys = TelemetrySystem::new();
+    assert!(
+        sys.get_uptime() < Duration::from_secs(5),
+        "uptime of a freshly created system should be well under 5 s"
+    );
+}
+
+#[test]
+fn telemetry_system_get_prometheus_exporter_returns_none_by_default() {
+    let sys = TelemetrySystem::new();
+    assert!(
+        sys.get_prometheus_exporter().is_none(),
+        "no prometheus exporter is registered by default"
+    );
+}
+
+#[tokio::test]
+async fn telemetry_system_export_all_with_no_exporters_succeeds() {
+    let sys = TelemetrySystem::new();
+    sys.record_counter("c", 1.0, vec![]);
+    sys.record_gauge("g", 2.0, vec![]);
+    sys.export_all().await.unwrap();
+}
+
+// ── TraceGuard RAII behaviour ──────────────────────────────────────────────
+// finish_trace internally calls tokio::spawn, so these tests must be async.
+
+#[tokio::test]
+async fn trace_guard_trace_returns_inner_context() {
+    let sys = TelemetrySystem::new();
+    let trace = sys.start_trace("guarded_op");
+    let guard = TraceGuard::new(&sys, trace);
+
+    let ctx = guard.trace().expect("trace should be Some inside guard");
+    assert_eq!(ctx.operation_name, "guarded_op");
+    // guard drops here, finish_trace spawns a task that completes in the runtime
+}
+
+#[tokio::test]
+async fn trace_guard_record_error_and_set_status_do_not_panic() {
+    let sys = TelemetrySystem::new();
+    let trace = sys.start_trace("error_op");
+    let mut guard = TraceGuard::new(&sys, trace);
+
+    guard.record_error("something went wrong");
+    guard.set_status(SpanStatus::Error);
+    // Guard drops here, which exercises the Drop impl (and spawns a task)
+}
+
+#[tokio::test]
+async fn trace_guard_drop_finishes_trace_and_decrements_active_count() {
+    let sys = TelemetrySystem::new();
+    assert_eq!(sys.get_active_trace_count(), 0);
+
+    {
+        let trace = sys.start_trace("auto_finish");
+        let _guard = TraceGuard::new(&sys, trace);
+        assert_eq!(sys.get_active_trace_count(), 1);
+    } // _guard drops here → finish_trace is called (spawns task)
+
+    assert_eq!(sys.get_active_trace_count(), 0);
+}


### PR DESCRIPTION
## Summary

- Adds `harness/tests/monitoring_coverage_tests.rs` with 12 tests targeting previously uncovered paths in `harness::monitoring`: `HealthStatus` helpers, severity ordering, `DefaultMetricsCollector` (record_error, record_model_inference, reset_metrics, custom-format export), `DefaultAlertManager` (get_alert_history, configure_thresholds, acknowledge_alert error path), and `MonitoringSystem` start/stop.
- Adds `harness/tests/telemetry_coverage_tests.rs` with 10 tests targeting previously uncovered paths in `harness::telemetry`: `TraceContext` builder/mutator methods, `PrometheusExporter::clear_buffer`, `TelemetrySystem` builder chain and helper methods, and the entire `TraceGuard` RAII struct (trace access, record_error, set_status, Drop).
- All 22 new tests pass locally; TraceGuard tests use `#[tokio::test]` because `finish_trace` calls `tokio::spawn` internally.

## Test plan

- [ ] `cargo test --package harness --test monitoring_coverage_tests` — all 12 pass
- [ ] `cargo test --package harness --test telemetry_coverage_tests` — all 10 pass
- [ ] CI tarpaulin run shows patch coverage at 100% (all new lines are test lines that execute)
- [ ] Codecov patch check passes

https://claude.ai/code/session_01661rHifom39onSdn3NGxLX

---
_Generated by [Claude Code](https://claude.ai/code/session_01661rHifom39onSdn3NGxLX)_