### PR TITLE
test(entities): add unit tests for TestEntity

### DIFF
--- a/harness/src/entities/test/types.rs
+++ b/harness/src/entities/test/types.rs
@@ -44,3 +44,50 @@ impl Default for TestEntity {
         Self::new()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::entities::EntityType;
+
+    #[test]
+    fn new_creates_entity_with_test_type() {
+        let entity = TestEntity::new();
+        assert_eq!(entity.metadata().entity_type, EntityType::Test);
+    }
+
+    #[test]
+    fn default_matches_new() {
+        let entity = TestEntity::default();
+        assert_eq!(entity.metadata().entity_type, EntityType::Test);
+    }
+
+    #[test]
+    fn to_json_roundtrip_preserves_type() {
+        let entity = TestEntity::new();
+        let json = entity.to_json().unwrap();
+        let back: TestEntity = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.metadata.entity_type, EntityType::Test);
+    }
+
+    #[test]
+    fn metadata_mut_allows_tag_mutation() {
+        let mut entity = TestEntity::new();
+        entity.metadata_mut().tags.push("smoke".to_string());
+        assert_eq!(entity.metadata().tags, vec!["smoke".to_string()]);
+    }
+
+    #[test]
+    fn entity_type_convenience_returns_test() {
+        let entity = TestEntity::new();
+        assert_eq!(entity.entity_type(), EntityType::Test);
+    }
+
+    #[test]
+    fn clone_produces_independent_copy() {
+        let original = TestEntity::new();
+        let cloned = original.clone();
+        assert_eq!(cloned.metadata.entity_type, EntityType::Test);
+        assert_eq!(original.metadata().id, cloned.metadata().id);
+    }
+}


### PR DESCRIPTION
## Summary

- `harness/src/entities/test/types.rs` was the largest zero-coverage gap in the harness crate — a real 47-LOC source file with no `#[cfg(test)]` block
- Adds 6 unit tests covering construction (`new`, `default`), JSON round-trip, metadata accessor mutation, the `entity_type()` convenience method, and `Clone`
- All new lines are executed by the test runner → 100% patch coverage

## Test plan

- [ ] `cargo nextest run --workspace --lib --all-features` green locally (6/6 pass)
- [ ] Codecov patch coverage ≥ 100%
- [ ] No change to `codecov.yml` targets or ignore list

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fcv5BHd7Q8fnQq3xYfn1RW)_