### PR TITLE
test(model): cover uncovered code paths in config, types, and judge

### DIFF
--- a/model/src/config.rs
+++ b/model/src/config.rs
@@ -233,4 +233,28 @@ mod tests {
             deserialized.default_context_length
         );
     }
+
+    #[test]
+    fn test_with_max_tokens() {
+        let config = OllamaConfig::new().with_max_tokens(2048);
+        assert_eq!(config.default_max_tokens, Some(2048));
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn test_validate_zero_max_tokens() {
+        let config = OllamaConfig {
+            default_max_tokens: Some(0),
+            ..Default::default()
+        };
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn test_model_defaults() {
+        let defaults = ModelDefaults::default();
+        assert_eq!(defaults.temperature, 0.7);
+        assert_eq!(defaults.max_tokens, None);
+        assert_eq!(defaults.context_length, 110_000);
+    }
 }

--- a/model/src/types.rs
+++ b/model/src/types.rs
@@ -240,4 +240,53 @@ mod tests {
         assert_eq!(message.content, deserialized.content);
         assert_eq!(message.role, deserialized.role);
     }
+
+    #[test]
+    fn test_assistant_constructor() {
+        let msg = ChatMessage::assistant("I can help with that");
+        assert_eq!(msg.role, MessageRole::Assistant);
+        assert_eq!(msg.content, Some("I can help with that".to_string()));
+        assert!(msg.tool_calls.is_none());
+        assert!(msg.tool_call_id.is_none());
+    }
+
+    #[test]
+    fn test_assistant_with_tools() {
+        let tool_call = ToolCall {
+            id: "call_abc".to_string(),
+            function: FunctionCall {
+                name: "search".to_string(),
+                arguments: serde_json::json!({"query": "rust"}),
+            },
+        };
+        let msg = ChatMessage::assistant_with_tools(
+            Some("Using search tool".to_string()),
+            vec![tool_call],
+        );
+        assert_eq!(msg.role, MessageRole::Assistant);
+        assert_eq!(msg.content, Some("Using search tool".to_string()));
+        assert!(msg.tool_calls.is_some());
+        assert_eq!(msg.tool_calls.as_ref().unwrap().len(), 1);
+        assert_eq!(msg.tool_calls.as_ref().unwrap()[0].id, "call_abc");
+    }
+
+    #[test]
+    fn test_chat_request_with_tools() {
+        let tool_def = ToolDefinition {
+            function: FunctionDefinition {
+                name: "search".to_string(),
+                description: "Search the web".to_string(),
+                parameters: JsonSchema {
+                    schema_type: SchemaType::Object,
+                    properties: None,
+                    required: None,
+                },
+            },
+        };
+        let request = ChatRequest::new("test-model", vec![ChatMessage::user("Hello")])
+            .with_tools(vec![tool_def]);
+        assert!(request.tools.is_some());
+        assert_eq!(request.tools.as_ref().unwrap().len(), 1);
+        assert_eq!(request.tool_choice, Some(ToolChoice::Auto));
+    }
 }

--- a/model/tests/judge_unit_tests.rs
+++ b/model/tests/judge_unit_tests.rs
@@ -302,3 +302,101 @@ fn creative_writing_criteria_more_lenient() {
     assert!(!creative.require_factual_accuracy);
     assert!(creative.max_response_length > default.max_response_length);
 }
+
+// ---------------------------------------------------------------------------
+// JudgeConfig builder methods
+// ---------------------------------------------------------------------------
+
+#[test]
+fn judge_config_with_retries() {
+    let config = JudgeConfig::with_retries(5, 200);
+    assert_eq!(config.max_retries, 5);
+    assert_eq!(config.base_delay_ms, 200);
+    assert_eq!(config.max_delay_ms, JudgeConfig::default().max_delay_ms);
+}
+
+#[test]
+fn judge_config_with_verbose_logging() {
+    let config = JudgeConfig::default().with_verbose_logging();
+    assert!(config.verbose_logging);
+}
+
+#[test]
+fn judge_config_with_timeout() {
+    let config = JudgeConfig::default().with_timeout(Duration::from_secs(60));
+    assert_eq!(config.default_timeout, Duration::from_secs(60));
+}
+
+// ---------------------------------------------------------------------------
+// ValidationResult boolean accessors
+// ---------------------------------------------------------------------------
+
+#[test]
+fn validation_result_is_success() {
+    let success = ValidationResult::Success {
+        message: "ok".into(),
+        metrics: ValidationMetrics::default(),
+    };
+    assert!(success.is_success());
+    assert!(!success.is_warning());
+    assert!(!success.is_failure());
+}
+
+#[test]
+fn validation_result_is_warning() {
+    let warning = ValidationResult::Warning {
+        message: "slow".into(),
+        suggestions: vec![],
+        metrics: ValidationMetrics::default(),
+    };
+    assert!(!warning.is_success());
+    assert!(warning.is_warning());
+    assert!(!warning.is_failure());
+}
+
+#[test]
+fn validation_result_is_failure() {
+    let failure = ValidationResult::Failure {
+        message: "bad".into(),
+        error_details: "err".into(),
+        suggestions: vec![],
+        metrics: None,
+    };
+    assert!(!failure.is_success());
+    assert!(!failure.is_warning());
+    assert!(failure.is_failure());
+}
+
+// ---------------------------------------------------------------------------
+// ValidationMetrics additional builders
+// ---------------------------------------------------------------------------
+
+#[test]
+fn metrics_with_response_length() {
+    let m = ValidationMetrics::default().with_response_length(42);
+    assert_eq!(m.response_length, Some(42));
+}
+
+#[test]
+fn metrics_add_custom_metric() {
+    let mut m = ValidationMetrics::default();
+    m.add_custom_metric("latency_p99".into(), 0.123);
+    assert_eq!(m.custom_metrics.get("latency_p99"), Some(&0.123));
+}
+
+#[test]
+fn metrics_display_includes_all_fields() {
+    let mut m = ValidationMetrics::with_duration(Duration::from_secs(1))
+        .with_response_length(100)
+        .with_coherence_score(0.8)
+        .with_relevance_score(0.9);
+    m.retry_count = 2;
+    m.success_rate = Some(0.95);
+    let s = format!("{}", m);
+    assert!(s.contains("duration"));
+    assert!(s.contains("retries"));
+    assert!(s.contains("length"));
+    assert!(s.contains("coherence"));
+    assert!(s.contains("relevance"));
+    assert!(s.contains("success_rate"));
+}


### PR DESCRIPTION
## Summary

Closes the largest code-coverage gaps in the `model` crate identified via codecov:

- **`model/src/config.rs`**: adds tests for `OllamaConfig::with_max_tokens`, the zero-`max_tokens` validation branch, and `ModelDefaults::default` field values.
- **`model/src/types.rs`**: adds tests for the `assistant()` and `assistant_with_tools()` constructors and the `with_tools()` / `ToolChoice::Auto` request builder path.
- **`model/tests/judge_unit_tests.rs`**: adds 9 focused unit tests for `JudgeConfig` builder methods (`with_retries`, `with_verbose_logging`, `with_timeout`), `ValidationResult` boolean accessors (`is_success`, `is_warning`, `is_failure`), and `ValidationMetrics` builder methods (`with_response_length`, `add_custom_metric`, `Display`).

## Test plan

- [ ] `cargo nextest run -p model` passes locally
- [ ] CI green (codecov patch ≥ 100 %)
- [ ] No new clippy warnings

https://claude.ai/code/session_012cH54GQM3dbQLk7FtXzYkg

---
_Generated by [Claude Code](https://claude.ai/code/session_012cH54GQM3dbQLk7FtXzYkg)_