### PR TITLE
test: expand coverage for monitoring and observability modules

### DIFF
--- a/harness/src/monitoring.rs
+++ b/harness/src/monitoring.rs
@@ -1242,4 +1242,146 @@ mod tests {
         let csv_export = collector.export_metrics(MetricsFormat::Csv).await.unwrap();
         assert!(csv_export.contains("timestamp,metric_type,service,value"));
     }
+
+    #[test]
+    fn test_health_status_is_healthy() {
+        assert!(HealthStatus::Healthy.is_healthy());
+        assert!(!HealthStatus::Warning.is_healthy());
+        assert!(!HealthStatus::Degraded.is_healthy());
+        assert!(!HealthStatus::Unhealthy.is_healthy());
+        assert!(!HealthStatus::Unknown.is_healthy());
+    }
+
+    #[test]
+    fn test_health_status_requires_attention() {
+        assert!(!HealthStatus::Healthy.requires_attention());
+        assert!(HealthStatus::Warning.requires_attention());
+        assert!(HealthStatus::Degraded.requires_attention());
+        assert!(HealthStatus::Unhealthy.requires_attention());
+        assert!(!HealthStatus::Unknown.requires_attention());
+    }
+
+    #[test]
+    fn test_alert_severity_ordering() {
+        assert!(AlertSeverity::Critical > AlertSeverity::Error);
+        assert!(AlertSeverity::Error > AlertSeverity::Warning);
+        assert!(AlertSeverity::Warning > AlertSeverity::Info);
+    }
+
+    #[test]
+    fn test_error_severity_ordering() {
+        assert!(ErrorSeverity::Critical > ErrorSeverity::Error);
+        assert!(ErrorSeverity::Error > ErrorSeverity::Warning);
+        assert!(ErrorSeverity::Warning > ErrorSeverity::Info);
+    }
+
+    #[tokio::test]
+    async fn test_acknowledge_nonexistent_alert_returns_error() {
+        let manager = DefaultAlertManager::new();
+        let result = manager.acknowledge_alert("nonexistent_id").await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_get_alert_history_respects_limit() {
+        let manager = DefaultAlertManager::new();
+        for i in 0..5 {
+            manager
+                .send_alert(&format!("Alert {}", i), "description", AlertSeverity::Info)
+                .await
+                .unwrap();
+        }
+        let history = manager.get_alert_history(3).await.unwrap();
+        assert_eq!(history.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn test_configure_thresholds() {
+        let mut manager = DefaultAlertManager::new();
+        let thresholds = AlertThresholds {
+            max_latency_ms: 1000,
+            min_cache_hit_rate: 0.7,
+            max_error_rate: 0.1,
+            max_cpu_usage: 0.8,
+            max_memory_usage: 0.8,
+            health_check_timeout: Duration::from_secs(60),
+        };
+        assert!(manager.configure_thresholds(thresholds).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_reset_metrics_clears_state() {
+        let mut collector = DefaultMetricsCollector::new();
+        collector
+            .record_request_latency("svc", Duration::from_millis(100))
+            .await;
+        collector.record_cache_hit("k").await;
+
+        collector.reset_metrics().await;
+
+        let metrics = collector.get_current_metrics().await.unwrap();
+        assert!(metrics.request_latencies.is_empty());
+        assert_eq!(metrics.cache_metrics.hits, 0);
+        assert_eq!(metrics.cache_metrics.misses, 0);
+    }
+
+    #[tokio::test]
+    async fn test_export_custom_format_returns_error() {
+        let collector = DefaultMetricsCollector::new();
+        let result = collector
+            .export_metrics(MetricsFormat::Custom("xml".to_string()))
+            .await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_start_and_stop_monitoring() {
+        let mut system = MonitoringSystem::new();
+        assert!(system.monitoring_task.is_none());
+
+        system.start_monitoring().await.unwrap();
+        assert!(system.monitoring_task.is_some());
+
+        system.stop_monitoring().await;
+        assert!(system.monitoring_task.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_record_error_populates_metrics() {
+        let mut collector = DefaultMetricsCollector::new();
+        let error = ErrorEvent {
+            timestamp: Utc::now(),
+            error_type: "TestError".to_string(),
+            message: "test error message".to_string(),
+            component: "test-component".to_string(),
+            severity: ErrorSeverity::Warning,
+        };
+        collector.record_error(error).await;
+
+        let metrics = collector.get_current_metrics().await.unwrap();
+        assert_eq!(metrics.error_metrics.total_errors, 1);
+        assert!(metrics
+            .error_metrics
+            .errors_by_type
+            .contains_key("TestError"));
+    }
+
+    #[tokio::test]
+    async fn test_multiple_services_latency_metrics() {
+        let mut collector = DefaultMetricsCollector::new();
+        collector
+            .record_request_latency("service-a", Duration::from_millis(100))
+            .await;
+        collector
+            .record_request_latency("service-b", Duration::from_millis(200))
+            .await;
+        collector
+            .record_request_latency("service-a", Duration::from_millis(150))
+            .await;
+
+        let metrics = collector.get_current_metrics().await.unwrap();
+        assert_eq!(metrics.request_latencies.len(), 2);
+        assert_eq!(metrics.request_latencies["service-a"].request_count, 2);
+        assert_eq!(metrics.request_latencies["service-b"].request_count, 1);
+    }
 }

--- a/harness/src/observability.rs
+++ b/harness/src/observability.rs
@@ -1345,6 +1345,9 @@ mod tests {
         let metrics = system.calculate_availability_metrics().unwrap();
         // Default availability is 99.5 which is at risk (< 99.9 target)
         assert_eq!(metrics.sla_compliance.status, SlaStatus::AtRisk);
-        assert!(metrics.sla_compliance.current_availability < metrics.sla_compliance.target_availability);
+        assert!(
+            metrics.sla_compliance.current_availability
+                < metrics.sla_compliance.target_availability
+        );
     }
 }

--- a/harness/src/observability.rs
+++ b/harness/src/observability.rs
@@ -1097,4 +1097,254 @@ mod tests {
         let trends = system.analyze_current_trends(&metrics).unwrap();
         assert!(trends.performance_score >= 0.0 && trends.performance_score <= 100.0);
     }
+
+    #[test]
+    fn test_get_uptime() {
+        let system = ObservabilitySystem::new();
+        let uptime = system.get_uptime();
+        assert!(uptime < Duration::from_secs(5));
+    }
+
+    #[tokio::test]
+    async fn test_stop_monitoring_when_not_started() {
+        let mut system = ObservabilitySystem::new();
+        system.stop_monitoring().await;
+    }
+
+    #[tokio::test]
+    async fn test_start_and_stop_monitoring() {
+        let mut system = ObservabilitySystem::new();
+        assert!(system.monitoring_task.is_none());
+        system.start_monitoring().await.unwrap();
+        assert!(system.monitoring_task.is_some());
+        system.stop_monitoring().await;
+        assert!(system.monitoring_task.is_none());
+    }
+
+    #[test]
+    fn test_determine_alert_category_container() {
+        let system = ObservabilitySystem::new();
+        let alert = crate::monitoring::Alert {
+            id: "a1".to_string(),
+            title: "Container down".to_string(),
+            description: "desc".to_string(),
+            severity: AlertSeverity::Error,
+            component: "container:test".to_string(),
+            timestamp: Utc::now(),
+            context: HashMap::new(),
+            acknowledged: false,
+        };
+        assert_eq!(
+            system.determine_alert_category(&alert),
+            AlertCategory::ContainerHealth
+        );
+    }
+
+    #[test]
+    fn test_determine_alert_category_model() {
+        let system = ObservabilitySystem::new();
+        let alert = crate::monitoring::Alert {
+            id: "a2".to_string(),
+            title: "Quality degraded".to_string(),
+            description: "desc".to_string(),
+            severity: AlertSeverity::Warning,
+            component: "model:qwen3".to_string(),
+            timestamp: Utc::now(),
+            context: HashMap::new(),
+            acknowledged: false,
+        };
+        assert_eq!(
+            system.determine_alert_category(&alert),
+            AlertCategory::ModelQuality
+        );
+    }
+
+    #[test]
+    fn test_determine_alert_category_performance() {
+        let system = ObservabilitySystem::new();
+        let alert = crate::monitoring::Alert {
+            id: "a3".to_string(),
+            title: "Performance degraded".to_string(),
+            description: "desc".to_string(),
+            severity: AlertSeverity::Warning,
+            component: "system".to_string(),
+            timestamp: Utc::now(),
+            context: HashMap::new(),
+            acknowledged: false,
+        };
+        assert_eq!(
+            system.determine_alert_category(&alert),
+            AlertCategory::Performance
+        );
+    }
+
+    #[test]
+    fn test_determine_alert_category_default_is_availability() {
+        let system = ObservabilitySystem::new();
+        let alert = crate::monitoring::Alert {
+            id: "a4".to_string(),
+            title: "Something wrong".to_string(),
+            description: "desc".to_string(),
+            severity: AlertSeverity::Info,
+            component: "system".to_string(),
+            timestamp: Utc::now(),
+            context: HashMap::new(),
+            acknowledged: false,
+        };
+        assert_eq!(
+            system.determine_alert_category(&alert),
+            AlertCategory::Availability
+        );
+    }
+
+    #[test]
+    fn test_calculate_priority_score_critical_capped() {
+        let system = ObservabilitySystem::new();
+        let alert = crate::monitoring::Alert {
+            id: "a5".to_string(),
+            title: "Down".to_string(),
+            description: "desc".to_string(),
+            severity: AlertSeverity::Critical,
+            component: "system".to_string(),
+            timestamp: Utc::now(),
+            context: HashMap::new(),
+            acknowledged: false,
+        };
+        let score = system.calculate_priority_score(&alert, &AlertCategory::Availability);
+        assert_eq!(score, 100);
+    }
+
+    #[test]
+    fn test_calculate_priority_score_info_configuration() {
+        let system = ObservabilitySystem::new();
+        let alert = crate::monitoring::Alert {
+            id: "a6".to_string(),
+            title: "Info".to_string(),
+            description: "desc".to_string(),
+            severity: AlertSeverity::Info,
+            component: "system".to_string(),
+            timestamp: Utc::now(),
+            context: HashMap::new(),
+            acknowledged: false,
+        };
+        let score = system.calculate_priority_score(&alert, &AlertCategory::Configuration);
+        assert_eq!(score, 25);
+    }
+
+    #[test]
+    fn test_calculate_priority_score_error_performance() {
+        let system = ObservabilitySystem::new();
+        let alert = crate::monitoring::Alert {
+            id: "a7".to_string(),
+            title: "Slow".to_string(),
+            description: "desc".to_string(),
+            severity: AlertSeverity::Error,
+            component: "system".to_string(),
+            timestamp: Utc::now(),
+            context: HashMap::new(),
+            acknowledged: false,
+        };
+        let score = system.calculate_priority_score(&alert, &AlertCategory::Performance);
+        assert_eq!(score, 85);
+    }
+
+    #[test]
+    fn test_generate_recommended_actions_container() {
+        let system = ObservabilitySystem::new();
+        let alert = crate::monitoring::Alert {
+            id: "a8".to_string(),
+            title: "Container unhealthy".to_string(),
+            description: "desc".to_string(),
+            severity: AlertSeverity::Error,
+            component: "container:test".to_string(),
+            timestamp: Utc::now(),
+            context: HashMap::new(),
+            acknowledged: false,
+        };
+        let actions =
+            system.generate_recommended_actions(&alert, &AlertCategory::ContainerHealth);
+        assert_eq!(actions.len(), 3);
+        assert!(actions[0].contains("logs"));
+    }
+
+    #[test]
+    fn test_generate_recommended_actions_performance() {
+        let system = ObservabilitySystem::new();
+        let alert = crate::monitoring::Alert {
+            id: "a9".to_string(),
+            title: "Slow".to_string(),
+            description: "desc".to_string(),
+            severity: AlertSeverity::Warning,
+            component: "system".to_string(),
+            timestamp: Utc::now(),
+            context: HashMap::new(),
+            acknowledged: false,
+        };
+        let actions = system.generate_recommended_actions(&alert, &AlertCategory::Performance);
+        assert!(!actions.is_empty());
+    }
+
+    #[test]
+    fn test_generate_recommended_actions_model_quality() {
+        let system = ObservabilitySystem::new();
+        let alert = crate::monitoring::Alert {
+            id: "a10".to_string(),
+            title: "Poor quality".to_string(),
+            description: "desc".to_string(),
+            severity: AlertSeverity::Warning,
+            component: "model:test".to_string(),
+            timestamp: Utc::now(),
+            context: HashMap::new(),
+            acknowledged: false,
+        };
+        let actions = system.generate_recommended_actions(&alert, &AlertCategory::ModelQuality);
+        assert!(!actions.is_empty());
+    }
+
+    #[test]
+    fn test_trend_direction_equality() {
+        assert_eq!(TrendDirection::Improving, TrendDirection::Improving);
+        assert_eq!(TrendDirection::Stable, TrendDirection::Stable);
+        assert_eq!(TrendDirection::Degrading, TrendDirection::Degrading);
+        assert_eq!(TrendDirection::Unknown, TrendDirection::Unknown);
+        assert_ne!(TrendDirection::Improving, TrendDirection::Degrading);
+        assert_ne!(TrendDirection::Stable, TrendDirection::Unknown);
+    }
+
+    #[test]
+    fn test_sla_status_equality() {
+        assert_eq!(SlaStatus::Compliant, SlaStatus::Compliant);
+        assert_eq!(SlaStatus::AtRisk, SlaStatus::AtRisk);
+        assert_eq!(SlaStatus::Breached, SlaStatus::Breached);
+        assert_ne!(SlaStatus::Compliant, SlaStatus::Breached);
+        assert_ne!(SlaStatus::AtRisk, SlaStatus::Breached);
+    }
+
+    #[test]
+    fn test_escalation_status_equality() {
+        assert_eq!(EscalationStatus::New, EscalationStatus::New);
+        assert_eq!(EscalationStatus::Resolved, EscalationStatus::Resolved);
+        assert_eq!(EscalationStatus::Escalated, EscalationStatus::Escalated);
+        assert_ne!(EscalationStatus::New, EscalationStatus::Resolved);
+        assert_ne!(EscalationStatus::Escalated, EscalationStatus::HighlyEscalated);
+        assert_ne!(EscalationStatus::UnderInvestigation, EscalationStatus::New);
+    }
+
+    #[test]
+    fn test_alert_category_equality() {
+        assert_eq!(AlertCategory::Performance, AlertCategory::Performance);
+        assert_eq!(AlertCategory::ContainerHealth, AlertCategory::ContainerHealth);
+        assert_ne!(AlertCategory::Performance, AlertCategory::Security);
+        assert_ne!(AlertCategory::ModelQuality, AlertCategory::Resources);
+        assert_ne!(AlertCategory::Availability, AlertCategory::Configuration);
+    }
+
+    #[test]
+    fn test_availability_metrics_sla_at_risk() {
+        let system = ObservabilitySystem::new();
+        let metrics = system.calculate_availability_metrics().unwrap();
+        // Default availability is 99.5 which is at risk (< 99.9 target)
+        assert_eq!(metrics.sla_compliance.status, SlaStatus::AtRisk);
+        assert!(metrics.sla_compliance.current_availability < metrics.sla_compliance.target_availability);
+    }
 }

--- a/harness/src/observability.rs
+++ b/harness/src/observability.rs
@@ -1261,8 +1261,7 @@ mod tests {
             context: HashMap::new(),
             acknowledged: false,
         };
-        let actions =
-            system.generate_recommended_actions(&alert, &AlertCategory::ContainerHealth);
+        let actions = system.generate_recommended_actions(&alert, &AlertCategory::ContainerHealth);
         assert_eq!(actions.len(), 3);
         assert!(actions[0].contains("logs"));
     }
@@ -1326,14 +1325,20 @@ mod tests {
         assert_eq!(EscalationStatus::Resolved, EscalationStatus::Resolved);
         assert_eq!(EscalationStatus::Escalated, EscalationStatus::Escalated);
         assert_ne!(EscalationStatus::New, EscalationStatus::Resolved);
-        assert_ne!(EscalationStatus::Escalated, EscalationStatus::HighlyEscalated);
+        assert_ne!(
+            EscalationStatus::Escalated,
+            EscalationStatus::HighlyEscalated
+        );
         assert_ne!(EscalationStatus::UnderInvestigation, EscalationStatus::New);
     }
 
     #[test]
     fn test_alert_category_equality() {
         assert_eq!(AlertCategory::Performance, AlertCategory::Performance);
-        assert_eq!(AlertCategory::ContainerHealth, AlertCategory::ContainerHealth);
+        assert_eq!(
+            AlertCategory::ContainerHealth,
+            AlertCategory::ContainerHealth
+        );
         assert_ne!(AlertCategory::Performance, AlertCategory::Security);
         assert_ne!(AlertCategory::ModelQuality, AlertCategory::Resources);
         assert_ne!(AlertCategory::Availability, AlertCategory::Configuration);


### PR DESCRIPTION
## Coverage gaps addressed\n\n### `harness/src/monitoring.rs`\n- `HealthStatus::is_healthy()` — all variants\n- `HealthStatus::requires_attention()` — all variants\n- `AlertSeverity` / `ErrorSeverity` ordering via `PartialOrd`\n- `DefaultAlertManager::acknowledge_alert` with a non-existent ID (error path)\n- `DefaultAlertManager::get_alert_history` respects the `limit` parameter\n- `DefaultAlertManager::configure_thresholds`\n- `DefaultMetricsCollector::reset_metrics` clears all state\n- `export_metrics(MetricsFormat::Custom(...))` returns an error\n- `MonitoringSystem::start_monitoring` / `stop_monitoring` lifecycle\n- `record_error` populates `error_metrics`\n- Multiple services recorded in latency metrics\n\n### `harness/src/observability.rs`\n- `ObservabilitySystem::get_uptime()`\n- `stop_monitoring` is safe to call when not started\n- `start_monitoring` / `stop_monitoring` lifecycle\n- `determine_alert_category` — container, model, performance, and default paths\n- `calculate_priority_score` — Critical+Availability capped at 100, Info+Configuration=25, Error+Performance=85\n- `generate_recommended_actions` — ContainerHealth, Performance, ModelQuality branches\n- `TrendDirection`, `SlaStatus`, `EscalationStatus`, `AlertCategory` equality/inequality\n- `calculate_availability_metrics` SLA status is AtRisk when availability is 99.5%

---
_Generated by [Claude Code](https://claude.ai/code/session_018kKgt5qBKTuai6Dp9YC8r8)_