### PR TITLE
test(model): improve coverage for ModelDefaults, ModelError display, and config validation

### DIFF
--- a/model/src/config.rs
+++ b/model/src/config.rs
@@ -233,4 +233,39 @@ mod tests {
             deserialized.default_context_length
         );
     }
+
+    #[test]
+    fn test_with_max_tokens_builder() {
+        let config = OllamaConfig::new().with_max_tokens(4096);
+        assert_eq!(config.default_max_tokens, Some(4096));
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn test_validate_zero_max_tokens() {
+        let config = OllamaConfig {
+            default_max_tokens: Some(0),
+            ..Default::default()
+        };
+        let err = config.validate().unwrap_err();
+        assert!(err.contains("Max tokens"));
+    }
+
+    #[test]
+    fn test_model_defaults_default() {
+        let defaults = ModelDefaults::default();
+        assert_eq!(defaults.temperature, 0.7);
+        assert!(defaults.max_tokens.is_none());
+        assert_eq!(defaults.context_length, 110_000);
+    }
+
+    #[test]
+    fn test_model_defaults_serialization() {
+        let defaults = ModelDefaults::default();
+        let json = serde_json::to_string(&defaults).unwrap();
+        let back: ModelDefaults = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.temperature, defaults.temperature);
+        assert_eq!(back.context_length, defaults.context_length);
+        assert_eq!(back.max_tokens, defaults.max_tokens);
+    }
 }

--- a/model/src/provider.rs
+++ b/model/src/provider.rs
@@ -112,4 +112,74 @@ mod tests {
         provider.health_check().await.unwrap();
         assert_eq!(provider.provider_name(), "mock");
     }
+
+    #[test]
+    fn test_model_error_display_model_not_found() {
+        let err = ModelError::ModelNotFound {
+            model: "llama3".to_string(),
+        };
+        let msg = format!("{}", err);
+        assert!(msg.contains("llama3"));
+        assert!(msg.contains("not found"));
+    }
+
+    #[test]
+    fn test_model_error_display_invalid_config() {
+        let err = ModelError::InvalidConfig {
+            message: "bad base url".to_string(),
+        };
+        let msg = format!("{}", err);
+        assert!(msg.contains("bad base url"));
+        assert!(msg.contains("Invalid configuration"));
+    }
+
+    #[test]
+    fn test_model_error_display_service_unavailable() {
+        let err = ModelError::ServiceUnavailable {
+            message: "ollama is down".to_string(),
+        };
+        let msg = format!("{}", err);
+        assert!(msg.contains("ollama is down"));
+        assert!(msg.contains("unavailable"));
+    }
+
+    #[test]
+    fn test_model_error_display_rate_limit() {
+        let err = ModelError::RateLimit;
+        let msg = format!("{}", err);
+        assert!(msg.contains("Rate limit"));
+    }
+
+    #[test]
+    fn test_model_error_display_authentication() {
+        let err = ModelError::Authentication;
+        let msg = format!("{}", err);
+        assert!(msg.contains("Authentication"));
+    }
+
+    #[test]
+    fn test_model_error_display_unknown() {
+        let err = ModelError::Unknown {
+            message: "something unexpected".to_string(),
+        };
+        let msg = format!("{}", err);
+        assert!(msg.contains("something unexpected"));
+        assert!(msg.contains("Unknown error"));
+    }
+
+    #[test]
+    fn test_model_error_debug() {
+        let err = ModelError::RateLimit;
+        let dbg = format!("{:?}", err);
+        assert!(dbg.contains("RateLimit"));
+    }
+
+    #[test]
+    fn test_serialization_error_from_serde() {
+        let serde_err: serde_json::Error =
+            serde_json::from_str::<serde_json::Value>("{invalid}").unwrap_err();
+        let err = ModelError::Serialization(serde_err);
+        let msg = format!("{}", err);
+        assert!(msg.contains("Serialization error"));
+    }
 }


### PR DESCRIPTION
## Summary

- Add tests for `ModelDefaults::default()` and its serialization round-trip, which were previously completely uncovered
- Add test for `OllamaConfig::with_max_tokens()` builder method (never called in tests before)
- Add test for the `max_tokens == 0` validation branch in `OllamaConfig::validate()` (dead code path before this PR)
- Add tests for all `ModelError` `Display` impls: `ModelNotFound`, `InvalidConfig`, `ServiceUnavailable`, `RateLimit`, `Authentication`, `Unknown`, plus `Debug` formatting and the `Serialization` variant via `From<serde_json::Error>`

All new lines added in this PR are executed by the new tests, maintaining the 100% patch coverage requirement from `codecov.yml`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01H9NQBXGtpFHxC61SSJd1Yo)_