### PR TITLE
test(harness): expand monitoring and tools coverage

### DIFF
--- a/harness/src/monitoring.rs
+++ b/harness/src/monitoring.rs
@@ -1276,10 +1276,7 @@ mod tests {
         let metrics = collector.get_current_metrics().await.unwrap();
         assert_eq!(metrics.error_metrics.total_errors, 1);
         assert_eq!(metrics.error_metrics.recent_errors.len(), 1);
-        assert_eq!(
-            metrics.error_metrics.recent_errors[0].error_type,
-            "timeout"
-        );
+        assert_eq!(metrics.error_metrics.recent_errors[0].error_type, "timeout");
     }
 
     #[tokio::test]
@@ -1318,11 +1315,7 @@ mod tests {
 
         for i in 0..5 {
             manager
-                .send_alert(
-                    &format!("Alert {}", i),
-                    "description",
-                    AlertSeverity::Info,
-                )
+                .send_alert(&format!("Alert {}", i), "description", AlertSeverity::Info)
                 .await
                 .unwrap();
         }
@@ -1375,10 +1368,7 @@ mod tests {
             max_memory_usage: 0.85,
             health_check_timeout: Duration::from_secs(10),
         };
-        manager
-            .configure_thresholds(new_thresholds)
-            .await
-            .unwrap();
+        manager.configure_thresholds(new_thresholds).await.unwrap();
     }
 
     #[tokio::test]

--- a/harness/src/monitoring.rs
+++ b/harness/src/monitoring.rs
@@ -1242,4 +1242,178 @@ mod tests {
         let csv_export = collector.export_metrics(MetricsFormat::Csv).await.unwrap();
         assert!(csv_export.contains("timestamp,metric_type,service,value"));
     }
+
+    #[test]
+    fn test_health_status_is_healthy() {
+        assert!(HealthStatus::Healthy.is_healthy());
+        assert!(!HealthStatus::Warning.is_healthy());
+        assert!(!HealthStatus::Degraded.is_healthy());
+        assert!(!HealthStatus::Unhealthy.is_healthy());
+        assert!(!HealthStatus::Unknown.is_healthy());
+    }
+
+    #[test]
+    fn test_health_status_requires_attention() {
+        assert!(!HealthStatus::Healthy.requires_attention());
+        assert!(HealthStatus::Warning.requires_attention());
+        assert!(HealthStatus::Degraded.requires_attention());
+        assert!(HealthStatus::Unhealthy.requires_attention());
+        assert!(!HealthStatus::Unknown.requires_attention());
+    }
+
+    #[tokio::test]
+    async fn test_record_error_appears_in_metrics() {
+        let mut collector = DefaultMetricsCollector::new();
+        let error = ErrorEvent {
+            timestamp: chrono::Utc::now(),
+            error_type: "timeout".to_string(),
+            message: "connection timed out".to_string(),
+            component: "ollama".to_string(),
+            severity: ErrorSeverity::Error,
+        };
+        collector.record_error(error).await;
+
+        let metrics = collector.get_current_metrics().await.unwrap();
+        assert_eq!(metrics.error_metrics.total_errors, 1);
+        assert_eq!(metrics.error_metrics.recent_errors.len(), 1);
+        assert_eq!(
+            metrics.error_metrics.recent_errors[0].error_type,
+            "timeout"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_record_model_inference() {
+        let mut collector = DefaultMetricsCollector::new();
+        let model_metrics = ModelMetrics {
+            model_name: "llama3".to_string(),
+            inference_count: 10,
+            avg_inference_time_ms: 250.0,
+            tokens_per_second: 40.0,
+            success_rate: 0.99,
+            quality_scores: QualityMetrics {
+                avg_coherence: 0.9,
+                avg_relevance: 0.85,
+                consistency: 0.88,
+                accuracy_rate: 0.92,
+            },
+            resource_usage: ModelResourceUsage {
+                peak_memory_mb: 4096.0,
+                avg_cpu_percent: 0.75,
+                gpu_utilization_percent: Some(0.9),
+            },
+        };
+        collector
+            .record_model_inference("llama3", model_metrics)
+            .await;
+
+        let metrics = collector.get_current_metrics().await.unwrap();
+        assert!(metrics.model_metrics.contains_key("llama3"));
+        assert_eq!(metrics.model_metrics["llama3"].inference_count, 10);
+    }
+
+    #[tokio::test]
+    async fn test_alert_history_with_limit() {
+        let manager = DefaultAlertManager::new();
+
+        for i in 0..5 {
+            manager
+                .send_alert(
+                    &format!("Alert {}", i),
+                    "description",
+                    AlertSeverity::Info,
+                )
+                .await
+                .unwrap();
+        }
+
+        let history = manager.get_alert_history(3).await.unwrap();
+        assert_eq!(history.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn test_alert_severity_variants() {
+        let manager = DefaultAlertManager::new();
+
+        manager
+            .send_alert("Critical alert", "desc", AlertSeverity::Critical)
+            .await
+            .unwrap();
+        manager
+            .send_alert("Error alert", "desc", AlertSeverity::Error)
+            .await
+            .unwrap();
+        manager
+            .send_alert("Info alert", "desc", AlertSeverity::Info)
+            .await
+            .unwrap();
+
+        let active = manager.get_active_alerts().await.unwrap();
+        assert_eq!(active.len(), 3);
+
+        let severities: Vec<_> = active.iter().map(|a| &a.severity).collect();
+        assert!(severities.contains(&&AlertSeverity::Critical));
+        assert!(severities.contains(&&AlertSeverity::Error));
+        assert!(severities.contains(&&AlertSeverity::Info));
+    }
+
+    #[tokio::test]
+    async fn test_acknowledge_nonexistent_alert_is_error() {
+        let manager = DefaultAlertManager::new();
+        let result = manager.acknowledge_alert("nonexistent-id").await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_configure_thresholds() {
+        let mut manager = DefaultAlertManager::new();
+        let new_thresholds = AlertThresholds {
+            max_latency_ms: 1000,
+            min_cache_hit_rate: 0.5,
+            max_error_rate: 0.1,
+            max_cpu_usage: 0.8,
+            max_memory_usage: 0.85,
+            health_check_timeout: Duration::from_secs(10),
+        };
+        manager
+            .configure_thresholds(new_thresholds)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_alert_severity_ordering() {
+        assert!(AlertSeverity::Critical > AlertSeverity::Error);
+        assert!(AlertSeverity::Error > AlertSeverity::Warning);
+        assert!(AlertSeverity::Warning > AlertSeverity::Info);
+    }
+
+    #[tokio::test]
+    async fn test_multiple_errors_tracked_in_metrics() {
+        let mut collector = DefaultMetricsCollector::new();
+        for _ in 0..3 {
+            collector
+                .record_error(ErrorEvent {
+                    timestamp: chrono::Utc::now(),
+                    error_type: "io_error".to_string(),
+                    message: "disk write failed".to_string(),
+                    component: "storage".to_string(),
+                    severity: ErrorSeverity::Critical,
+                })
+                .await;
+        }
+
+        let metrics = collector.get_current_metrics().await.unwrap();
+        assert_eq!(metrics.error_metrics.total_errors, 3);
+        assert_eq!(metrics.error_metrics.errors_by_type["io_error"], 3);
+    }
+
+    #[tokio::test]
+    async fn test_zero_cache_requests_hit_rate() {
+        let collector = DefaultMetricsCollector::new();
+        let metrics = collector.get_current_metrics().await.unwrap();
+        assert_eq!(metrics.cache_metrics.hit_rate, 0.0);
+        assert_eq!(metrics.cache_metrics.hits, 0);
+        assert_eq!(metrics.cache_metrics.misses, 0);
+    }
 }

--- a/harness/src/tools.rs
+++ b/harness/src/tools.rs
@@ -1988,9 +1988,7 @@ mod tests {
     #[tokio::test]
     async fn test_calculator_missing_operands() {
         let tool = CalculatorTool::new();
-        let result = tool
-            .execute(json!({ "operation": "add", "a": 1.0 }))
-            .await;
+        let result = tool.execute(json!({ "operation": "add", "a": 1.0 })).await;
         assert!(result.is_err());
     }
 

--- a/harness/src/tools.rs
+++ b/harness/src/tools.rs
@@ -1928,6 +1928,84 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_tool_registry_execute_not_found() {
+        let registry = ToolRegistry::new();
+        let result = registry.execute("missing_tool", json!({})).await;
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), ToolError::NotFound { .. }));
+    }
+
+    #[tokio::test]
+    async fn test_calculator_subtract() {
+        let tool = CalculatorTool::new();
+        let result = tool
+            .execute(json!({ "operation": "subtract", "a": 10.0, "b": 3.0 }))
+            .await
+            .unwrap();
+        assert_eq!(result["result"], 7.0);
+    }
+
+    #[tokio::test]
+    async fn test_calculator_multiply() {
+        let tool = CalculatorTool::new();
+        let result = tool
+            .execute(json!({ "operation": "multiply", "a": 4.0, "b": 5.0 }))
+            .await
+            .unwrap();
+        assert_eq!(result["result"], 20.0);
+    }
+
+    #[tokio::test]
+    async fn test_calculator_divide() {
+        let tool = CalculatorTool::new();
+        let result = tool
+            .execute(json!({ "operation": "divide", "a": 15.0, "b": 3.0 }))
+            .await
+            .unwrap();
+        assert_eq!(result["result"], 5.0);
+    }
+
+    #[tokio::test]
+    async fn test_calculator_unknown_operation() {
+        let tool = CalculatorTool::new();
+        let result = tool
+            .execute(json!({ "operation": "modulo", "a": 10.0, "b": 3.0 }))
+            .await;
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            ToolError::InvalidArguments { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_calculator_missing_operation() {
+        let tool = CalculatorTool::new();
+        let result = tool.execute(json!({ "a": 1.0, "b": 2.0 })).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_calculator_missing_operands() {
+        let tool = CalculatorTool::new();
+        let result = tool
+            .execute(json!({ "operation": "add", "a": 1.0 }))
+            .await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_echo_missing_message() {
+        let tool = EchoTool::new();
+        let result = tool.execute(json!({})).await;
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            ToolError::InvalidArguments { .. }
+        ));
+    }
+
+    #[tokio::test]
     async fn test_read_file_tool() {
         let temp_dir = std::env::temp_dir().join("nanna_test_read");
         std::fs::create_dir_all(&temp_dir).unwrap();


### PR DESCRIPTION
## Summary

Targets the two largest sets of untested code paths in `harness`:

1. **`monitoring.rs`** — had 5 basic smoke tests covering ~100 lines out of 1245. Many public methods and enum variants had zero coverage.
2. **`tools.rs`** — `CalculatorTool` only tested `add` and divide-by-zero; several error paths were untested.

## Changes

### `harness/src/monitoring.rs` — 10 new tests

- `test_health_status_is_healthy` — covers `HealthStatus::is_healthy()` for all 5 variants
- `test_health_status_requires_attention` — covers `HealthStatus::requires_attention()` for all 5 variants
- `test_record_error_appears_in_metrics` — exercises `record_error()` and verifies error propagates into `get_current_metrics()`
- `test_record_model_inference` — exercises `record_model_inference()` and verifies model metrics are stored
- `test_alert_history_with_limit` — exercises `get_alert_history()` with a limit
- `test_alert_severity_variants` — exercises `send_alert()` with `Critical`, `Error`, and `Info` severity (only `Warning` was previously tested)
- `test_acknowledge_nonexistent_alert_is_error` — exercises the error path in `acknowledge_alert()`
- `test_configure_thresholds` — exercises `configure_thresholds()`
- `test_alert_severity_ordering` — verifies `AlertSeverity` ordering (`Critical > Error > Warning > Info`)
- `test_multiple_errors_tracked_in_metrics` — verifies error count and `errors_by_type` aggregation
- `test_zero_cache_requests_hit_rate` — exercises the zero-denominator branch in cache hit rate calculation

### `harness/src/tools.rs` — 7 new tests

- `test_tool_registry_execute_not_found` — exercises `ToolError::NotFound` path
- `test_calculator_subtract` — covers `subtract` operation branch
- `test_calculator_multiply` — covers `multiply` operation branch  
- `test_calculator_divide` — covers non-zero `divide` path
- `test_calculator_unknown_operation` — covers unknown-operation error branch
- `test_calculator_missing_operation` — covers missing `operation` param error
- `test_calculator_missing_operands` — covers missing `b` param error
- `test_echo_missing_message` — covers `EchoTool` missing-param error path

## Test plan

- [ ] CI passes (all new tests green)
- [ ] Codecov shows coverage increase for `monitoring.rs` and `tools.rs`

---
_Generated by [Claude Code](https://claude.ai/code/session_01QTzsjVjAeJ7iGC67mDs8eQ)_