### PR TITLE
test(coverage): cover bin helpers, MCP branches, and TestEntity

### DIFF
--- a/harness/src/bin/eval.rs
+++ b/harness/src/bin/eval.rs
@@ -154,3 +154,42 @@ async fn main() -> ExitCode {
         ExitCode::FAILURE
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn case_matches_no_filter_always_true() {
+        assert!(case_matches("any-case-id", &None));
+    }
+
+    #[test]
+    fn case_matches_empty_filter_always_true() {
+        assert!(case_matches("any-case-id", &Some(String::new())));
+    }
+
+    #[test]
+    fn case_matches_needle_found() {
+        assert!(case_matches("repo__fix-login-bug", &Some("login".to_string())));
+    }
+
+    #[test]
+    fn case_matches_needle_not_found() {
+        assert!(!case_matches("repo__fix-login-bug", &Some("perf".to_string())));
+    }
+
+    #[test]
+    fn resolve_model_cli_arg_wins() {
+        assert_eq!(
+            resolve_model(Some("my-custom-model".to_string())),
+            "my-custom-model"
+        );
+    }
+
+    #[test]
+    fn resolve_model_none_returns_nonempty() {
+        let model = resolve_model(None);
+        assert!(!model.is_empty());
+    }
+}

--- a/harness/src/bin/eval.rs
+++ b/harness/src/bin/eval.rs
@@ -171,12 +171,18 @@ mod tests {
 
     #[test]
     fn case_matches_needle_found() {
-        assert!(case_matches("repo__fix-login-bug", &Some("login".to_string())));
+        assert!(case_matches(
+            "repo__fix-login-bug",
+            &Some("login".to_string())
+        ));
     }
 
     #[test]
     fn case_matches_needle_not_found() {
-        assert!(!case_matches("repo__fix-login-bug", &Some("perf".to_string())));
+        assert!(!case_matches(
+            "repo__fix-login-bug",
+            &Some("perf".to_string())
+        ));
     }
 
     #[test]

--- a/harness/src/bin/score.rs
+++ b/harness/src/bin/score.rs
@@ -394,3 +394,72 @@ fn print_summary(card: &Scorecard) {
     println!("commit:             {}", card.commit);
     println!("appended to evals/scorecards/index.jsonl");
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_category_nanna_solo() {
+        assert_eq!(
+            parse_category("nanna_solo").unwrap(),
+            ScorecardCategory::NannaSolo
+        );
+    }
+
+    #[test]
+    fn parse_category_claude_solo() {
+        assert_eq!(
+            parse_category("claude_solo").unwrap(),
+            ScorecardCategory::ClaudeSolo
+        );
+    }
+
+    #[test]
+    fn parse_category_claude_mcp_claude() {
+        assert_eq!(
+            parse_category("claude_mcp_claude").unwrap(),
+            ScorecardCategory::ClaudeMcpClaude
+        );
+    }
+
+    #[test]
+    fn parse_category_claude_mcp_nanna_gemma4() {
+        assert_eq!(
+            parse_category("claude_mcp_nanna_gemma4").unwrap(),
+            ScorecardCategory::ClaudeMcpNannaGemma4
+        );
+    }
+
+    #[test]
+    fn parse_category_unknown_returns_err() {
+        assert!(parse_category("not_a_real_category").is_err());
+    }
+
+    #[test]
+    fn iso_now_returns_nonempty_iso8601() {
+        let s = iso_now();
+        assert!(!s.is_empty());
+        assert!(s.len() == 20, "expected YYYY-MM-DDTHH:MM:SSZ (20 chars), got {s:?}");
+        assert!(s.ends_with('Z'));
+    }
+
+    #[test]
+    fn run_id_default_starts_with_nanna() {
+        let id = run_id_default();
+        assert!(id.starts_with("nanna-"), "expected 'nanna-' prefix, got {id:?}");
+    }
+
+    #[test]
+    fn git_capture_version_returns_some() {
+        let out = git_capture(&["--version"]);
+        assert!(out.is_some());
+        assert!(out.unwrap().contains("git"));
+    }
+
+    #[test]
+    fn git_capture_bad_subcommand_returns_none() {
+        let out = git_capture(&["__no_such_subcommand__"]);
+        assert!(out.is_none());
+    }
+}

--- a/harness/src/bin/score.rs
+++ b/harness/src/bin/score.rs
@@ -440,14 +440,20 @@ mod tests {
     fn iso_now_returns_nonempty_iso8601() {
         let s = iso_now();
         assert!(!s.is_empty());
-        assert!(s.len() == 20, "expected YYYY-MM-DDTHH:MM:SSZ (20 chars), got {s:?}");
+        assert!(
+            s.len() == 20,
+            "expected YYYY-MM-DDTHH:MM:SSZ (20 chars), got {s:?}"
+        );
         assert!(s.ends_with('Z'));
     }
 
     #[test]
     fn run_id_default_starts_with_nanna() {
         let id = run_id_default();
-        assert!(id.starts_with("nanna-"), "expected 'nanna-' prefix, got {id:?}");
+        assert!(
+            id.starts_with("nanna-"),
+            "expected 'nanna-' prefix, got {id:?}"
+        );
     }
 
     #[test]

--- a/harness/src/mcp/mod.rs
+++ b/harness/src/mcp/mod.rs
@@ -495,4 +495,34 @@ mod tests {
             .unwrap();
         assert!(output.is_empty());
     }
+
+    #[tokio::test]
+    async fn test_handle_request_invalid_jsonrpc_version() {
+        let server = make_server();
+        let req = JsonRpcRequest {
+            jsonrpc: "1.0".to_string(),
+            id: Some(serde_json::json!(99)),
+            method: "initialize".to_string(),
+            params: None,
+        };
+        let resp = server.handle_request(req).await;
+        assert!(resp.error.is_some());
+        assert_eq!(resp.error.unwrap().code, -32600);
+    }
+
+    #[tokio::test]
+    async fn test_tools_call_missing_name_returns_error() {
+        let server = make_server();
+        let req = JsonRpcRequest {
+            jsonrpc: "2.0".to_string(),
+            id: Some(serde_json::json!(5)),
+            method: "tools/call".to_string(),
+            params: Some(serde_json::json!({
+                "arguments": {}
+            })),
+        };
+        let resp = server.handle_request(req).await;
+        assert!(resp.error.is_some());
+        assert_eq!(resp.error.unwrap().code, -32602);
+    }
 }

--- a/harness/tests/test_entity_tests.rs
+++ b/harness/tests/test_entity_tests.rs
@@ -1,5 +1,5 @@
-use harness::entities::{Entity, EntityType};
 use harness::entities::test::types::TestEntity;
+use harness::entities::{Entity, EntityType};
 
 #[test]
 fn test_entity_new_has_correct_type() {

--- a/harness/tests/test_entity_tests.rs
+++ b/harness/tests/test_entity_tests.rs
@@ -1,0 +1,37 @@
+use harness::entities::{Entity, EntityType};
+use harness::entities::test::types::TestEntity;
+
+#[test]
+fn test_entity_new_has_correct_type() {
+    let e = TestEntity::new();
+    assert_eq!(e.metadata().entity_type, EntityType::Test);
+}
+
+#[test]
+fn test_entity_default_equals_new() {
+    let a = TestEntity::new();
+    let b = TestEntity::default();
+    assert_eq!(a.metadata().entity_type, b.metadata().entity_type);
+}
+
+#[test]
+fn test_entity_to_json_is_valid() {
+    let e = TestEntity::new();
+    let json = e.to_json().unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+    assert!(parsed.is_object());
+}
+
+#[test]
+fn test_entity_metadata_accessor() {
+    let e = TestEntity::new();
+    let m = e.metadata();
+    assert_eq!(m.entity_type, EntityType::Test);
+}
+
+#[test]
+fn test_entity_metadata_mut_accessor() {
+    let mut e = TestEntity::new();
+    let m = e.metadata_mut();
+    assert_eq!(m.entity_type, EntityType::Test);
+}


### PR DESCRIPTION
## Summary

Adds targeted unit tests to close coverage gaps identified via codecov:

- **`harness/src/bin/eval.rs`**: inline `#[cfg(test)]` block covering `case_matches` (all 4 branches: no filter, empty filter, match, no-match) and `resolve_model` (CLI arg wins; None path)
- **`harness/src/bin/score.rs`**: inline `#[cfg(test)]` block covering `parse_category` (all 4 valid variants + invalid input), `iso_now` (format length and `Z` suffix), `run_id_default` (`nanna-` prefix), and `git_capture` (success and failure paths)
- **`harness/src/mcp/mod.rs`**: two new inline tests covering the previously untested `req.jsonrpc != "2.0"` error path and the missing `name` field in `tools/call` (→ `-32602`)
- **`harness/tests/test_entity_tests.rs`**: new integration test file covering `TestEntity::new`, `default`, `to_json`, `metadata`, and `metadata_mut`

All existing tests continue to pass. The one pre-existing failure (`github_pr_status_integration::test_l1_github_field_via_tool`) requires live GitHub credentials and was failing before this branch.

---
_Generated by [Claude Code](https://claude.ai/code/session_014oNQV3g4V54viws2oAfNHN)_