### PR TITLE
test(harness): expand coverage for monitoring, telemetry, and observability

### DIFF
--- a/harness/src/monitoring.rs
+++ b/harness/src/monitoring.rs
@@ -1242,4 +1242,141 @@ mod tests {
         let csv_export = collector.export_metrics(MetricsFormat::Csv).await.unwrap();
         assert!(csv_export.contains("timestamp,metric_type,service,value"));
     }
+
+    #[tokio::test]
+    async fn test_health_status_methods() {
+        assert!(HealthStatus::Healthy.is_healthy());
+        assert!(!HealthStatus::Warning.is_healthy());
+        assert!(!HealthStatus::Degraded.is_healthy());
+        assert!(!HealthStatus::Unhealthy.is_healthy());
+        assert!(!HealthStatus::Unknown.is_healthy());
+
+        assert!(!HealthStatus::Healthy.requires_attention());
+        assert!(HealthStatus::Warning.requires_attention());
+        assert!(HealthStatus::Degraded.requires_attention());
+        assert!(HealthStatus::Unhealthy.requires_attention());
+        assert!(!HealthStatus::Unknown.requires_attention());
+    }
+
+    #[tokio::test]
+    async fn test_alert_thresholds_default() {
+        let t = AlertThresholds::default();
+        assert!(t.max_latency_ms > 0);
+        assert!(t.min_cache_hit_rate > 0.0);
+        assert!(t.max_error_rate > 0.0);
+        assert!(t.max_cpu_usage > 0.0);
+        assert!(t.max_memory_usage > 0.0);
+    }
+
+    #[tokio::test]
+    async fn test_record_error_and_model_inference() {
+        let mut collector = DefaultMetricsCollector::new();
+
+        let error = ErrorEvent {
+            timestamp: chrono::Utc::now(),
+            error_type: "TestError".to_string(),
+            message: "something broke".to_string(),
+            component: "test-component".to_string(),
+            severity: ErrorSeverity::Warning,
+        };
+        collector.record_error(error).await;
+
+        let model_metrics = ModelMetrics {
+            model_name: "test-model".to_string(),
+            inference_count: 10,
+            avg_inference_time_ms: 150.0,
+            tokens_per_second: 50.0,
+            success_rate: 0.99,
+            quality_scores: QualityMetrics {
+                avg_coherence: 0.9,
+                avg_relevance: 0.85,
+                consistency: 0.88,
+                accuracy_rate: 0.92,
+            },
+            resource_usage: ModelResourceUsage {
+                peak_memory_mb: 512.0,
+                avg_cpu_percent: 40.0,
+                gpu_utilization_percent: None,
+            },
+        };
+        collector
+            .record_model_inference("test-model", model_metrics)
+            .await;
+
+        let metrics = collector.get_current_metrics().await.unwrap();
+        assert_eq!(metrics.error_metrics.total_errors, 1);
+        assert!(metrics.model_metrics.contains_key("test-model"));
+    }
+
+    #[tokio::test]
+    async fn test_reset_metrics() {
+        let mut collector = DefaultMetricsCollector::new();
+        collector
+            .record_request_latency("svc", Duration::from_millis(100))
+            .await;
+
+        let before = collector.get_current_metrics().await.unwrap();
+        assert!(!before.request_latencies.is_empty());
+
+        collector.reset_metrics().await;
+
+        let after = collector.get_current_metrics().await.unwrap();
+        assert!(after.request_latencies.is_empty());
+        assert_eq!(after.cache_metrics.hits, 0);
+    }
+
+    #[tokio::test]
+    async fn test_metrics_format_custom_error() {
+        let collector = DefaultMetricsCollector::new();
+        let result = collector
+            .export_metrics(MetricsFormat::Custom("myformat".to_string()))
+            .await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_health_monitor_model_and_comprehensive() {
+        let mut monitor = DefaultHealthMonitor::new(Duration::from_secs(30));
+
+        let model_health = monitor.check_model_health("qwen3:0.6b").await.unwrap();
+        assert_eq!(model_health.status, HealthStatus::Healthy);
+        assert!(model_health.message.contains("qwen3:0.6b"));
+
+        let all_checks = monitor.comprehensive_health_check().await.unwrap();
+        assert!(!all_checks.is_empty());
+
+        monitor.set_check_interval(Duration::from_secs(10));
+    }
+
+    #[tokio::test]
+    async fn test_alert_manager_history_configure_and_missing() {
+        let mut manager = DefaultAlertManager::new();
+
+        manager
+            .send_alert("Alert 1", "First", AlertSeverity::Info)
+            .await
+            .unwrap();
+        manager
+            .send_alert("Alert 2", "Second", AlertSeverity::Error)
+            .await
+            .unwrap();
+
+        let history = manager.get_alert_history(10).await.unwrap();
+        assert_eq!(history.len(), 2);
+
+        let err = manager.acknowledge_alert("nonexistent_id").await;
+        assert!(err.is_err());
+
+        manager
+            .configure_thresholds(AlertThresholds::default())
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_monitoring_system_start_stop() {
+        let mut system = MonitoringSystem::new();
+        system.start_monitoring().await.unwrap();
+        system.stop_monitoring().await;
+    }
 }

--- a/harness/src/observability.rs
+++ b/harness/src/observability.rs
@@ -1100,11 +1100,13 @@ mod tests {
 
     #[tokio::test]
     async fn test_with_health_thresholds() {
-        let mut custom = HealthThreshold::default();
-        custom.cpu_threshold = 95.0;
-        custom.max_latency_ms = 500;
+        let custom = HealthThreshold {
+            cpu_threshold: 95.0,
+            max_latency_ms: 500,
+            ..HealthThreshold::default()
+        };
 
-        let system = ObservabilitySystem::new().with_health_thresholds(custom.clone());
+        let system = ObservabilitySystem::new().with_health_thresholds(custom);
         assert_eq!(system.health_thresholds.cpu_threshold, 95.0);
         assert_eq!(system.health_thresholds.max_latency_ms, 500);
     }

--- a/harness/src/observability.rs
+++ b/harness/src/observability.rs
@@ -1111,8 +1111,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_observability_start_stop_monitoring() {
-        let mut system = ObservabilitySystem::new()
-            .with_health_check_interval(Duration::from_secs(60));
+        let mut system =
+            ObservabilitySystem::new().with_health_check_interval(Duration::from_secs(60));
         system.start_monitoring().await.unwrap();
         system.stop_monitoring().await;
     }

--- a/harness/src/observability.rs
+++ b/harness/src/observability.rs
@@ -1097,4 +1097,143 @@ mod tests {
         let trends = system.analyze_current_trends(&metrics).unwrap();
         assert!(trends.performance_score >= 0.0 && trends.performance_score <= 100.0);
     }
+
+    #[tokio::test]
+    async fn test_with_health_thresholds() {
+        let mut custom = HealthThreshold::default();
+        custom.cpu_threshold = 95.0;
+        custom.max_latency_ms = 500;
+
+        let system = ObservabilitySystem::new().with_health_thresholds(custom.clone());
+        assert_eq!(system.health_thresholds.cpu_threshold, 95.0);
+        assert_eq!(system.health_thresholds.max_latency_ms, 500);
+    }
+
+    #[tokio::test]
+    async fn test_observability_start_stop_monitoring() {
+        let mut system = ObservabilitySystem::new()
+            .with_health_check_interval(Duration::from_secs(60));
+        system.start_monitoring().await.unwrap();
+        system.stop_monitoring().await;
+    }
+
+    #[tokio::test]
+    async fn test_trend_direction_variants() {
+        let improving = TrendDirection::Improving;
+        let stable = TrendDirection::Stable;
+        let degrading = TrendDirection::Degrading;
+        let unknown = TrendDirection::Unknown;
+
+        assert_eq!(improving, TrendDirection::Improving);
+        assert_eq!(stable, TrendDirection::Stable);
+        assert_eq!(degrading, TrendDirection::Degrading);
+        assert_eq!(unknown, TrendDirection::Unknown);
+        assert_ne!(improving, degrading);
+    }
+
+    #[tokio::test]
+    async fn test_sla_status_variants() {
+        assert_eq!(SlaStatus::Compliant, SlaStatus::Compliant);
+        assert_eq!(SlaStatus::AtRisk, SlaStatus::AtRisk);
+        assert_eq!(SlaStatus::Breached, SlaStatus::Breached);
+        assert_ne!(SlaStatus::Compliant, SlaStatus::Breached);
+    }
+
+    #[tokio::test]
+    async fn test_alert_category_variants() {
+        let cats = [
+            AlertCategory::Performance,
+            AlertCategory::Availability,
+            AlertCategory::Security,
+            AlertCategory::Resources,
+            AlertCategory::Configuration,
+            AlertCategory::ModelQuality,
+            AlertCategory::ContainerHealth,
+        ];
+        assert_eq!(cats.len(), 7);
+        assert_eq!(cats[0], AlertCategory::Performance);
+        assert_eq!(cats[6], AlertCategory::ContainerHealth);
+    }
+
+    #[tokio::test]
+    async fn test_escalation_and_channel_variants() {
+        let statuses = [
+            EscalationStatus::New,
+            EscalationStatus::Escalated,
+            EscalationStatus::HighlyEscalated,
+            EscalationStatus::UnderInvestigation,
+            EscalationStatus::Resolved,
+        ];
+        assert_eq!(statuses.len(), 5);
+        assert_eq!(statuses[0], EscalationStatus::New);
+        assert_eq!(statuses[4], EscalationStatus::Resolved);
+
+        let channels = [
+            ChannelType::Email,
+            ChannelType::Slack,
+            ChannelType::Discord,
+            ChannelType::Webhook,
+            ChannelType::LogFile,
+            ChannelType::Console,
+        ];
+        assert_eq!(channels.len(), 6);
+        assert_eq!(channels[0], ChannelType::Email);
+        assert_eq!(channels[5], ChannelType::Console);
+    }
+
+    #[tokio::test]
+    async fn test_performance_degradation_score() {
+        let system = ObservabilitySystem::new();
+
+        let mut request_latencies = HashMap::new();
+        request_latencies.insert(
+            "slow-svc".to_string(),
+            crate::monitoring::LatencyMetrics {
+                avg_latency_ms: 3000.0,
+                p95_latency_ms: 4000.0,
+                p99_latency_ms: 4500.0,
+                max_latency_ms: 5000.0,
+                min_latency_ms: 2000.0,
+                request_count: 100,
+                requests_per_second: 10.0,
+            },
+        );
+
+        let metrics = SystemMetrics {
+            timestamp: Utc::now(),
+            request_latencies,
+            cache_metrics: crate::monitoring::CacheMetrics {
+                hits: 10,
+                misses: 90,
+                hit_rate: 0.1,
+                size_bytes: 0,
+                item_count: 0,
+                evictions: 0,
+            },
+            container_metrics: Vec::new(),
+            system_resources: crate::monitoring::SystemResourceMetrics {
+                cpu_usage_percent: 50.0,
+                total_memory_bytes: 8589934592,
+                used_memory_bytes: 4294967296,
+                memory_usage_percent: 50.0,
+                available_disk_bytes: 107374182400,
+                total_disk_bytes: 214748364800,
+                disk_usage_percent: 50.0,
+                load_average: [1.0, 1.2, 1.1],
+            },
+            model_metrics: HashMap::new(),
+            error_metrics: crate::monitoring::ErrorMetrics {
+                total_errors: 10,
+                errors_by_type: HashMap::new(),
+                error_rate: 0.1,
+                recent_errors: Vec::new(),
+            },
+        };
+
+        let trends = system.analyze_current_trends(&metrics).unwrap();
+        assert_eq!(trends.latency_trend, TrendDirection::Degrading);
+        assert_eq!(trends.error_rate_trend, TrendDirection::Degrading);
+        assert_eq!(trends.cache_performance_trend, TrendDirection::Degrading);
+        assert!(trends.performance_score <= 40.0 + f64::EPSILON);
+    }
 }

--- a/harness/src/telemetry.rs
+++ b/harness/src/telemetry.rs
@@ -1073,8 +1073,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_add_exporter_and_export_all() {
-        let telemetry = TelemetrySystem::new()
-            .add_exporter(Box::new(PrometheusExporter::new(None)));
+        let telemetry =
+            TelemetrySystem::new().add_exporter(Box::new(PrometheusExporter::new(None)));
 
         telemetry.record_counter("test_count", 5.0, vec![]);
         telemetry.record_event("test_event", "test_cat", serde_json::json!({"k": "v"}));

--- a/harness/src/telemetry.rs
+++ b/harness/src/telemetry.rs
@@ -1044,4 +1044,195 @@ mod tests {
             Some(&"Something went wrong".to_string())
         );
     }
+
+    #[tokio::test]
+    async fn test_global_attribute_and_uptime() {
+        let telemetry = TelemetrySystem::new()
+            .with_global_attribute("environment", "test")
+            .with_global_attribute("region", "us-east-1");
+
+        assert_eq!(
+            telemetry.config.global_attributes.get("environment"),
+            Some(&"test".to_string())
+        );
+        assert_eq!(
+            telemetry.config.global_attributes.get("region"),
+            Some(&"us-east-1".to_string())
+        );
+        assert!(telemetry.get_uptime().as_nanos() > 0);
+    }
+
+    #[tokio::test]
+    async fn test_with_config() {
+        let mut config = TelemetryConfig::default();
+        config.service.name = "custom-service".to_string();
+
+        let telemetry = TelemetrySystem::new().with_config(config);
+        assert_eq!(telemetry.config.service.name, "custom-service");
+    }
+
+    #[tokio::test]
+    async fn test_add_exporter_and_export_all() {
+        let telemetry = TelemetrySystem::new()
+            .add_exporter(Box::new(PrometheusExporter::new(None)));
+
+        telemetry.record_counter("test_count", 5.0, vec![]);
+        telemetry.record_event("test_event", "test_cat", serde_json::json!({"k": "v"}));
+        telemetry.export_all().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_prometheus_clear_buffer() {
+        let exporter = PrometheusExporter::new(None);
+
+        exporter.add_metric(MetricPoint {
+            name: "test_counter".to_string(),
+            metric_type: MetricType::Counter,
+            value: 1.0,
+            timestamp: Utc::now(),
+            labels: HashMap::new(),
+            unit: None,
+            description: None,
+        });
+
+        let output = exporter.export_prometheus().await.unwrap();
+        assert!(!output.is_empty());
+
+        exporter.clear_buffer();
+        let empty_output = exporter.export_prometheus().await.unwrap();
+        assert!(empty_output.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_prometheus_trait_methods() {
+        let exporter = PrometheusExporter::new(None);
+
+        let mut trace = TraceContext::new("test-op");
+        trace.finish();
+        TelemetryExporter::export_traces(&exporter, vec![trace])
+            .await
+            .unwrap();
+
+        let event = CustomEvent {
+            name: "test_event".to_string(),
+            timestamp: Utc::now(),
+            category: "test".to_string(),
+            attributes: HashMap::new(),
+            data: serde_json::json!({}),
+            trace_context: None,
+        };
+        TelemetryExporter::export_events(&exporter, vec![event])
+            .await
+            .unwrap();
+
+        let system_metrics = crate::monitoring::SystemMetrics {
+            timestamp: Utc::now(),
+            request_latencies: {
+                let mut m = HashMap::new();
+                m.insert(
+                    "svc".to_string(),
+                    crate::monitoring::LatencyMetrics {
+                        avg_latency_ms: 100.0,
+                        p95_latency_ms: 150.0,
+                        p99_latency_ms: 200.0,
+                        max_latency_ms: 300.0,
+                        min_latency_ms: 50.0,
+                        request_count: 20,
+                        requests_per_second: 5.0,
+                    },
+                );
+                m
+            },
+            cache_metrics: crate::monitoring::CacheMetrics {
+                hits: 10,
+                misses: 5,
+                hit_rate: 0.67,
+                size_bytes: 1024,
+                item_count: 15,
+                evictions: 0,
+            },
+            container_metrics: vec![],
+            system_resources: crate::monitoring::SystemResourceMetrics {
+                cpu_usage_percent: 30.0,
+                total_memory_bytes: 8_000_000_000,
+                used_memory_bytes: 2_000_000_000,
+                memory_usage_percent: 25.0,
+                available_disk_bytes: 100_000_000_000,
+                total_disk_bytes: 200_000_000_000,
+                disk_usage_percent: 50.0,
+                load_average: [0.5, 0.6, 0.7],
+            },
+            model_metrics: HashMap::new(),
+            error_metrics: crate::monitoring::ErrorMetrics {
+                total_errors: 0,
+                errors_by_type: HashMap::new(),
+                error_rate: 0.0,
+                recent_errors: vec![],
+            },
+        };
+        TelemetryExporter::export_system_metrics(&exporter, system_metrics)
+            .await
+            .unwrap();
+
+        let healthy = TelemetryExporter::health_check(&exporter).await.unwrap();
+        assert!(healthy);
+    }
+
+    #[tokio::test]
+    async fn test_prometheus_all_metric_types() {
+        let exporter = PrometheusExporter::new(None);
+
+        for (name, mt) in [
+            ("test_counter", MetricType::Counter),
+            ("test_gauge", MetricType::Gauge),
+            ("test_histogram", MetricType::Histogram),
+            ("test_summary", MetricType::Summary),
+        ] {
+            exporter.add_metric(MetricPoint {
+                name: name.to_string(),
+                metric_type: mt,
+                value: 1.0,
+                timestamp: Utc::now(),
+                labels: HashMap::new(),
+                unit: None,
+                description: None,
+            });
+        }
+
+        let output = exporter.export_prometheus().await.unwrap();
+        assert!(output.contains("# TYPE test_counter counter"));
+        assert!(output.contains("# TYPE test_gauge gauge"));
+        assert!(output.contains("# TYPE test_histogram histogram"));
+        assert!(output.contains("# TYPE test_summary summary"));
+    }
+
+    #[test]
+    fn test_trace_context_set_status() {
+        let mut trace = TraceContext::new("test");
+        trace.set_status(SpanStatus::Cancelled);
+        assert_eq!(trace.status, SpanStatus::Cancelled);
+
+        trace.set_status(SpanStatus::Timeout);
+        assert_eq!(trace.status, SpanStatus::Timeout);
+    }
+
+    #[tokio::test]
+    async fn test_trace_guard_lifecycle() {
+        let telemetry = TelemetrySystem::new();
+        assert_eq!(telemetry.get_active_trace_count(), 0);
+
+        let mut guard = TraceGuard::new(&telemetry, telemetry.start_trace("guarded-op"));
+        assert_eq!(telemetry.get_active_trace_count(), 1);
+        assert!(guard.trace().is_some());
+        assert_eq!(guard.trace().unwrap().operation_name, "guarded-op");
+
+        guard.record_error("test error");
+        assert_eq!(guard.trace().unwrap().status, SpanStatus::Error);
+
+        guard.set_status(SpanStatus::Cancelled);
+        assert_eq!(guard.trace().unwrap().status, SpanStatus::Cancelled);
+
+        drop(guard);
+        assert_eq!(telemetry.get_active_trace_count(), 0);
+    }
 }


### PR DESCRIPTION
## Summary

Adds tests for the largest uncovered code paths across the three observability modules in `harness/`. All additions are `#[cfg(test)]` code, so every new line in the diff is executed during test runs (100% patch coverage).

### `monitoring.rs` — 9 new tests
- `HealthStatus::is_healthy()` and `requires_attention()` for all five variants
- `AlertThresholds::default()` field assertions
- `record_error()` and `record_model_inference()` with full struct construction
- `reset_metrics()` — verifies state is cleared
- `MetricsFormat::Custom` error path
- `check_model_health()`, `comprehensive_health_check()`, `set_check_interval()`
- `get_alert_history()`, `acknowledge_alert()` for a nonexistent ID (error path), `configure_thresholds()`
- `MonitoringSystem::start_monitoring()` / `stop_monitoring()`

### `telemetry.rs` — 7 new tests
- `with_global_attribute()` and `get_uptime()`
- `with_config()` builder method
- `add_exporter()` + `export_all()` with buffered metrics and events
- `PrometheusExporter::clear_buffer()`
- All four `TelemetryExporter` trait methods: `export_traces`, `export_events`, `export_system_metrics`, `health_check`
- All four `MetricType` variants (`Counter`, `Gauge`, `Histogram`, `Summary`) appearing in Prometheus output
- `TraceContext::set_status()` with `Cancelled` and `Timeout` variants
- `TraceGuard` full lifecycle: `new`, `trace()`, `record_error`, `set_status`, and `Drop` (auto-finish)

### `observability.rs` — 8 new tests
- `with_health_thresholds()` builder method
- `ObservabilitySystem::start_monitoring()` / `stop_monitoring()`
- All `TrendDirection` variants exercised as values
- All `SlaStatus` variants
- All `AlertCategory` variants (7 total)
- All `EscalationStatus` variants (5 total) and all `ChannelType` variants (6 total)
- Performance degradation score path: latency > threshold, error rate > threshold, and cache hit rate < threshold simultaneously → score ≤ 40

## Coverage impact

All new lines are `#[cfg(test)]` test code executed during `cargo test`. No production code is changed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JMAHjxwh7GyTiDpgnFwGG9)_