### PR TITLE
test(entities): add unit tests for TestEntity — closes coverage gap

### DIFF
--- a/harness/src/entities/test/types.rs
+++ b/harness/src/entities/test/types.rs
@@ -44,3 +44,42 @@ impl Default for TestEntity {
         Self::new()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_creates_test_entity_with_correct_type() {
+        let entity = TestEntity::new();
+        assert_eq!(entity.metadata().entity_type, EntityType::Test);
+    }
+
+    #[test]
+    fn default_equals_new() {
+        let a = TestEntity::new();
+        let b = TestEntity::default();
+        assert_eq!(a.metadata().entity_type, b.metadata().entity_type);
+    }
+
+    #[test]
+    fn to_json_round_trips() {
+        let entity = TestEntity::new();
+        let json = entity.to_json().expect("serialize");
+        let decoded: TestEntity = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(decoded.metadata().entity_type, EntityType::Test);
+    }
+
+    #[tokio::test]
+    async fn metadata_mut_allows_tag_update() {
+        let mut entity = TestEntity::new();
+        entity.metadata_mut().tags.push("smoke".to_string());
+        assert_eq!(entity.metadata().tags, vec!["smoke"]);
+    }
+
+    #[test]
+    fn entity_type_helper_returns_test() {
+        let entity = TestEntity::new();
+        assert_eq!(entity.entity_type(), EntityType::Test);
+    }
+}


### PR DESCRIPTION
## Summary

`harness/src/entities/test/types.rs` contained `TestEntity` — a public struct with four methods (`new`, `default`, `metadata`, `metadata_mut`, `to_json`) — but had no `#[cfg(test)]` module at all. This was the largest uncovered module in the entity layer.

- Adds five inline unit tests covering every public method: `new()`, `default()`, `metadata()` (via `entity_type()`), `metadata_mut()`, and `to_json()` (serde round-trip).
- All new lines are exercised by the tests themselves, satisfying the 100% patch requirement.

## Test plan

- [ ] `cargo test -p harness --lib entities::test` — all 5 new tests green
- [ ] CI tarpaulin coverage run reports 100% patch coverage for `harness/src/entities/test/types.rs`
- [ ] All other CI jobs (unit, lint, security, integration) green

---
_Generated by [Claude Code](https://claude.ai/code/session_013C6LiwvRPP8touzM31THE9)_