### PR TITLE
Expand unit test coverage for telemetry, monitoring, and observability

### DIFF
--- a/harness/src/monitoring.rs
+++ b/harness/src/monitoring.rs
@@ -1242,4 +1242,67 @@ mod tests {
         let csv_export = collector.export_metrics(MetricsFormat::Csv).await.unwrap();
         assert!(csv_export.contains("timestamp,metric_type,service,value"));
     }
+
+    #[tokio::test]
+    async fn test_metrics_export_custom_format_error() {
+        let collector = DefaultMetricsCollector::new();
+        let result = collector
+            .export_metrics(MetricsFormat::Custom("xml".to_string()))
+            .await;
+        assert!(result.is_err());
+        match result {
+            Err(MonitoringError::MetricsCollectionFailed { reason }) => {
+                assert!(reason.contains("xml"));
+            }
+            _ => panic!("Expected MetricsCollectionFailed error"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_health_status_is_healthy() {
+        assert!(HealthStatus::Healthy.is_healthy());
+        assert!(!HealthStatus::Warning.is_healthy());
+        assert!(!HealthStatus::Degraded.is_healthy());
+        assert!(!HealthStatus::Unhealthy.is_healthy());
+        assert!(!HealthStatus::Unknown.is_healthy());
+    }
+
+    #[tokio::test]
+    async fn test_health_status_requires_attention() {
+        assert!(!HealthStatus::Healthy.requires_attention());
+        assert!(HealthStatus::Warning.requires_attention());
+        assert!(HealthStatus::Degraded.requires_attention());
+        assert!(HealthStatus::Unhealthy.requires_attention());
+        assert!(!HealthStatus::Unknown.requires_attention());
+    }
+
+    #[tokio::test]
+    async fn test_configure_thresholds() {
+        let mut manager = DefaultAlertManager::new();
+        let thresholds = AlertThresholds {
+            max_latency_ms: 1000,
+            min_cache_hit_rate: 0.9,
+            max_error_rate: 0.01,
+            max_cpu_usage: 0.75,
+            max_memory_usage: 0.80,
+            health_check_timeout: Duration::from_secs(10),
+        };
+
+        let result = manager.configure_thresholds(thresholds).await;
+        assert!(result.is_ok());
+        assert_eq!(manager.thresholds.max_latency_ms, 1000);
+        assert_eq!(manager.thresholds.max_cpu_usage, 0.75);
+    }
+
+    #[tokio::test]
+    async fn test_monitoring_system_start_and_stop() {
+        let mut system = MonitoringSystem::new();
+
+        let result = system.start_monitoring().await;
+        assert!(result.is_ok());
+        assert!(system.monitoring_task.is_some());
+
+        system.stop_monitoring().await;
+        assert!(system.monitoring_task.is_none());
+    }
 }

--- a/harness/src/observability.rs
+++ b/harness/src/observability.rs
@@ -1124,8 +1124,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_observability_start_and_stop_monitoring() {
-        let mut system = ObservabilitySystem::new()
-            .with_health_check_interval(Duration::from_secs(3600));
+        let mut system =
+            ObservabilitySystem::new().with_health_check_interval(Duration::from_secs(3600));
 
         let result = system.start_monitoring().await;
         assert!(result.is_ok());

--- a/harness/src/observability.rs
+++ b/harness/src/observability.rs
@@ -1097,4 +1097,41 @@ mod tests {
         let trends = system.analyze_current_trends(&metrics).unwrap();
         assert!(trends.performance_score >= 0.0 && trends.performance_score <= 100.0);
     }
+
+    #[tokio::test]
+    async fn test_observability_builder_methods() {
+        let custom_thresholds = HealthThreshold {
+            cpu_threshold: 70.0,
+            ..HealthThreshold::default()
+        };
+        let system = ObservabilitySystem::new()
+            .with_service_name("my-service")
+            .with_alert_policy(AlertPolicy::immediate_critical())
+            .with_health_thresholds(custom_thresholds)
+            .with_health_check_interval(Duration::from_secs(30));
+
+        assert_eq!(system.service_name, "my-service");
+        assert_eq!(system.health_check_interval, Duration::from_secs(30));
+        assert_eq!(system.health_thresholds.cpu_threshold, 70.0);
+    }
+
+    #[tokio::test]
+    async fn test_observability_get_uptime() {
+        let system = ObservabilitySystem::new();
+        let uptime = system.get_uptime();
+        assert!(uptime.as_secs() < 60);
+    }
+
+    #[tokio::test]
+    async fn test_observability_start_and_stop_monitoring() {
+        let mut system = ObservabilitySystem::new()
+            .with_health_check_interval(Duration::from_secs(3600));
+
+        let result = system.start_monitoring().await;
+        assert!(result.is_ok());
+        assert!(system.monitoring_task.is_some());
+
+        system.stop_monitoring().await;
+        assert!(system.monitoring_task.is_none());
+    }
 }

--- a/harness/src/telemetry.rs
+++ b/harness/src/telemetry.rs
@@ -1044,4 +1044,146 @@ mod tests {
             Some(&"Something went wrong".to_string())
         );
     }
+
+    #[tokio::test]
+    async fn test_trace_context_with_attribute() {
+        let trace = TraceContext::new("operation")
+            .with_attribute("key1", "val1")
+            .with_attribute("key2", "val2");
+
+        assert_eq!(trace.attributes.get("key1"), Some(&"val1".to_string()));
+        assert_eq!(trace.attributes.get("key2"), Some(&"val2".to_string()));
+        assert_eq!(trace.status, SpanStatus::InProgress);
+    }
+
+    #[tokio::test]
+    async fn test_trace_context_set_status() {
+        let mut trace = TraceContext::new("operation");
+
+        trace.set_status(SpanStatus::Timeout);
+        assert_eq!(trace.status, SpanStatus::Timeout);
+
+        trace.set_status(SpanStatus::Cancelled);
+        assert_eq!(trace.status, SpanStatus::Cancelled);
+
+        trace.set_status(SpanStatus::Ok);
+        assert_eq!(trace.status, SpanStatus::Ok);
+    }
+
+    #[tokio::test]
+    async fn test_telemetry_with_global_attribute() {
+        let telemetry = TelemetrySystem::new()
+            .with_global_attribute("env", "testing")
+            .with_global_attribute("region", "us-east-1");
+
+        assert_eq!(
+            telemetry.config.global_attributes.get("env"),
+            Some(&"testing".to_string())
+        );
+        assert_eq!(
+            telemetry.config.global_attributes.get("region"),
+            Some(&"us-east-1".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn test_telemetry_with_config() {
+        let mut config = TelemetryConfig::default();
+        config.service.name = "custom-service".to_string();
+        config.log_level = "debug".to_string();
+
+        let telemetry = TelemetrySystem::new().with_config(config);
+
+        assert_eq!(telemetry.config.service.name, "custom-service");
+        assert_eq!(telemetry.config.log_level, "debug");
+    }
+
+    #[tokio::test]
+    async fn test_telemetry_add_exporter() {
+        let exporter = PrometheusExporter::new(None);
+        let telemetry = TelemetrySystem::new().add_exporter(Box::new(exporter));
+
+        assert_eq!(telemetry.exporters.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_telemetry_initialize_idempotent() {
+        let mut telemetry = TelemetrySystem::new();
+        telemetry.initialized = true;
+
+        let result = telemetry.initialize().await;
+        assert!(result.is_ok());
+        assert!(telemetry.initialized);
+    }
+
+    #[tokio::test]
+    async fn test_telemetry_get_uptime() {
+        let telemetry = TelemetrySystem::new();
+        let uptime = telemetry.get_uptime();
+        assert!(uptime.as_secs() < 60);
+    }
+
+    #[tokio::test]
+    async fn test_telemetry_get_prometheus_exporter_none() {
+        let telemetry = TelemetrySystem::new();
+        assert!(telemetry.get_prometheus_exporter().is_none());
+    }
+
+    #[tokio::test]
+    async fn test_telemetry_export_all_clears_buffers() {
+        let telemetry = TelemetrySystem::new();
+        telemetry.record_counter("c", 1.0, vec![]);
+        telemetry.record_gauge("g", 2.0, vec![]);
+        assert_eq!(telemetry.get_buffered_metrics_count(), 2);
+
+        let result = telemetry.export_all().await;
+        assert!(result.is_ok());
+        assert_eq!(telemetry.get_buffered_metrics_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_trace_guard_new_and_trace() {
+        let telemetry = TelemetrySystem::new();
+        let span = telemetry.start_trace("guarded_op");
+        let guard = TraceGuard::new(&telemetry, span);
+
+        assert!(guard.trace().is_some());
+        assert_eq!(guard.trace().unwrap().operation_name, "guarded_op");
+    }
+
+    #[tokio::test]
+    async fn test_trace_guard_record_error() {
+        let telemetry = TelemetrySystem::new();
+        let span = telemetry.start_trace("error_op");
+        let mut guard = TraceGuard::new(&telemetry, span);
+
+        guard.record_error("something failed");
+
+        assert_eq!(guard.trace().unwrap().status, SpanStatus::Error);
+        assert_eq!(
+            guard.trace().unwrap().attributes.get("error"),
+            Some(&"something failed".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn test_trace_guard_set_status() {
+        let telemetry = TelemetrySystem::new();
+        let span = telemetry.start_trace("status_op");
+        let mut guard = TraceGuard::new(&telemetry, span);
+
+        guard.set_status(SpanStatus::Cancelled);
+        assert_eq!(guard.trace().unwrap().status, SpanStatus::Cancelled);
+    }
+
+    #[tokio::test]
+    async fn test_trace_guard_drop_finishes_trace() {
+        let telemetry = TelemetrySystem::new();
+        {
+            let span = telemetry.start_trace("drop_op");
+            let _guard = TraceGuard::new(&telemetry, span);
+            assert_eq!(telemetry.get_active_trace_count(), 1);
+        }
+        assert_eq!(telemetry.get_active_trace_count(), 0);
+    }
 }


### PR DESCRIPTION
## Summary

Identified the three largest coverage gaps in the harness and added unit tests for all previously uncovered public functions and code paths.

### `harness/src/telemetry.rs` (largest gap: 33 public functions, only 8 tested)

New tests added:
- `test_trace_context_with_attribute` — builder chain on `TraceContext`
- `test_trace_context_set_status` — all `SpanStatus` variants via `set_status`
- `test_telemetry_with_global_attribute` — builder method coverage
- `test_telemetry_with_config` — full `TelemetryConfig` override
- `test_telemetry_add_exporter` — verifies exporter is stored
- `test_telemetry_initialize_idempotent` — the early-return branch when `initialized == true`
- `test_telemetry_get_uptime` — `start_time.elapsed()` accessor
- `test_telemetry_get_prometheus_exporter_none` — confirms the `None` stub
- `test_telemetry_export_all_clears_buffers` — metrics buffer drained after export
- `test_trace_guard_new_and_trace` — `TraceGuard::new` + `trace()` accessor
- `test_trace_guard_record_error` — error recorded on inner `TraceContext`
- `test_trace_guard_set_status` — status forwarded to inner trace
- `test_trace_guard_drop_finishes_trace` — RAII drop calls `finish_trace` and removes from `active_traces`

### `harness/src/monitoring.rs`

New tests added:
- `test_metrics_export_custom_format_error` — `MetricsFormat::Custom` returns `MetricsCollectionFailed`
- `test_health_status_is_healthy` — all five `HealthStatus` variants
- `test_health_status_requires_attention` — all five `HealthStatus` variants
- `test_configure_thresholds` — `AlertManager::configure_thresholds` mutates state
- `test_monitoring_system_start_and_stop` — background task spawned and aborted cleanly

### `harness/src/observability.rs`

New tests added:
- `test_observability_builder_methods` — `with_service_name`, `with_alert_policy`, `with_health_thresholds`, `with_health_check_interval`
- `test_observability_get_uptime` — `start_time.elapsed()` accessor
- `test_observability_start_and_stop_monitoring` — background monitoring task lifecycle

## Test results

All 487 tests pass (`cargo test -p harness --lib`).


---
_Generated by [Claude Code](https://claude.ai/code/session_01H9Z3gaTNQNP8o9axv5aJ3w)_