### PR TITLE
test(monitoring): cover all uncovered code paths in monitoring.rs

### DIFF
--- a/harness/src/monitoring.rs
+++ b/harness/src/monitoring.rs
@@ -1242,4 +1242,144 @@ mod tests {
         let csv_export = collector.export_metrics(MetricsFormat::Csv).await.unwrap();
         assert!(csv_export.contains("timestamp,metric_type,service,value"));
     }
+
+    #[tokio::test]
+    async fn test_metrics_custom_format_error() {
+        let collector = DefaultMetricsCollector::new();
+        let result = collector
+            .export_metrics(MetricsFormat::Custom("myformat".to_string()))
+            .await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Custom format"));
+    }
+
+    #[tokio::test]
+    async fn test_metrics_reset() {
+        let mut collector = DefaultMetricsCollector::new();
+        collector
+            .record_request_latency("svc", Duration::from_millis(100))
+            .await;
+        collector.record_cache_hit("k").await;
+        collector.reset_metrics().await;
+        let metrics = collector.get_current_metrics().await.unwrap();
+        assert!(metrics.request_latencies.is_empty());
+        assert_eq!(metrics.cache_metrics.hits, 0);
+    }
+
+    #[tokio::test]
+    async fn test_record_error_event() {
+        let mut collector = DefaultMetricsCollector::new();
+        let evt = ErrorEvent {
+            timestamp: Utc::now(),
+            error_type: "timeout".to_string(),
+            message: "connection timed out".to_string(),
+            component: "ollama".to_string(),
+            severity: ErrorSeverity::Error,
+        };
+        collector.record_error(evt).await;
+        let metrics = collector.get_current_metrics().await.unwrap();
+        assert_eq!(metrics.error_metrics.total_errors, 1);
+        assert!(metrics.error_metrics.errors_by_type.contains_key("timeout"));
+    }
+
+    #[tokio::test]
+    async fn test_record_model_inference() {
+        let mut collector = DefaultMetricsCollector::new();
+        let model_metrics = ModelMetrics {
+            model_name: "qwen3:0.6b".to_string(),
+            inference_count: 10,
+            avg_inference_time_ms: 50.0,
+            tokens_per_second: 20.0,
+            success_rate: 1.0,
+            quality_scores: QualityMetrics {
+                avg_coherence: 0.9,
+                avg_relevance: 0.9,
+                consistency: 0.9,
+                accuracy_rate: 0.9,
+            },
+            resource_usage: ModelResourceUsage {
+                peak_memory_mb: 512.0,
+                avg_cpu_percent: 0.4,
+                gpu_utilization_percent: None,
+            },
+        };
+        collector
+            .record_model_inference("qwen3:0.6b", model_metrics)
+            .await;
+        let metrics = collector.get_current_metrics().await.unwrap();
+        assert!(metrics.model_metrics.contains_key("qwen3:0.6b"));
+    }
+
+    #[tokio::test]
+    async fn test_monitoring_start_stop() {
+        let mut system = MonitoringSystem::new();
+        system.start_monitoring().await.unwrap();
+        system.stop_monitoring().await;
+        system.stop_monitoring().await;
+    }
+
+    #[tokio::test]
+    async fn test_alert_configure_thresholds() {
+        let mut manager = DefaultAlertManager::new();
+        let thresholds = AlertThresholds {
+            max_latency_ms: 1000,
+            min_cache_hit_rate: 0.9,
+            max_error_rate: 0.01,
+            max_cpu_usage: 0.8,
+            max_memory_usage: 0.8,
+            health_check_timeout: Duration::from_secs(10),
+        };
+        manager.configure_thresholds(thresholds).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_alert_history_with_limit() {
+        let manager = DefaultAlertManager::new();
+        manager
+            .send_alert("First", "desc", AlertSeverity::Info)
+            .await
+            .unwrap();
+        manager
+            .send_alert("Second", "desc", AlertSeverity::Warning)
+            .await
+            .unwrap();
+        let history = manager.get_alert_history(1).await.unwrap();
+        assert_eq!(history.len(), 1);
+        assert_eq!(history[0].title, "Second");
+    }
+
+    #[tokio::test]
+    async fn test_acknowledge_alert_not_found() {
+        let manager = DefaultAlertManager::new();
+        let result = manager.acknowledge_alert("nonexistent").await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_comprehensive_health_check() {
+        let monitor = DefaultHealthMonitor::new(Duration::from_secs(30));
+        let results = monitor.comprehensive_health_check().await.unwrap();
+        assert!(!results.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_set_check_interval() {
+        let mut monitor = DefaultHealthMonitor::new(Duration::from_secs(30));
+        monitor.set_check_interval(Duration::from_secs(60));
+    }
+
+    #[test]
+    fn test_health_status_helpers() {
+        assert!(HealthStatus::Healthy.is_healthy());
+        assert!(!HealthStatus::Warning.is_healthy());
+        assert!(!HealthStatus::Degraded.is_healthy());
+        assert!(!HealthStatus::Unhealthy.is_healthy());
+        assert!(!HealthStatus::Unknown.is_healthy());
+
+        assert!(!HealthStatus::Healthy.requires_attention());
+        assert!(HealthStatus::Warning.requires_attention());
+        assert!(HealthStatus::Degraded.requires_attention());
+        assert!(HealthStatus::Unhealthy.requires_attention());
+        assert!(!HealthStatus::Unknown.requires_attention());
+    }
 }


### PR DESCRIPTION
## Summary

`harness/src/monitoring.rs` had a `#[cfg(test)]` block with 5 tests covering the happy path, but roughly a dozen code paths were not exercised. This PR adds 11 new unit tests to close those gaps:

| Test | Code path covered |
|---|---|
| `test_metrics_custom_format_error` | `MetricsFormat::Custom` error branch in `export_metrics` |
| `test_metrics_reset` | `reset_metrics()` — clears latencies and cache counters |
| `test_record_error_event` | `record_error()` and error aggregation in `get_current_metrics` |
| `test_record_model_inference` | `record_model_inference()` |
| `test_monitoring_start_stop` | `MonitoringSystem::start_monitoring` / `stop_monitoring` (including double-stop no-op) |
| `test_alert_configure_thresholds` | `DefaultAlertManager::configure_thresholds` |
| `test_alert_history_with_limit` | `get_alert_history` with a limit |
| `test_acknowledge_alert_not_found` | `acknowledge_alert` error path for a non-existent ID |
| `test_comprehensive_health_check` | `DefaultHealthMonitor::comprehensive_health_check` |
| `test_set_check_interval` | `DefaultHealthMonitor::set_check_interval` |
| `test_health_status_helpers` | `HealthStatus::is_healthy` and `requires_attention` for all variants |

All tests are synchronous `#[test]` or `#[tokio::test]` within the existing `#[cfg(test)] mod tests` block, consistent with the project's TESTING.md guidelines.

---
_Generated by [Claude Code](https://claude.ai/code/session_015UvhZJ2eTxLupx5kr4dp71)_