### PR TITLE
Add tests for monitoring and observability to improve coverage

### DIFF
--- a/harness/src/monitoring.rs
+++ b/harness/src/monitoring.rs
@@ -1242,4 +1242,132 @@ mod tests {
         let csv_export = collector.export_metrics(MetricsFormat::Csv).await.unwrap();
         assert!(csv_export.contains("timestamp,metric_type,service,value"));
     }
+
+    #[tokio::test]
+    async fn test_health_status_methods() {
+        assert!(HealthStatus::Healthy.is_healthy());
+        assert!(!HealthStatus::Warning.is_healthy());
+        assert!(!HealthStatus::Degraded.is_healthy());
+        assert!(!HealthStatus::Unhealthy.is_healthy());
+        assert!(!HealthStatus::Unknown.is_healthy());
+
+        assert!(!HealthStatus::Healthy.requires_attention());
+        assert!(HealthStatus::Warning.requires_attention());
+        assert!(HealthStatus::Degraded.requires_attention());
+        assert!(HealthStatus::Unhealthy.requires_attention());
+        assert!(!HealthStatus::Unknown.requires_attention());
+    }
+
+    #[tokio::test]
+    async fn test_alert_severity_ordering() {
+        assert!(AlertSeverity::Info < AlertSeverity::Warning);
+        assert!(AlertSeverity::Warning < AlertSeverity::Error);
+        assert!(AlertSeverity::Error < AlertSeverity::Critical);
+    }
+
+    #[tokio::test]
+    async fn test_alert_severity_all_levels() {
+        let manager = DefaultAlertManager::new();
+
+        let id_info = manager
+            .send_alert("Info", "Info message", AlertSeverity::Info)
+            .await
+            .unwrap();
+        let id_error = manager
+            .send_alert("Error", "Error message", AlertSeverity::Error)
+            .await
+            .unwrap();
+        let id_critical = manager
+            .send_alert("Critical", "Critical message", AlertSeverity::Critical)
+            .await
+            .unwrap();
+
+        let alerts = manager.get_active_alerts().await.unwrap();
+        assert_eq!(alerts.len(), 3);
+
+        manager.acknowledge_alert(&id_info).await.unwrap();
+        manager.acknowledge_alert(&id_error).await.unwrap();
+        manager.acknowledge_alert(&id_critical).await.unwrap();
+
+        let alerts = manager.get_active_alerts().await.unwrap();
+        assert!(alerts.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_metrics_collector_error_and_model() {
+        let mut collector = DefaultMetricsCollector::new();
+
+        let error = ErrorEvent {
+            timestamp: Utc::now(),
+            error_type: "NetworkError".to_string(),
+            message: "Connection refused".to_string(),
+            component: "ollama-client".to_string(),
+            severity: ErrorSeverity::High,
+        };
+        collector.record_error(error).await;
+
+        let model_metrics = ModelMetrics {
+            model_name: "qwen3:0.6b".to_string(),
+            inference_count: 10,
+            avg_inference_time_ms: 250.0,
+            tokens_per_second: 40.0,
+            success_rate: 0.95,
+            quality_scores: QualityMetrics {
+                avg_coherence: 0.85,
+                avg_relevance: 0.9,
+                consistency: 0.88,
+                accuracy_rate: 0.92,
+            },
+            resource_usage: ModelResourceUsage {
+                peak_memory_mb: 512.0,
+                avg_cpu_percent: 45.0,
+                gpu_utilization_percent: None,
+            },
+        };
+        collector
+            .record_model_inference("qwen3:0.6b", model_metrics)
+            .await;
+
+        let metrics = collector.get_current_metrics().await.unwrap();
+        assert_eq!(metrics.error_metrics.total_errors, 1);
+        assert!(metrics.model_metrics.contains_key("qwen3:0.6b"));
+
+        collector.reset_metrics().await;
+        let metrics_after_reset = collector.get_current_metrics().await.unwrap();
+        assert_eq!(metrics_after_reset.error_metrics.total_errors, 0);
+        assert!(metrics_after_reset.model_metrics.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_metrics_custom_format_error() {
+        let collector = DefaultMetricsCollector::new();
+        let result = collector
+            .export_metrics(MetricsFormat::Custom("xml".to_string()))
+            .await;
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Custom format 'xml' not implemented"));
+    }
+
+    #[tokio::test]
+    async fn test_monitoring_system_start_stop() {
+        let mut system = MonitoringSystem::new();
+        let result = system.start_monitoring().await;
+        assert!(result.is_ok());
+        system.stop_monitoring().await;
+    }
+
+    #[tokio::test]
+    async fn test_health_monitor_model_and_comprehensive() {
+        let monitor = DefaultHealthMonitor::new(Duration::from_secs(30));
+
+        let model_health = monitor.check_model_health("qwen3:0.6b").await.unwrap();
+        assert_eq!(model_health.status, HealthStatus::Healthy);
+        assert!(model_health.component.contains("model:"));
+
+        let results = monitor.comprehensive_health_check().await.unwrap();
+        assert!(!results.is_empty());
+    }
 }

--- a/harness/src/observability.rs
+++ b/harness/src/observability.rs
@@ -1097,4 +1097,132 @@ mod tests {
         let trends = system.analyze_current_trends(&metrics).unwrap();
         assert!(trends.performance_score >= 0.0 && trends.performance_score <= 100.0);
     }
+
+    #[tokio::test]
+    async fn test_trend_direction_variants() {
+        let directions = [
+            TrendDirection::Improving,
+            TrendDirection::Stable,
+            TrendDirection::Degrading,
+            TrendDirection::Unknown,
+        ];
+        for dir in &directions {
+            let _ = format!("{:?}", dir);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_sla_status_variants() {
+        let statuses = [SlaStatus::Compliant, SlaStatus::AtRisk, SlaStatus::Breached];
+        for s in &statuses {
+            let _ = format!("{:?}", s);
+        }
+        assert_ne!(SlaStatus::Compliant, SlaStatus::AtRisk);
+        assert_ne!(SlaStatus::AtRisk, SlaStatus::Breached);
+    }
+
+    #[tokio::test]
+    async fn test_escalation_status_variants() {
+        let statuses = [
+            EscalationStatus::New,
+            EscalationStatus::Escalated,
+            EscalationStatus::HighlyEscalated,
+            EscalationStatus::UnderInvestigation,
+            EscalationStatus::Resolved,
+        ];
+        for s in &statuses {
+            let _ = format!("{:?}", s);
+        }
+        assert_ne!(EscalationStatus::New, EscalationStatus::Resolved);
+    }
+
+    #[tokio::test]
+    async fn test_alert_category_variants() {
+        let categories = [
+            AlertCategory::Performance,
+            AlertCategory::Availability,
+            AlertCategory::Security,
+            AlertCategory::Resources,
+            AlertCategory::Configuration,
+            AlertCategory::ModelQuality,
+            AlertCategory::ContainerHealth,
+        ];
+        for cat in &categories {
+            let _ = format!("{:?}", cat);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_channel_type_variants() {
+        let channels = [
+            ChannelType::Email,
+            ChannelType::Slack,
+            ChannelType::Discord,
+            ChannelType::Webhook,
+            ChannelType::LogFile,
+            ChannelType::Console,
+        ];
+        for ch in &channels {
+            let _ = format!("{:?}", ch);
+        }
+        assert_ne!(ChannelType::Email, ChannelType::Slack);
+    }
+
+    #[tokio::test]
+    async fn test_observability_system_builder_methods() {
+        let policy = AlertPolicy::immediate_critical();
+        let thresholds = HealthThreshold::default();
+        let system = ObservabilitySystem::new()
+            .with_service_name("test-svc")
+            .with_alert_policy(policy)
+            .with_health_thresholds(thresholds)
+            .with_health_check_interval(Duration::from_secs(60));
+        let _ = format!("{:?}", system.get_uptime());
+    }
+
+    #[tokio::test]
+    async fn test_observability_system_start_stop() {
+        let mut system = ObservabilitySystem::new();
+        let result = system.start_monitoring().await;
+        assert!(result.is_ok());
+        system.stop_monitoring().await;
+    }
+
+    #[tokio::test]
+    async fn test_performance_trends_degrading() {
+        let system = ObservabilitySystem::new();
+        let metrics = SystemMetrics {
+            timestamp: Utc::now(),
+            request_latencies: HashMap::new(),
+            cache_metrics: crate::monitoring::CacheMetrics {
+                hits: 10,
+                misses: 90,
+                hit_rate: 0.1,
+                size_bytes: 512,
+                item_count: 10,
+                evictions: 50,
+            },
+            container_metrics: Vec::new(),
+            system_resources: crate::monitoring::SystemResourceMetrics {
+                cpu_usage_percent: 95.0,
+                total_memory_bytes: 8589934592,
+                used_memory_bytes: 8000000000,
+                memory_usage_percent: 93.0,
+                available_disk_bytes: 1073741824,
+                total_disk_bytes: 214748364800,
+                disk_usage_percent: 99.0,
+                load_average: [10.0, 12.0, 11.0],
+            },
+            model_metrics: HashMap::new(),
+            error_metrics: crate::monitoring::ErrorMetrics {
+                total_errors: 100,
+                errors_by_type: HashMap::new(),
+                error_rate: 0.5,
+                recent_errors: Vec::new(),
+            },
+        };
+
+        let trends = system.analyze_current_trends(&metrics).unwrap();
+        assert!(trends.performance_score >= 0.0 && trends.performance_score <= 100.0);
+    }
 }


### PR DESCRIPTION
## Summary

- Add 7 new `#[tokio::test]` functions to `harness/src/monitoring.rs` covering `HealthStatus` methods, `AlertSeverity` ordering, all severity levels, error/model metrics recording and reset, custom metrics format error path, `MonitoringSystem` start/stop, and `DefaultHealthMonitor` model and comprehensive health checks
- Add 8 new `#[tokio::test]` functions to `harness/src/observability.rs` covering all `TrendDirection`, `SlaStatus`, `EscalationStatus`, `AlertCategory`, and `ChannelType` variants, `ObservabilitySystem` builder methods and lifecycle, and degraded-performance trend analysis

## Motivation

`monitoring.rs` (1245 lines) and `observability.rs` (1100 lines) were the largest coverage gaps in the codebase — each had only ~10 tests. The new tests target the untested code paths to bring patch coverage to 100%.

## Test plan

- [ ] `cargo nextest run --workspace --lib --all-features` passes
- [ ] `cargo tarpaulin` shows 100% patch coverage on changed files
- [ ] CI green

---
_Generated by [Claude Code](https://claude.ai/code/session_014zWig8AuCWXH87imqaT6v5)_