### PR TITLE
test(harness): expand unit test coverage for monitoring, telemetry, and test entities

### DIFF
--- a/harness/src/entities/test/types.rs
+++ b/harness/src/entities/test/types.rs
@@ -44,3 +44,45 @@ impl Default for TestEntity {
         Self::new()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::entities::EntityType;
+
+    #[test]
+    fn test_new_creates_test_entity() {
+        let entity = TestEntity::new();
+        assert_eq!(entity.metadata.entity_type, EntityType::Test);
+        assert_eq!(entity.metadata.version, 1);
+        assert!(entity.metadata.tags.is_empty());
+    }
+
+    #[test]
+    fn test_default_matches_new() {
+        let entity = TestEntity::default();
+        assert_eq!(entity.metadata.entity_type, EntityType::Test);
+    }
+
+    #[test]
+    fn test_to_json_serializes_entity_type() {
+        let entity = TestEntity::new();
+        let json = entity.to_json().unwrap();
+        assert!(json.contains("\"entity_type\""));
+        assert!(json.contains("Test"));
+    }
+
+    #[test]
+    fn test_metadata_returns_reference() {
+        let entity = TestEntity::new();
+        let metadata = entity.metadata();
+        assert_eq!(metadata.entity_type, EntityType::Test);
+    }
+
+    #[test]
+    fn test_metadata_mut_allows_modification() {
+        let mut entity = TestEntity::new();
+        entity.metadata_mut().tags.push("ci".to_string());
+        assert_eq!(entity.metadata.tags, vec!["ci".to_string()]);
+    }
+}

--- a/harness/src/monitoring.rs
+++ b/harness/src/monitoring.rs
@@ -1242,4 +1242,167 @@ mod tests {
         let csv_export = collector.export_metrics(MetricsFormat::Csv).await.unwrap();
         assert!(csv_export.contains("timestamp,metric_type,service,value"));
     }
+
+    #[tokio::test]
+    async fn test_record_error() {
+        let mut collector = DefaultMetricsCollector::new();
+        let error = ErrorEvent {
+            timestamp: Utc::now(),
+            error_type: "network_error".to_string(),
+            message: "Connection refused".to_string(),
+            component: "container".to_string(),
+            severity: ErrorSeverity::Error,
+        };
+        collector.record_error(error).await;
+
+        let metrics = collector.get_current_metrics().await.unwrap();
+        assert_eq!(metrics.error_metrics.total_errors, 1);
+        assert!(metrics.error_metrics.errors_by_type.contains_key("network_error"));
+    }
+
+    #[tokio::test]
+    async fn test_record_model_inference() {
+        let mut collector = DefaultMetricsCollector::new();
+        let model_metrics = ModelMetrics {
+            model_name: "qwen3:0.6b".to_string(),
+            inference_count: 5,
+            avg_inference_time_ms: 120.0,
+            tokens_per_second: 40.0,
+            success_rate: 0.98,
+            quality_scores: QualityMetrics {
+                avg_coherence: 0.88,
+                avg_relevance: 0.92,
+                consistency: 0.85,
+                accuracy_rate: 0.9,
+            },
+            resource_usage: ModelResourceUsage {
+                peak_memory_mb: 256.0,
+                avg_cpu_percent: 30.0,
+                gpu_utilization_percent: None,
+            },
+        };
+        collector.record_model_inference("qwen3:0.6b", model_metrics).await;
+
+        let metrics = collector.get_current_metrics().await.unwrap();
+        assert!(metrics.model_metrics.contains_key("qwen3:0.6b"));
+        assert_eq!(metrics.model_metrics["qwen3:0.6b"].inference_count, 5);
+    }
+
+    #[tokio::test]
+    async fn test_reset_metrics() {
+        let mut collector = DefaultMetricsCollector::new();
+        collector.record_cache_hit("key1").await;
+        collector.record_cache_hit("key2").await;
+        collector.record_cache_miss("miss").await;
+
+        let before = collector.get_current_metrics().await.unwrap();
+        assert_eq!(before.cache_metrics.hits, 2);
+        assert_eq!(before.cache_metrics.misses, 1);
+
+        collector.reset_metrics().await;
+
+        let after = collector.get_current_metrics().await.unwrap();
+        assert_eq!(after.cache_metrics.hits, 0);
+        assert_eq!(after.cache_metrics.misses, 0);
+    }
+
+    #[tokio::test]
+    async fn test_custom_format_error() {
+        let collector = DefaultMetricsCollector::new();
+        let result = collector
+            .export_metrics(MetricsFormat::Custom("xml".to_string()))
+            .await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_get_alert_history() {
+        let manager = DefaultAlertManager::new();
+        manager
+            .send_alert("Alert 1", "First", AlertSeverity::Info)
+            .await
+            .unwrap();
+        manager
+            .send_alert("Alert 2", "Second", AlertSeverity::Warning)
+            .await
+            .unwrap();
+        manager
+            .send_alert("Alert 3", "Third", AlertSeverity::Error)
+            .await
+            .unwrap();
+
+        let history = manager.get_alert_history(2).await.unwrap();
+        assert_eq!(history.len(), 2);
+
+        let all_history = manager.get_alert_history(10).await.unwrap();
+        assert_eq!(all_history.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn test_configure_thresholds() {
+        let mut manager = DefaultAlertManager::new();
+        let thresholds = AlertThresholds {
+            max_latency_ms: 2000,
+            min_cache_hit_rate: 0.7,
+            max_error_rate: 0.1,
+            max_cpu_usage: 0.8,
+            max_memory_usage: 0.85,
+            health_check_timeout: Duration::from_secs(15),
+        };
+        manager.configure_thresholds(thresholds).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_check_model_health() {
+        let monitor = DefaultHealthMonitor::new(Duration::from_secs(30));
+        let result = monitor.check_model_health("qwen3:0.6b").await.unwrap();
+        assert_eq!(result.status, HealthStatus::Healthy);
+        assert!(result.component.starts_with("model:"));
+    }
+
+    #[tokio::test]
+    async fn test_monitoring_start_stop() {
+        let mut system = MonitoringSystem::new();
+        system.start_monitoring().await.unwrap();
+        system.stop_monitoring().await;
+    }
+
+    #[test]
+    fn test_alert_thresholds_default() {
+        let thresholds = AlertThresholds::default();
+        assert_eq!(thresholds.max_latency_ms, 5000);
+        assert_eq!(thresholds.min_cache_hit_rate, 0.8);
+        assert_eq!(thresholds.max_error_rate, 0.05);
+        assert_eq!(thresholds.max_cpu_usage, 0.9);
+        assert_eq!(thresholds.max_memory_usage, 0.9);
+    }
+
+    #[test]
+    fn test_error_severity_ordering() {
+        assert!(ErrorSeverity::Critical > ErrorSeverity::Error);
+        assert!(ErrorSeverity::Error > ErrorSeverity::Warning);
+        assert!(ErrorSeverity::Warning > ErrorSeverity::Info);
+    }
+
+    #[test]
+    fn test_alert_severity_ordering() {
+        assert!(AlertSeverity::Critical > AlertSeverity::Error);
+        assert!(AlertSeverity::Error > AlertSeverity::Warning);
+        assert!(AlertSeverity::Warning > AlertSeverity::Info);
+    }
+
+    #[test]
+    fn test_health_status_methods() {
+        assert!(HealthStatus::Healthy.is_healthy());
+        assert!(!HealthStatus::Warning.is_healthy());
+        assert!(!HealthStatus::Degraded.is_healthy());
+        assert!(!HealthStatus::Unhealthy.is_healthy());
+        assert!(!HealthStatus::Unknown.is_healthy());
+
+        assert!(!HealthStatus::Healthy.requires_attention());
+        assert!(HealthStatus::Warning.requires_attention());
+        assert!(HealthStatus::Degraded.requires_attention());
+        assert!(HealthStatus::Unhealthy.requires_attention());
+        assert!(!HealthStatus::Unknown.requires_attention());
+    }
 }

--- a/harness/src/monitoring.rs
+++ b/harness/src/monitoring.rs
@@ -1257,7 +1257,10 @@ mod tests {
 
         let metrics = collector.get_current_metrics().await.unwrap();
         assert_eq!(metrics.error_metrics.total_errors, 1);
-        assert!(metrics.error_metrics.errors_by_type.contains_key("network_error"));
+        assert!(metrics
+            .error_metrics
+            .errors_by_type
+            .contains_key("network_error"));
     }
 
     #[tokio::test]
@@ -1281,7 +1284,9 @@ mod tests {
                 gpu_utilization_percent: None,
             },
         };
-        collector.record_model_inference("qwen3:0.6b", model_metrics).await;
+        collector
+            .record_model_inference("qwen3:0.6b", model_metrics)
+            .await;
 
         let metrics = collector.get_current_metrics().await.unwrap();
         assert!(metrics.model_metrics.contains_key("qwen3:0.6b"));

--- a/harness/src/telemetry.rs
+++ b/harness/src/telemetry.rs
@@ -1185,8 +1185,8 @@ mod tests {
 
     #[test]
     fn test_add_exporter() {
-        let telemetry = TelemetrySystem::new()
-            .add_exporter(Box::new(PrometheusExporter::new(None)));
+        let telemetry =
+            TelemetrySystem::new().add_exporter(Box::new(PrometheusExporter::new(None)));
         assert_eq!(telemetry.exporters.len(), 1);
     }
 

--- a/harness/src/telemetry.rs
+++ b/harness/src/telemetry.rs
@@ -1044,4 +1044,223 @@ mod tests {
             Some(&"Something went wrong".to_string())
         );
     }
+
+    #[test]
+    fn test_telemetry_config_default() {
+        let config = TelemetryConfig::default();
+        assert_eq!(config.service.name, "nanna-coder");
+        assert_eq!(config.service.version, "0.1.0");
+        assert_eq!(config.service.environment, "development");
+        assert!(config.enable_logging);
+        assert!(config.enable_tracing);
+        assert!(config.enable_metrics);
+        assert_eq!(config.log_level, "info");
+        assert_eq!(config.trace_sample_rate, 1.0);
+    }
+
+    #[test]
+    fn test_trace_with_attribute() {
+        let trace = TraceContext::new("test_op")
+            .with_attribute("key1", "value1")
+            .with_attribute("key2", "value2");
+        assert_eq!(trace.attributes.get("key1"), Some(&"value1".to_string()));
+        assert_eq!(trace.attributes.get("key2"), Some(&"value2".to_string()));
+    }
+
+    #[test]
+    fn test_trace_set_status() {
+        let mut trace = TraceContext::new("test_op");
+        trace.set_status(SpanStatus::Cancelled);
+        assert_eq!(trace.status, SpanStatus::Cancelled);
+        trace.set_status(SpanStatus::Timeout);
+        assert_eq!(trace.status, SpanStatus::Timeout);
+    }
+
+    #[tokio::test]
+    async fn test_prometheus_exporter_clear_and_health_check() {
+        let exporter = PrometheusExporter::new(None);
+        let metric = MetricPoint {
+            name: "test_gauge".to_string(),
+            metric_type: MetricType::Gauge,
+            value: 1.0,
+            timestamp: Utc::now(),
+            labels: HashMap::new(),
+            unit: None,
+            description: None,
+        };
+        exporter.add_metric(metric);
+
+        let output = exporter.export_prometheus().await.unwrap();
+        assert!(!output.is_empty());
+
+        exporter.clear_buffer();
+        let output_after = exporter.export_prometheus().await.unwrap();
+        assert!(output_after.is_empty());
+
+        let healthy = exporter.health_check().await.unwrap();
+        assert!(healthy);
+    }
+
+    #[tokio::test]
+    async fn test_prometheus_export_finished_traces() {
+        let exporter = PrometheusExporter::new(None);
+        let mut trace = TraceContext::new("traced_op");
+        trace.finish();
+        exporter.export_traces(vec![trace]).await.unwrap();
+
+        let output = exporter.export_prometheus().await.unwrap();
+        assert!(output.contains("trace_duration_seconds"));
+    }
+
+    #[tokio::test]
+    async fn test_prometheus_export_unfinished_trace_skipped() {
+        let exporter = PrometheusExporter::new(None);
+        let trace = TraceContext::new("unfinished_op");
+        exporter.export_traces(vec![trace]).await.unwrap();
+
+        let output = exporter.export_prometheus().await.unwrap();
+        assert!(output.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_prometheus_export_events() {
+        let exporter = PrometheusExporter::new(None);
+        let event = CustomEvent {
+            name: "user_action".to_string(),
+            timestamp: Utc::now(),
+            category: "ux".to_string(),
+            attributes: HashMap::new(),
+            data: serde_json::json!({}),
+            trace_context: None,
+        };
+        exporter.export_events(vec![event]).await.unwrap();
+
+        let output = exporter.export_prometheus().await.unwrap();
+        assert!(output.contains("custom_events_total"));
+        assert!(output.contains("event_name=\"user_action\""));
+    }
+
+    #[tokio::test]
+    async fn test_prometheus_trait_export_metrics() {
+        let exporter = PrometheusExporter::new(None);
+        let metric = MetricPoint {
+            name: "api_calls".to_string(),
+            metric_type: MetricType::Counter,
+            value: 10.0,
+            timestamp: Utc::now(),
+            labels: HashMap::new(),
+            unit: Some("calls".to_string()),
+            description: Some("API call count".to_string()),
+        };
+        exporter.export_metrics(vec![metric]).await.unwrap();
+
+        let output = exporter.export_prometheus().await.unwrap();
+        assert!(output.contains("api_calls"));
+    }
+
+    #[test]
+    fn test_telemetry_builder_with_global_attribute() {
+        let telemetry = TelemetrySystem::new()
+            .with_service_name("my-service")
+            .with_version("2.0.0")
+            .with_environment("staging")
+            .with_global_attribute("region", "eu-west-1");
+
+        assert_eq!(telemetry.config.service.name, "my-service");
+        assert_eq!(telemetry.config.service.version, "2.0.0");
+        assert_eq!(telemetry.config.service.environment, "staging");
+        assert_eq!(
+            telemetry.config.global_attributes.get("region"),
+            Some(&"eu-west-1".to_string())
+        );
+    }
+
+    #[test]
+    fn test_telemetry_uptime_and_prometheus_exporter_none() {
+        let telemetry = TelemetrySystem::new();
+        let uptime = telemetry.get_uptime();
+        assert!(uptime.as_secs() < 10);
+        assert!(telemetry.get_prometheus_exporter().is_none());
+    }
+
+    #[test]
+    fn test_add_exporter() {
+        let telemetry = TelemetrySystem::new()
+            .add_exporter(Box::new(PrometheusExporter::new(None)));
+        assert_eq!(telemetry.exporters.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_export_all_clears_buffers() {
+        let telemetry = TelemetrySystem::new();
+        telemetry.record_counter("test_metric", 1.0, vec![]);
+        telemetry.record_event("test_event", "category", serde_json::json!({}));
+        assert_eq!(telemetry.get_buffered_metrics_count(), 1);
+
+        telemetry.export_all().await.unwrap();
+
+        assert_eq!(telemetry.get_buffered_metrics_count(), 0);
+        let events = telemetry.events_buffer.lock().unwrap();
+        assert_eq!(events.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_trace_guard_drop_finishes_trace() {
+        let telemetry = TelemetrySystem::new();
+        assert_eq!(telemetry.get_active_trace_count(), 0);
+
+        {
+            let trace = telemetry.start_trace("guarded_op");
+            let _guard = TraceGuard::new(&telemetry, trace);
+            assert_eq!(telemetry.get_active_trace_count(), 1);
+        }
+
+        assert_eq!(telemetry.get_active_trace_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_trace_guard_methods() {
+        let telemetry = TelemetrySystem::new();
+        let trace = telemetry.start_trace("error_op");
+        let mut guard = TraceGuard::new(&telemetry, trace);
+
+        assert!(guard.trace().is_some());
+
+        guard.record_error("something failed");
+        assert_eq!(guard.trace().unwrap().status, SpanStatus::Error);
+
+        guard.set_status(SpanStatus::Timeout);
+        assert_eq!(guard.trace().unwrap().status, SpanStatus::Timeout);
+    }
+
+    #[tokio::test]
+    async fn test_with_config() {
+        let custom_config = TelemetryConfig {
+            service: crate::telemetry::ServiceInfo {
+                name: "custom-svc".to_string(),
+                version: "3.0.0".to_string(),
+                environment: "prod".to_string(),
+                instance_id: "i-001".to_string(),
+                metadata: HashMap::new(),
+            },
+            enable_logging: false,
+            enable_tracing: true,
+            enable_metrics: true,
+            log_level: "warn".to_string(),
+            metrics_export_interval: Duration::from_secs(30),
+            trace_sample_rate: 0.5,
+            export_endpoints: crate::telemetry::ExportEndpoints {
+                prometheus_endpoint: None,
+                otlp_endpoint: None,
+                webhook_endpoints: vec![],
+                log_endpoint: None,
+            },
+            global_attributes: HashMap::new(),
+        };
+
+        let telemetry = TelemetrySystem::new().with_config(custom_config);
+        assert_eq!(telemetry.config.service.name, "custom-svc");
+        assert!(!telemetry.config.enable_logging);
+        assert_eq!(telemetry.config.trace_sample_rate, 0.5);
+    }
 }


### PR DESCRIPTION
## Summary

Expands unit test coverage in the `harness` crate across three previously under-tested modules, targeting the largest coverage gaps identified via Codecov.

### Changes

- **`harness/src/monitoring.rs`** — Added 13 tests covering `DefaultMetricsCollector` methods: `record_error`, `record_model_inference`, `reset_metrics`, alert history, threshold configuration, model health checks, monitoring start/stop lifecycle, and value-type helper methods (`AlertThresholds::default`, `ErrorSeverity`/`AlertSeverity` ordering, `HealthStatus` helpers).

- **`harness/src/telemetry.rs`** — Added 15 tests covering `TelemetrySystem` builder methods (`with_global_attribute`, `with_config`, `add_exporter`), `PrometheusExporter` operations (clear, health check, export finished/unfinished traces, events, trait impl), and `TraceGuard` lifecycle (drop finishes trace, method accessors). Tests requiring `tokio::spawn` in `Drop` use `#[tokio::test]` to provide a live reactor.

- **`harness/src/entities/test/types.rs`** — Added 5 tests covering all public methods of `TestEntity` (`new`, `default`, `to_json`, `metadata`, `metadata_mut`), which had zero coverage.

### Coverage impact

All 688 harness lib tests pass locally (`cargo test -p harness --lib --all-features`). The additions cover code paths that were previously untouched, improving patch coverage toward the codecov `target: 100%` requirement.

---
_Generated by [Claude Code](https://claude.ai/code/session_019u6kwS4zDyb1dasWee4hXM)_