### PR TITLE
test(harness): extend telemetry and observability test coverage

### DIFF
--- a/harness/src/observability.rs
+++ b/harness/src/observability.rs
@@ -1097,4 +1097,60 @@ mod tests {
         let trends = system.analyze_current_trends(&metrics).unwrap();
         assert!(trends.performance_score >= 0.0 && trends.performance_score <= 100.0);
     }
+
+    #[tokio::test]
+    async fn test_observability_default() {
+        let system = ObservabilitySystem::default();
+        assert_eq!(system.service_name, "nanna-coder");
+    }
+
+    #[tokio::test]
+    async fn test_with_service_name() {
+        let system = ObservabilitySystem::new().with_service_name("my-service");
+        assert_eq!(system.service_name, "my-service");
+    }
+
+    #[tokio::test]
+    async fn test_with_alert_policy() {
+        let policy = AlertPolicy::immediate_critical();
+        let system = ObservabilitySystem::new().with_alert_policy(policy);
+        assert!(!system.alert_policy.escalation_rules.is_empty());
+        assert!(!system.alert_policy.notification_channels.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_with_health_thresholds() {
+        let thresholds = HealthThreshold {
+            cpu_threshold: 90.0,
+            memory_threshold: 95.0,
+            disk_threshold: 98.0,
+            max_latency_ms: 5000,
+            min_cache_hit_rate: 0.5,
+            max_error_rate: 0.1,
+            container_timeout: Duration::from_secs(60),
+        };
+        let system = ObservabilitySystem::new().with_health_thresholds(thresholds);
+        assert_eq!(system.health_thresholds.cpu_threshold, 90.0);
+        assert_eq!(system.health_thresholds.max_latency_ms, 5000);
+    }
+
+    #[tokio::test]
+    async fn test_with_health_check_interval() {
+        let system =
+            ObservabilitySystem::new().with_health_check_interval(Duration::from_secs(120));
+        assert_eq!(system.health_check_interval, Duration::from_secs(120));
+    }
+
+    #[tokio::test]
+    async fn test_get_uptime() {
+        let system = ObservabilitySystem::new();
+        let uptime = system.get_uptime();
+        assert!(uptime < Duration::from_secs(1));
+    }
+
+    #[tokio::test]
+    async fn test_stop_monitoring_no_task() {
+        let mut system = ObservabilitySystem::new();
+        system.stop_monitoring().await;
+    }
 }

--- a/harness/src/telemetry.rs
+++ b/harness/src/telemetry.rs
@@ -1044,4 +1044,162 @@ mod tests {
             Some(&"Something went wrong".to_string())
         );
     }
+
+    #[tokio::test]
+    async fn test_telemetry_default() {
+        let telemetry = TelemetrySystem::default();
+        assert!(!telemetry.initialized);
+        assert_eq!(telemetry.get_buffered_metrics_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_with_global_attribute() {
+        let telemetry = TelemetrySystem::new()
+            .with_global_attribute("region", "us-east-1")
+            .with_global_attribute("tier", "production");
+
+        assert_eq!(
+            telemetry.config.global_attributes.get("region"),
+            Some(&"us-east-1".to_string())
+        );
+        assert_eq!(
+            telemetry.config.global_attributes.get("tier"),
+            Some(&"production".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn test_with_config() {
+        let config = TelemetryConfig {
+            service: ServiceInfo {
+                name: "custom-service".to_string(),
+                version: "2.0.0".to_string(),
+                environment: "staging".to_string(),
+                instance_id: "test-instance".to_string(),
+                metadata: HashMap::new(),
+            },
+            enable_logging: false,
+            enable_tracing: true,
+            enable_metrics: true,
+            log_level: "debug".to_string(),
+            metrics_export_interval: Duration::from_secs(30),
+            trace_sample_rate: 0.5,
+            export_endpoints: ExportEndpoints {
+                prometheus_endpoint: None,
+                otlp_endpoint: None,
+                webhook_endpoints: Vec::new(),
+                log_endpoint: None,
+            },
+            global_attributes: HashMap::new(),
+        };
+
+        let telemetry = TelemetrySystem::new().with_config(config);
+        assert_eq!(telemetry.config.service.name, "custom-service");
+        assert_eq!(telemetry.config.service.version, "2.0.0");
+        assert!(!telemetry.config.enable_logging);
+    }
+
+    #[tokio::test]
+    async fn test_add_exporter() {
+        let exporter = PrometheusExporter::new(None);
+        let telemetry = TelemetrySystem::new().add_exporter(Box::new(exporter));
+        assert_eq!(telemetry.exporters.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_get_uptime() {
+        let telemetry = TelemetrySystem::new();
+        let uptime = telemetry.get_uptime();
+        assert!(uptime < Duration::from_secs(1));
+    }
+
+    #[tokio::test]
+    async fn test_get_prometheus_exporter_returns_none() {
+        let telemetry = TelemetrySystem::new();
+        assert!(telemetry.get_prometheus_exporter().is_none());
+    }
+
+    #[tokio::test]
+    async fn test_export_all_with_exporter() {
+        let exporter = PrometheusExporter::new(None);
+        let telemetry = TelemetrySystem::new().add_exporter(Box::new(exporter));
+
+        telemetry.record_counter("requests", 5.0, vec![]);
+        telemetry.record_event("test_event", "testing", serde_json::json!({}));
+        assert_eq!(telemetry.get_buffered_metrics_count(), 1);
+
+        telemetry.export_all().await.unwrap();
+
+        assert_eq!(telemetry.get_buffered_metrics_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_export_all_no_exporter() {
+        let telemetry = TelemetrySystem::new();
+        telemetry.record_counter("requests", 1.0, vec![]);
+        telemetry.export_all().await.unwrap();
+        assert_eq!(telemetry.get_buffered_metrics_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_prometheus_exporter_clear_buffer() {
+        let exporter = PrometheusExporter::new(None);
+
+        exporter.add_metric(MetricPoint {
+            name: "test_metric".to_string(),
+            metric_type: MetricType::Gauge,
+            value: 1.0,
+            timestamp: Utc::now(),
+            labels: HashMap::new(),
+            unit: None,
+            description: None,
+        });
+
+        let output = exporter.export_prometheus().await.unwrap();
+        assert!(!output.is_empty());
+
+        exporter.clear_buffer();
+        let output_after = exporter.export_prometheus().await.unwrap();
+        assert!(output_after.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_trace_context_with_attribute() {
+        let trace = TraceContext::new("test_op")
+            .with_attribute("key1", "value1")
+            .with_attribute("key2", "value2");
+
+        assert_eq!(trace.attributes.get("key1"), Some(&"value1".to_string()));
+        assert_eq!(trace.attributes.get("key2"), Some(&"value2".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_trace_context_set_status() {
+        let mut trace = TraceContext::new("test_op");
+        assert_eq!(trace.status, SpanStatus::InProgress);
+
+        trace.set_status(SpanStatus::Timeout);
+        assert_eq!(trace.status, SpanStatus::Timeout);
+
+        trace.set_status(SpanStatus::Cancelled);
+        assert_eq!(trace.status, SpanStatus::Cancelled);
+    }
+
+    #[tokio::test]
+    async fn test_trace_guard_lifecycle() {
+        let telemetry = TelemetrySystem::new();
+        let trace = telemetry.start_trace("guard_op");
+        assert_eq!(telemetry.get_active_trace_count(), 1);
+
+        {
+            let mut guard = TraceGuard::new(&telemetry, trace);
+            assert!(guard.trace().is_some());
+            guard.record_error("test error");
+            assert_eq!(guard.trace().unwrap().status, SpanStatus::Error);
+            guard.set_status(SpanStatus::Cancelled);
+            assert_eq!(guard.trace().unwrap().status, SpanStatus::Cancelled);
+        }
+
+        assert_eq!(telemetry.get_active_trace_count(), 0);
+    }
 }


### PR DESCRIPTION
## Summary

- `telemetry.rs` had 8 tests but left 12+ public API methods untested, including `with_global_attribute`, `with_config`, `add_exporter`, `export_all`, `TraceGuard` lifecycle, and `PrometheusExporter::clear_buffer`
- `observability.rs` had 5 tests but left all builder methods (`with_service_name`, `with_alert_policy`, `with_health_thresholds`, `with_health_check_interval`), `get_uptime`, `default()`, and `stop_monitoring` untested
- Added 19 new `#[tokio::test]` functions covering these gaps

## Changes

**`harness/src/telemetry.rs`** — 12 new tests:

| Test | Covers |
|---|---|
| `test_telemetry_default` | `TelemetrySystem::default()` |
| `test_with_global_attribute` | `with_global_attribute` builder |
| `test_with_config` | `with_config` builder |
| `test_add_exporter` | `add_exporter` builder |
| `test_get_uptime` | `get_uptime` |
| `test_get_prometheus_exporter_returns_none` | `get_prometheus_exporter` |
| `test_export_all_with_exporter` | `export_all` with a configured exporter; verifies buffer drain |
| `test_export_all_no_exporter` | `export_all` with no exporters |
| `test_prometheus_exporter_clear_buffer` | `PrometheusExporter::clear_buffer` |
| `test_trace_context_with_attribute` | `TraceContext::with_attribute` |
| `test_trace_context_set_status` | `TraceContext::set_status` |
| `test_trace_guard_lifecycle` | `TraceGuard::new`, `trace()`, `record_error`, `set_status`, and `Drop` (RAII finish) |

**`harness/src/observability.rs`** — 7 new tests:

| Test | Covers |
|---|---|
| `test_observability_default` | `ObservabilitySystem::default()` |
| `test_with_service_name` | `with_service_name` builder |
| `test_with_alert_policy` | `with_alert_policy` builder |
| `test_with_health_thresholds` | `with_health_thresholds` builder |
| `test_with_health_check_interval` | `with_health_check_interval` builder |
| `test_get_uptime` | `get_uptime` |
| `test_stop_monitoring_no_task` | `stop_monitoring` when no background task is running |

All 520 library tests pass locally.

---
_Generated by [Claude Code](https://claude.ai/code/session_01X8nRJV8xnUKXQuHd4BcsoR)_