### PR TITLE
test(entities): add coverage tests for TestEntity

### DIFF
--- a/harness/tests/entity_coverage_tests.rs
+++ b/harness/tests/entity_coverage_tests.rs
@@ -1,0 +1,61 @@
+//! Tests for entity types that lack inline test modules.
+//!
+//! Coverage target: harness/src/entities/test/types.rs (TestEntity).
+
+use harness::entities::{Entity, EntityType, InMemoryEntityStore, EntityStore};
+
+#[test]
+fn test_entity_new_has_test_type() {
+    use harness::entities::test::TestEntity;
+    let entity = TestEntity::new();
+    assert_eq!(entity.entity_type(), EntityType::Test);
+}
+
+#[test]
+fn test_entity_default_has_test_type() {
+    use harness::entities::test::TestEntity;
+    let entity = TestEntity::default();
+    assert_eq!(entity.entity_type(), EntityType::Test);
+}
+
+#[test]
+fn test_entity_metadata_ref() {
+    use harness::entities::test::TestEntity;
+    let entity = TestEntity::new();
+    assert_eq!(entity.metadata().entity_type, EntityType::Test);
+}
+
+#[test]
+fn test_entity_metadata_mut() {
+    use harness::entities::test::TestEntity;
+    let mut entity = TestEntity::new();
+    entity.metadata_mut().version = 2;
+    assert_eq!(entity.metadata().version, 2);
+}
+
+#[test]
+fn test_entity_to_json_is_valid() {
+    use harness::entities::test::TestEntity;
+    let entity = TestEntity::new();
+    let json = entity.to_json().expect("TestEntity should serialize to JSON");
+    let parsed: serde_json::Value =
+        serde_json::from_str(&json).expect("JSON should parse back");
+    assert_eq!(parsed["entity_type"], "Test");
+}
+
+#[tokio::test]
+async fn test_entity_stored_and_found_by_kind() {
+    use harness::entities::test::TestEntity;
+
+    let mut store = InMemoryEntityStore::new();
+    let entity = Box::new(TestEntity::new()) as Box<dyn Entity>;
+    let id = store.store(entity).await.expect("store should succeed");
+
+    assert!(store.exists(&id).await);
+
+    let by_kind = store
+        .list_by_kind(EntityType::Test)
+        .await
+        .expect("list_by_kind should succeed");
+    assert_eq!(by_kind, vec![id]);
+}

--- a/harness/tests/entity_coverage_tests.rs
+++ b/harness/tests/entity_coverage_tests.rs
@@ -2,7 +2,7 @@
 //!
 //! Coverage target: harness/src/entities/test/types.rs (TestEntity).
 
-use harness::entities::{Entity, EntityType, InMemoryEntityStore, EntityStore};
+use harness::entities::{Entity, EntityStore, EntityType, InMemoryEntityStore};
 
 #[test]
 fn test_entity_new_has_test_type() {
@@ -37,9 +37,10 @@ fn test_entity_metadata_mut() {
 fn test_entity_to_json_is_valid() {
     use harness::entities::test::TestEntity;
     let entity = TestEntity::new();
-    let json = entity.to_json().expect("TestEntity should serialize to JSON");
-    let parsed: serde_json::Value =
-        serde_json::from_str(&json).expect("JSON should parse back");
+    let json = entity
+        .to_json()
+        .expect("TestEntity should serialize to JSON");
+    let parsed: serde_json::Value = serde_json::from_str(&json).expect("JSON should parse back");
     assert_eq!(parsed["entity_type"], "Test");
 }
 


### PR DESCRIPTION
## Summary

`harness/src/entities/test/types.rs` had no test coverage. `TestEntity` (the placeholder for issue #24 test-result entities) exposes `new()`, `Default`, and the full `Entity` trait surface, none of which were exercised by any test.

This PR adds `harness/tests/entity_coverage_tests.rs` covering:

- `TestEntity::new()` and `Default::default()` — entity type is `EntityType::Test`
- `metadata()` / `metadata_mut()` — read and mutate the entity's version field
- `to_json()` — serializes to valid JSON with `"entity_type": "Test"`
- Round-trip storage — stores a `TestEntity` in `InMemoryEntityStore` and retrieves it via `list_by_kind(EntityType::Test)`

All six tests pass locally with `cargo test --package harness --test entity_coverage_tests`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gk1ZePKnidxft8zzHyTbqy)_