### PR TITLE
test(monitoring,tools): cover record_error, model inference, alert history, and parse_github_remote

### DIFF
--- a/harness/src/monitoring.rs
+++ b/harness/src/monitoring.rs
@@ -1242,4 +1242,125 @@ mod tests {
         let csv_export = collector.export_metrics(MetricsFormat::Csv).await.unwrap();
         assert!(csv_export.contains("timestamp,metric_type,service,value"));
     }
+
+    #[tokio::test]
+    async fn test_record_error_appears_in_metrics() {
+        let mut collector = DefaultMetricsCollector::new();
+
+        let event = ErrorEvent {
+            timestamp: Utc::now(),
+            error_type: "timeout".to_string(),
+            message: "connection timed out".to_string(),
+            component: "ollama".to_string(),
+            severity: ErrorSeverity::Warning,
+        };
+        collector.record_error(event).await;
+
+        let metrics = collector.get_current_metrics().await.unwrap();
+        assert_eq!(metrics.error_metrics.total_errors, 1);
+        assert_eq!(metrics.error_metrics.recent_errors.len(), 1);
+        assert_eq!(metrics.error_metrics.recent_errors[0].error_type, "timeout");
+    }
+
+    #[tokio::test]
+    async fn test_record_model_inference_appears_in_metrics() {
+        let mut collector = DefaultMetricsCollector::new();
+
+        let model_metrics = ModelMetrics {
+            model_name: "llama3".to_string(),
+            inference_count: 42,
+            avg_inference_time_ms: 250.0,
+            tokens_per_second: 100.0,
+            success_rate: 0.99,
+            quality_scores: QualityMetrics {
+                avg_coherence: 0.9,
+                avg_relevance: 0.85,
+                consistency: 0.8,
+                accuracy_rate: 0.95,
+            },
+            resource_usage: ModelResourceUsage {
+                peak_memory_mb: 512.0,
+                avg_cpu_percent: 30.0,
+                gpu_utilization_percent: None,
+            },
+        };
+        collector
+            .record_model_inference("llama3", model_metrics)
+            .await;
+
+        let metrics = collector.get_current_metrics().await.unwrap();
+        assert!(metrics.model_metrics.contains_key("llama3"));
+        assert_eq!(metrics.model_metrics["llama3"].inference_count, 42);
+    }
+
+    #[tokio::test]
+    async fn test_export_metrics_custom_format_errors() {
+        let collector = DefaultMetricsCollector::new();
+        let result = collector
+            .export_metrics(MetricsFormat::Custom("html".to_string()))
+            .await;
+        assert!(result.is_err());
+        if let Err(MonitoringError::MetricsCollectionFailed { reason }) = result {
+            assert!(reason.contains("html"));
+        }
+    }
+
+    #[tokio::test]
+    async fn test_get_alert_history_includes_acknowledged() {
+        let manager = DefaultAlertManager::new();
+
+        let id1 = manager
+            .send_alert("Alert One", "first", AlertSeverity::Info)
+            .await
+            .unwrap();
+        let _id2 = manager
+            .send_alert("Alert Two", "second", AlertSeverity::Warning)
+            .await
+            .unwrap();
+        let _id3 = manager
+            .send_alert("Alert Three", "third", AlertSeverity::Error)
+            .await
+            .unwrap();
+
+        manager.acknowledge_alert(&id1).await.unwrap();
+
+        // get_active_alerts filters out acknowledged; get_alert_history does not
+        let active = manager.get_active_alerts().await.unwrap();
+        assert_eq!(active.len(), 2);
+
+        let history = manager.get_alert_history(10).await.unwrap();
+        assert_eq!(history.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn test_get_alert_history_respects_limit() {
+        let manager = DefaultAlertManager::new();
+
+        for i in 0..5 {
+            manager
+                .send_alert(&format!("Alert {i}"), "msg", AlertSeverity::Info)
+                .await
+                .unwrap();
+        }
+
+        let history = manager.get_alert_history(2).await.unwrap();
+        assert_eq!(history.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_configure_thresholds_updates_successfully() {
+        let mut manager = DefaultAlertManager::new();
+
+        let custom = AlertThresholds {
+            max_latency_ms: 100,
+            min_cache_hit_rate: 0.5,
+            max_error_rate: 0.1,
+            max_cpu_usage: 0.7,
+            max_memory_usage: 0.7,
+            health_check_timeout: Duration::from_secs(10),
+        };
+
+        let result = manager.configure_thresholds(custom).await;
+        assert!(result.is_ok());
+    }
 }

--- a/harness/src/tools.rs
+++ b/harness/src/tools.rs
@@ -2484,6 +2484,42 @@ mod tests {
         let registry = create_tool_registry(&cwd);
         assert!(registry.get_tool("github_pr_status").is_some());
     }
+
+    #[test]
+    fn test_parse_github_remote_ssh() {
+        let result = parse_github_remote("git@github.com:owner/repo.git");
+        assert_eq!(result, Some(("owner".to_string(), "repo".to_string())));
+    }
+
+    #[test]
+    fn test_parse_github_remote_ssh_no_git_suffix() {
+        let result = parse_github_remote("git@github.com:owner/repo");
+        assert_eq!(result, Some(("owner".to_string(), "repo".to_string())));
+    }
+
+    #[test]
+    fn test_parse_github_remote_https_with_git_suffix() {
+        let result = parse_github_remote("https://github.com/owner/repo.git");
+        assert_eq!(result, Some(("owner".to_string(), "repo".to_string())));
+    }
+
+    #[test]
+    fn test_parse_github_remote_https_without_git_suffix() {
+        let result = parse_github_remote("https://github.com/owner/repo");
+        assert_eq!(result, Some(("owner".to_string(), "repo".to_string())));
+    }
+
+    #[test]
+    fn test_parse_github_remote_non_github_url_returns_none() {
+        let result = parse_github_remote("https://gitlab.com/owner/repo.git");
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_parse_github_remote_empty_string_returns_none() {
+        let result = parse_github_remote("");
+        assert_eq!(result, None);
+    }
 }
 
 #[cfg(kani)]


### PR DESCRIPTION
## Summary

Addresses the largest actionable coverage gaps in `harness/src/monitoring.rs` and `harness/src/tools.rs` — both files have pure in-memory logic that was untested.

### `harness/src/monitoring.rs` — 6 new tests

Previously uncovered code paths:

- `record_error` — stores an `ErrorEvent`; verified via `get_current_metrics().error_metrics`
- `record_model_inference` — inserts into `model_metrics`; verified via `get_current_metrics().model_metrics`
- `get_alert_history(limit)` — returns all alerts (including acknowledged) in reverse insertion order, respecting the `limit` parameter; contrasted against `get_active_alerts` which filters acknowledged alerts
- `configure_thresholds` — updates `AlertThresholds` on `DefaultAlertManager`; verified it returns `Ok`
- `MetricsFormat::Custom("html")` error variant in `export_metrics` — verified it returns `Err` containing the format name

### `harness/src/tools.rs` — 6 new tests

`parse_github_remote` is a private function called only from the network-dependent `fetch_github_pr_data`; its pure string-parsing logic had no direct tests:

- SSH URL with `.git` suffix: `git@github.com:owner/repo.git` → `Some(("owner", "repo"))`
- SSH URL without `.git` suffix
- HTTPS URL with `.git` suffix
- HTTPS URL without `.git` suffix
- Non-GitHub URL (GitLab) → `None`
- Empty string → `None`

All 157 new lines are executed by the tests themselves. No production code was modified.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HhQezxqVCYyC6LdL919wpG)_