### PR TITLE
test(entities): add unit tests for TestEntity covering all public methods

### DIFF
--- a/harness/src/entities/test/types.rs
+++ b/harness/src/entities/test/types.rs
@@ -44,3 +44,89 @@ impl Default for TestEntity {
         Self::new()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::entities::{Entity, EntityType};
+
+    // ── Construction ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn new_produces_test_entity_type() {
+        let e = TestEntity::new();
+        assert_eq!(e.entity_type(), EntityType::Test);
+    }
+
+    #[test]
+    fn default_matches_new() {
+        let e = TestEntity::default();
+        assert_eq!(e.entity_type(), EntityType::Test);
+        // The ID is randomly generated; just confirm it is non-empty.
+        assert!(!e.id().is_empty());
+    }
+
+    // ── Entity trait methods ─────────────────────────────────────────────────
+
+    #[test]
+    fn id_is_non_empty_and_unique() {
+        let e1 = TestEntity::new();
+        let e2 = TestEntity::new();
+        assert!(!e1.id().is_empty());
+        // Two separate instances must not share the same UUID.
+        assert_ne!(e1.id(), e2.id());
+    }
+
+    #[test]
+    fn entity_type_returns_test() {
+        let e = TestEntity::new();
+        assert_eq!(e.entity_type(), EntityType::Test);
+    }
+
+    #[test]
+    fn metadata_ref_consistent_with_id() {
+        let e = TestEntity::new();
+        assert_eq!(e.metadata().id, e.id());
+    }
+
+    #[test]
+    fn metadata_mut_allows_tag_mutation() {
+        let mut e = TestEntity::new();
+        assert!(e.metadata().tags.is_empty());
+        e.metadata_mut().tags.push("ci".to_string());
+        assert_eq!(e.metadata().tags, vec!["ci"]);
+    }
+
+    // ── Serialization ────────────────────────────────────────────────────────
+
+    #[test]
+    fn to_json_succeeds_and_contains_id() {
+        let e = TestEntity::new();
+        let id = e.id().to_string();
+        let json = e.to_json().expect("to_json must succeed");
+        assert!(
+            json.contains(&id),
+            "expected JSON to contain entity id {id:?}, got: {json}"
+        );
+    }
+
+    #[test]
+    fn to_json_roundtrip_preserves_entity_type() {
+        let e = TestEntity::new();
+        let json = e.to_json().expect("serialization");
+        let restored: TestEntity =
+            serde_json::from_str(&json).expect("deserialization must succeed");
+        assert_eq!(restored.entity_type(), EntityType::Test);
+        assert_eq!(restored.id(), e.id());
+    }
+
+    // ── Clone ────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn clone_produces_equal_metadata() {
+        let e = TestEntity::new();
+        let c = e.clone();
+        assert_eq!(c.id(), e.id());
+        assert_eq!(c.entity_type(), e.entity_type());
+    }
+}


### PR DESCRIPTION
## Summary

`harness/src/entities/test/types.rs` had 0% test coverage. This PR adds a comprehensive `#[cfg(test)]` module that exercises every public method and code path in `TestEntity`.

## What changed

**`harness/src/entities/test/types.rs`** — added 9 unit tests:

### Construction
| Test | What it covers |
|------|---------------|
| `new_produces_test_entity_type` | `TestEntity::new()` produces `EntityType::Test` |
| `default_matches_new` | `Default` impl delegates correctly; id is non-empty |

### Entity trait methods
| Test | What it covers |
|------|---------------|
| `id_is_non_empty_and_unique` | `id()` is non-empty; two instances have distinct UUIDs |
| `entity_type_returns_test` | `entity_type()` always returns `EntityType::Test` |
| `metadata_ref_consistent_with_id` | `metadata().id` matches `id()` |
| `metadata_mut_allows_tag_mutation` | `metadata_mut()` allows in-place tag mutation |

### Serialization
| Test | What it covers |
|------|---------------|
| `to_json_succeeds_and_contains_id` | `to_json()` succeeds and embeds the entity id |
| `to_json_roundtrip_preserves_entity_type` | serde roundtrip preserves `entity_type` and `id` |

### Clone
| Test | What it covers |
|------|---------------|
| `clone_produces_equal_metadata` | cloned entity shares the same id and entity type |

## Coverage impact

All three `Entity` trait methods (`metadata`, `metadata_mut`, `to_json`) and both constructors (`new`, `Default`) are now exercised, bringing `types.rs` from 0% to full coverage. Only test code is added, so codecov patch coverage is 100% by definition.

---
_Generated by [Claude Code](https://claude.ai/code/session_018ZuB46zjTLQCr91JSTjuiS)_