### PR TITLE
test(monitoring): fill coverage gaps in monitoring.rs

### DIFF
--- a/harness/src/monitoring.rs
+++ b/harness/src/monitoring.rs
@@ -1374,7 +1374,7 @@ mod tests {
         assert!(ErrorSeverity::Warning < ErrorSeverity::Error);
         assert!(ErrorSeverity::Error < ErrorSeverity::Critical);
         assert!(ErrorSeverity::Info < ErrorSeverity::Critical);
-        assert!(!(ErrorSeverity::Critical < ErrorSeverity::Info));
+        assert!(ErrorSeverity::Critical >= ErrorSeverity::Info);
     }
 
     #[test]

--- a/harness/src/monitoring.rs
+++ b/harness/src/monitoring.rs
@@ -1242,4 +1242,160 @@ mod tests {
         let csv_export = collector.export_metrics(MetricsFormat::Csv).await.unwrap();
         assert!(csv_export.contains("timestamp,metric_type,service,value"));
     }
+
+    #[tokio::test]
+    async fn test_custom_format_error() {
+        let collector = DefaultMetricsCollector::new();
+        let result = collector
+            .export_metrics(MetricsFormat::Custom("myformat".to_string()))
+            .await;
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(err_msg.contains("myformat"));
+    }
+
+    #[tokio::test]
+    async fn test_record_error() {
+        let mut collector = DefaultMetricsCollector::new();
+        let error_event = ErrorEvent {
+            timestamp: Utc::now(),
+            error_type: "test_error".to_string(),
+            message: "something went wrong".to_string(),
+            component: "test_component".to_string(),
+            severity: ErrorSeverity::Error,
+        };
+        collector.record_error(error_event).await;
+
+        let metrics = collector.get_current_metrics().await.unwrap();
+        assert_eq!(metrics.error_metrics.total_errors, 1);
+        assert_eq!(
+            metrics
+                .error_metrics
+                .errors_by_type
+                .get("test_error")
+                .copied()
+                .unwrap_or(0),
+            1
+        );
+        assert_eq!(metrics.error_metrics.recent_errors.len(), 1);
+        assert_eq!(
+            metrics.error_metrics.recent_errors[0].error_type,
+            "test_error"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_record_model_inference() {
+        let mut collector = DefaultMetricsCollector::new();
+        let model_metrics = ModelMetrics {
+            model_name: "test-model".to_string(),
+            inference_count: 10,
+            avg_inference_time_ms: 50.0,
+            tokens_per_second: 100.0,
+            success_rate: 0.99,
+            quality_scores: QualityMetrics {
+                avg_coherence: 0.9,
+                avg_relevance: 0.85,
+                consistency: 0.88,
+                accuracy_rate: 0.92,
+            },
+            resource_usage: ModelResourceUsage {
+                peak_memory_mb: 512.0,
+                avg_cpu_percent: 30.0,
+                gpu_utilization_percent: None,
+            },
+        };
+        collector
+            .record_model_inference("test-model", model_metrics)
+            .await;
+
+        let metrics = collector.get_current_metrics().await.unwrap();
+        assert!(metrics.model_metrics.contains_key("test-model"));
+        assert_eq!(metrics.model_metrics["test-model"].inference_count, 10);
+        assert_eq!(
+            metrics.model_metrics["test-model"].model_name,
+            "test-model"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_reset_metrics() {
+        let mut collector = DefaultMetricsCollector::new();
+        collector
+            .record_request_latency("test-service", Duration::from_millis(100))
+            .await;
+        collector.record_cache_hit("key1").await;
+        collector.record_cache_miss("key2").await;
+
+        let before = collector.get_current_metrics().await.unwrap();
+        assert!(!before.request_latencies.is_empty());
+        assert_eq!(before.cache_metrics.hits, 1);
+        assert_eq!(before.cache_metrics.misses, 1);
+
+        collector.reset_metrics().await;
+
+        let after = collector.get_current_metrics().await.unwrap();
+        assert!(after.request_latencies.is_empty());
+        assert_eq!(after.cache_metrics.hits, 0);
+        assert_eq!(after.cache_metrics.misses, 0);
+        assert_eq!(after.error_metrics.total_errors, 0);
+    }
+
+    #[test]
+    fn test_health_status_is_healthy() {
+        assert!(HealthStatus::Healthy.is_healthy());
+        assert!(!HealthStatus::Warning.is_healthy());
+        assert!(!HealthStatus::Degraded.is_healthy());
+        assert!(!HealthStatus::Unhealthy.is_healthy());
+        assert!(!HealthStatus::Unknown.is_healthy());
+    }
+
+    #[test]
+    fn test_health_status_requires_attention() {
+        assert!(!HealthStatus::Healthy.requires_attention());
+        assert!(HealthStatus::Warning.requires_attention());
+        assert!(HealthStatus::Degraded.requires_attention());
+        assert!(HealthStatus::Unhealthy.requires_attention());
+        assert!(!HealthStatus::Unknown.requires_attention());
+    }
+
+    #[tokio::test]
+    async fn test_set_check_interval() {
+        let mut monitor = DefaultHealthMonitor::new(Duration::from_secs(30));
+        monitor.set_check_interval(Duration::from_secs(60));
+        // Interval update should not affect health check functionality
+        let health = monitor.check_system_health().await.unwrap();
+        assert_eq!(health.status, HealthStatus::Healthy);
+    }
+
+    #[test]
+    fn test_error_severity_ordering() {
+        assert!(ErrorSeverity::Info < ErrorSeverity::Warning);
+        assert!(ErrorSeverity::Warning < ErrorSeverity::Error);
+        assert!(ErrorSeverity::Error < ErrorSeverity::Critical);
+        assert!(ErrorSeverity::Info < ErrorSeverity::Critical);
+        assert!(!(ErrorSeverity::Critical < ErrorSeverity::Info));
+    }
+
+    #[test]
+    fn test_alert_thresholds_default() {
+        let thresholds = AlertThresholds::default();
+        assert_eq!(thresholds.max_latency_ms, 5000);
+        assert_eq!(thresholds.min_cache_hit_rate, 0.8);
+        assert_eq!(thresholds.max_error_rate, 0.05);
+        assert_eq!(thresholds.max_cpu_usage, 0.9);
+        assert_eq!(thresholds.max_memory_usage, 0.9);
+        assert_eq!(thresholds.health_check_timeout, Duration::from_secs(30));
+    }
+
+    #[tokio::test]
+    async fn test_start_and_stop_monitoring() {
+        let mut system = MonitoringSystem::new();
+        system.start_monitoring().await.unwrap();
+        // Allow the background task a moment to initialize
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        system.stop_monitoring().await;
+        // A second stop should be a no-op
+        system.stop_monitoring().await;
+    }
 }


### PR DESCRIPTION
## Summary

The `harness/src/monitoring.rs` module had several uncovered code paths identified via codecov. This PR adds unit tests for all missing branches.

## Coverage gaps closed

| Previously uncovered path | New test |
|---|---|
| `MetricsFormat::Custom` arm in `export_metrics` | `test_custom_format_error` |
| `record_error()` method | `test_record_error` |
| `record_model_inference()` method | `test_record_model_inference` |
| `reset_metrics()` method | `test_reset_metrics` |
| `HealthStatus::is_healthy()` – all variants | `test_health_status_is_healthy` |
| `HealthStatus::requires_attention()` – all variants | `test_health_status_requires_attention` |
| `set_check_interval()` on `DefaultHealthMonitor` | `test_set_check_interval` |
| `ErrorSeverity` `PartialOrd`/`Ord` | `test_error_severity_ordering` |
| `AlertThresholds::default()` field values | `test_alert_thresholds_default` |
| `MonitoringSystem::start_monitoring()` + `stop_monitoring()` | `test_start_and_stop_monitoring` |

## Testing strategy

All new code is `#[cfg(test)]`-gated inline unit tests added to the existing test module in `harness/src/monitoring.rs`. Because every added line is test code that executes during the test run, the patch coverage remains 100%.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DXgMdG6CB6iEa1u1szKtzd)_