### PR TITLE
test(harness): expand coverage for monitoring, telemetry, observability

### DIFF
--- a/harness/src/monitoring.rs
+++ b/harness/src/monitoring.rs
@@ -1242,4 +1242,186 @@ mod tests {
         let csv_export = collector.export_metrics(MetricsFormat::Csv).await.unwrap();
         assert!(csv_export.contains("timestamp,metric_type,service,value"));
     }
+
+    #[tokio::test]
+    async fn test_health_status_methods() {
+        assert!(HealthStatus::Healthy.is_healthy());
+        assert!(!HealthStatus::Warning.is_healthy());
+        assert!(!HealthStatus::Degraded.is_healthy());
+        assert!(!HealthStatus::Unhealthy.is_healthy());
+        assert!(!HealthStatus::Unknown.is_healthy());
+
+        assert!(!HealthStatus::Healthy.requires_attention());
+        assert!(HealthStatus::Warning.requires_attention());
+        assert!(HealthStatus::Degraded.requires_attention());
+        assert!(HealthStatus::Unhealthy.requires_attention());
+        assert!(!HealthStatus::Unknown.requires_attention());
+    }
+
+    #[tokio::test]
+    async fn test_alert_severity_ordering() {
+        assert!(AlertSeverity::Info < AlertSeverity::Warning);
+        assert!(AlertSeverity::Warning < AlertSeverity::Error);
+        assert!(AlertSeverity::Error < AlertSeverity::Critical);
+    }
+
+    #[tokio::test]
+    async fn test_record_error() {
+        let mut collector = DefaultMetricsCollector::new();
+        let event = ErrorEvent {
+            timestamp: chrono::Utc::now(),
+            error_type: "NetworkError".to_string(),
+            message: "Connection refused".to_string(),
+            component: "ollama".to_string(),
+            severity: ErrorSeverity::Error,
+        };
+        collector.record_error(event).await;
+        let metrics = collector.get_current_metrics().await.unwrap();
+        assert_eq!(metrics.error_metrics.total_errors, 1);
+        assert!(metrics
+            .error_metrics
+            .errors_by_type
+            .contains_key("NetworkError"));
+    }
+
+    #[tokio::test]
+    async fn test_record_model_inference() {
+        let mut collector = DefaultMetricsCollector::new();
+        let model_metrics = ModelMetrics {
+            model_name: "qwen3:0.6b".to_string(),
+            inference_count: 10,
+            avg_inference_time_ms: 150.0,
+            tokens_per_second: 25.0,
+            success_rate: 0.99,
+            quality_scores: QualityMetrics {
+                avg_coherence: 0.9,
+                avg_relevance: 0.85,
+                consistency: 0.88,
+                accuracy_rate: 0.92,
+            },
+            resource_usage: ModelResourceUsage {
+                peak_memory_mb: 512.0,
+                avg_cpu_percent: 30.0,
+                gpu_utilization_percent: None,
+            },
+        };
+        collector
+            .record_model_inference("qwen3:0.6b", model_metrics)
+            .await;
+        let metrics = collector.get_current_metrics().await.unwrap();
+        assert!(metrics.model_metrics.contains_key("qwen3:0.6b"));
+    }
+
+    #[tokio::test]
+    async fn test_get_alert_history() {
+        let manager = DefaultAlertManager::new();
+        manager
+            .send_alert("Alert 1", "desc1", AlertSeverity::Info)
+            .await
+            .unwrap();
+        manager
+            .send_alert("Alert 2", "desc2", AlertSeverity::Warning)
+            .await
+            .unwrap();
+        manager
+            .send_alert("Alert 3", "desc3", AlertSeverity::Critical)
+            .await
+            .unwrap();
+
+        let history = manager.get_alert_history(2).await.unwrap();
+        assert_eq!(history.len(), 2);
+        // History is reversed, so most recent first
+        assert_eq!(history[0].title, "Alert 3");
+        assert_eq!(history[1].title, "Alert 2");
+    }
+
+    #[tokio::test]
+    async fn test_configure_thresholds() {
+        let mut manager = DefaultAlertManager::new();
+        let thresholds = AlertThresholds {
+            max_latency_ms: 1000,
+            min_cache_hit_rate: 0.9,
+            max_error_rate: 0.01,
+            max_cpu_usage: 0.8,
+            max_memory_usage: 0.8,
+            health_check_timeout: Duration::from_secs(15),
+        };
+        manager.configure_thresholds(thresholds).await.unwrap();
+        // If we reach here, thresholds were configured successfully
+    }
+
+    #[tokio::test]
+    async fn test_reset_metrics() {
+        let mut collector = DefaultMetricsCollector::new();
+        collector
+            .record_request_latency("test", Duration::from_millis(100))
+            .await;
+        collector.record_cache_hit("key").await;
+
+        let metrics_before = collector.get_current_metrics().await.unwrap();
+        assert!(!metrics_before.request_latencies.is_empty());
+
+        collector.reset_metrics().await;
+
+        let metrics_after = collector.get_current_metrics().await.unwrap();
+        assert!(metrics_after.request_latencies.is_empty());
+        assert_eq!(metrics_after.cache_metrics.hits, 0);
+    }
+
+    #[tokio::test]
+    async fn test_monitoring_error_display() {
+        let err = MonitoringError::MetricsCollectionFailed {
+            reason: "test reason".to_string(),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("test reason"));
+
+        let err2 = MonitoringError::HealthCheckFailed {
+            component: "mycomp".to_string(),
+            reason: "check failed".to_string(),
+        };
+        let msg2 = err2.to_string();
+        assert!(msg2.contains("mycomp"));
+        assert!(msg2.contains("check failed"));
+
+        let err3 = MonitoringError::AlertSendFailed {
+            reason: "no channel".to_string(),
+        };
+        assert!(err3.to_string().contains("no channel"));
+
+        let err4 = MonitoringError::ContainerMonitoringFailed {
+            reason: "docker down".to_string(),
+        };
+        assert!(err4.to_string().contains("docker down"));
+
+        let err5 = MonitoringError::SystemMonitoringFailed {
+            reason: "resource unavailable".to_string(),
+        };
+        assert!(err5.to_string().contains("resource unavailable"));
+    }
+
+    #[tokio::test]
+    async fn test_alert_thresholds_default() {
+        let thresholds = AlertThresholds::default();
+        assert_eq!(thresholds.max_latency_ms, 5000);
+        assert!(thresholds.min_cache_hit_rate > 0.0);
+        assert!(thresholds.max_error_rate > 0.0);
+        assert!(thresholds.max_cpu_usage > 0.0);
+        assert!(thresholds.max_memory_usage > 0.0);
+    }
+
+    #[tokio::test]
+    async fn test_metrics_format_custom_error() {
+        let collector = DefaultMetricsCollector::new();
+        let result = collector
+            .export_metrics(MetricsFormat::Custom("my_format".to_string()))
+            .await;
+        assert!(result.is_err());
+        match result {
+            Err(MonitoringError::MetricsCollectionFailed { reason }) => {
+                assert!(reason.contains("my_format"));
+            }
+            _ => panic!("Expected MetricsCollectionFailed error"),
+        }
+    }
 }

--- a/harness/src/observability.rs
+++ b/harness/src/observability.rs
@@ -1097,4 +1097,72 @@ mod tests {
         let trends = system.analyze_current_trends(&metrics).unwrap();
         assert!(trends.performance_score >= 0.0 && trends.performance_score <= 100.0);
     }
+
+    #[tokio::test]
+    async fn test_with_alert_policy_builder() {
+        let policy = AlertPolicy::immediate_critical();
+        let expected_rules_count = policy.escalation_rules.len();
+        let system = ObservabilitySystem::new().with_alert_policy(policy);
+        assert_eq!(system.alert_policy.escalation_rules.len(), expected_rules_count);
+    }
+
+    #[tokio::test]
+    async fn test_with_health_thresholds_builder() {
+        let thresholds = HealthThreshold {
+            cpu_threshold: 95.0,
+            memory_threshold: 95.0,
+            disk_threshold: 95.0,
+            max_latency_ms: 5000,
+            min_cache_hit_rate: 0.5,
+            max_error_rate: 0.1,
+            container_timeout: Duration::from_secs(60),
+        };
+        let system = ObservabilitySystem::new().with_health_thresholds(thresholds);
+        assert_eq!(system.health_thresholds.cpu_threshold, 95.0);
+        assert_eq!(system.health_thresholds.max_latency_ms, 5000);
+        assert_eq!(system.health_thresholds.min_cache_hit_rate, 0.5);
+    }
+
+    #[tokio::test]
+    async fn test_observability_system_default() {
+        let system = ObservabilitySystem::default();
+        assert_eq!(system.service_name, "nanna-coder");
+        assert!(system.get_uptime() < Duration::from_secs(5));
+        assert!(system.monitoring_task.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_trend_direction_variants() {
+        assert_eq!(TrendDirection::Improving, TrendDirection::Improving);
+        assert_eq!(TrendDirection::Stable, TrendDirection::Stable);
+        assert_eq!(TrendDirection::Degrading, TrendDirection::Degrading);
+        assert_eq!(TrendDirection::Unknown, TrendDirection::Unknown);
+        assert_ne!(TrendDirection::Improving, TrendDirection::Degrading);
+        assert_ne!(TrendDirection::Unknown, TrendDirection::Stable);
+
+        // Verify they can appear in PerformanceTrends
+        let trends = PerformanceTrends {
+            latency_trend: TrendDirection::Improving,
+            throughput_trend: TrendDirection::Unknown,
+            error_rate_trend: TrendDirection::Stable,
+            resource_usage_trend: TrendDirection::Degrading,
+            cache_performance_trend: TrendDirection::Improving,
+            performance_score: 85.0,
+        };
+        assert_eq!(trends.latency_trend, TrendDirection::Improving);
+        assert_eq!(trends.throughput_trend, TrendDirection::Unknown);
+    }
+
+    #[tokio::test]
+    async fn test_start_stop_monitoring() {
+        let mut system = ObservabilitySystem::new()
+            // Long interval so the background task never actually fires
+            .with_health_check_interval(Duration::from_secs(3600));
+
+        system.start_monitoring().await.unwrap();
+        assert!(system.monitoring_task.is_some());
+
+        system.stop_monitoring().await;
+        assert!(system.monitoring_task.is_none());
+    }
 }

--- a/harness/src/observability.rs
+++ b/harness/src/observability.rs
@@ -1103,7 +1103,10 @@ mod tests {
         let policy = AlertPolicy::immediate_critical();
         let expected_rules_count = policy.escalation_rules.len();
         let system = ObservabilitySystem::new().with_alert_policy(policy);
-        assert_eq!(system.alert_policy.escalation_rules.len(), expected_rules_count);
+        assert_eq!(
+            system.alert_policy.escalation_rules.len(),
+            expected_rules_count
+        );
     }
 
     #[tokio::test]

--- a/harness/src/telemetry.rs
+++ b/harness/src/telemetry.rs
@@ -1044,4 +1044,143 @@ mod tests {
             Some(&"Something went wrong".to_string())
         );
     }
+
+    #[tokio::test]
+    async fn test_trace_with_attribute() {
+        let trace = TraceContext::new("test_op")
+            .with_attribute("key1", "value1")
+            .with_attribute("key2", "value2");
+        assert_eq!(trace.attributes.get("key1"), Some(&"value1".to_string()));
+        assert_eq!(trace.attributes.get("key2"), Some(&"value2".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_trace_set_status() {
+        let mut trace = TraceContext::new("test_op");
+        assert_eq!(trace.status, SpanStatus::InProgress);
+
+        trace.set_status(SpanStatus::Cancelled);
+        assert_eq!(trace.status, SpanStatus::Cancelled);
+
+        trace.set_status(SpanStatus::Timeout);
+        assert_eq!(trace.status, SpanStatus::Timeout);
+    }
+
+    #[tokio::test]
+    async fn test_prometheus_exporter_clear_buffer() {
+        let exporter = PrometheusExporter::new(None);
+        let metric = MetricPoint {
+            name: "test_metric".to_string(),
+            metric_type: MetricType::Gauge,
+            value: 10.0,
+            timestamp: Utc::now(),
+            labels: HashMap::new(),
+            unit: None,
+            description: None,
+        };
+        exporter.add_metric(metric);
+
+        let output_before = exporter.export_prometheus().await.unwrap();
+        assert!(!output_before.is_empty());
+
+        exporter.clear_buffer();
+        let output_after = exporter.export_prometheus().await.unwrap();
+        assert!(output_after.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_telemetry_system_with_global_attribute() {
+        let telemetry = TelemetrySystem::new()
+            .with_global_attribute("env", "test")
+            .with_global_attribute("region", "us-west");
+
+        let trace = telemetry.start_trace("test_op");
+        assert_eq!(trace.attributes.get("env"), Some(&"test".to_string()));
+        assert_eq!(trace.attributes.get("region"), Some(&"us-west".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_telemetry_system_with_config() {
+        let mut config = TelemetryConfig::default();
+        config.service.name = "custom-service".to_string();
+        config.log_level = "debug".to_string();
+
+        let telemetry = TelemetrySystem::new().with_config(config);
+        let trace = telemetry.start_trace("op");
+        assert_eq!(
+            trace.attributes.get("service.name"),
+            Some(&"custom-service".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn test_telemetry_system_add_exporter() {
+        let exporter = Box::new(PrometheusExporter::new(None));
+        let telemetry = TelemetrySystem::new().add_exporter(exporter);
+        assert_eq!(telemetry.exporters.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_telemetry_system_get_uptime() {
+        let telemetry = TelemetrySystem::new();
+        let uptime = telemetry.get_uptime();
+        assert!(uptime < Duration::from_secs(5));
+    }
+
+    #[tokio::test]
+    async fn test_prometheus_exporter_export_traces() {
+        let exporter = PrometheusExporter::new(None);
+
+        let mut trace = TraceContext::new("traced_op");
+        trace.finish();
+        assert!(trace.duration.is_some());
+
+        exporter.export_traces(vec![trace]).await.unwrap();
+
+        let output = exporter.export_prometheus().await.unwrap();
+        assert!(output.contains("trace_duration_seconds"));
+    }
+
+    #[tokio::test]
+    async fn test_gauge_and_summary_metric_types() {
+        let exporter = PrometheusExporter::new(None);
+
+        let gauge = MetricPoint {
+            name: "test_gauge".to_string(),
+            metric_type: MetricType::Gauge,
+            value: 42.0,
+            timestamp: Utc::now(),
+            labels: HashMap::new(),
+            unit: None,
+            description: None,
+        };
+
+        let summary = MetricPoint {
+            name: "test_summary".to_string(),
+            metric_type: MetricType::Summary,
+            value: 0.95,
+            timestamp: Utc::now(),
+            labels: HashMap::new(),
+            unit: None,
+            description: None,
+        };
+
+        exporter.add_metric(gauge);
+        exporter.add_metric(summary);
+
+        let output = exporter.export_prometheus().await.unwrap();
+        assert!(output.contains("# TYPE test_gauge gauge"));
+        assert!(output.contains("# TYPE test_summary summary"));
+    }
+
+    #[tokio::test]
+    async fn test_telemetry_config_default() {
+        let config = TelemetryConfig::default();
+        assert_eq!(config.service.name, "nanna-coder");
+        assert!(config.enable_logging);
+        assert!(config.enable_tracing);
+        assert!(config.enable_metrics);
+        assert_eq!(config.trace_sample_rate, 1.0);
+        assert!(config.global_attributes.is_empty());
+    }
 }


### PR DESCRIPTION
## Summary

Three `harness` modules had existing tests but many uncovered code paths. This PR adds 25 new `#[tokio::test]` functions across `monitoring.rs`, `telemetry.rs`, and `observability.rs` targeting previously-uncovered methods, enum variants, error paths, and builder chains.

## Changes

### `harness/src/monitoring.rs` — 10 new tests

| Test | Covers |
|------|--------|
| `test_health_status_methods` | `HealthStatus::is_healthy()` and `requires_attention()` for all 5 variants |
| `test_alert_severity_ordering` | `PartialOrd`/`Ord` derive on `AlertSeverity` |
| `test_record_error` | `record_error()`, `ErrorEvent`, error_metrics aggregation |
| `test_record_model_inference` | `record_model_inference()`, `ModelMetrics`, `QualityMetrics`, `ModelResourceUsage` |
| `test_get_alert_history` | `get_alert_history()` with a limit; verifies reverse-order |
| `test_configure_thresholds` | `AlertManager::configure_thresholds()` |
| `test_reset_metrics` | `reset_metrics()` clears latencies and cache counters |
| `test_monitoring_error_display` | `Display` impl for all 5 `MonitoringError` variants |
| `test_alert_thresholds_default` | `AlertThresholds::default()` |
| `test_metrics_format_custom_error` | `MetricsFormat::Custom` error path in `export_metrics` |

### `harness/src/telemetry.rs` — 10 new tests

| Test | Covers |
|------|--------|
| `test_trace_with_attribute` | `TraceContext::with_attribute()` builder |
| `test_trace_set_status` | `TraceContext::set_status()` for `Cancelled` and `Timeout` variants |
| `test_prometheus_exporter_clear_buffer` | `PrometheusExporter::clear_buffer()` |
| `test_telemetry_system_with_global_attribute` | `with_global_attribute()` and propagation into new traces |
| `test_telemetry_system_with_config` | `TelemetrySystem::with_config()` builder |
| `test_telemetry_system_add_exporter` | `TelemetrySystem::add_exporter()` builder |
| `test_telemetry_system_get_uptime` | `TelemetrySystem::get_uptime()` |
| `test_prometheus_exporter_export_traces` | `export_traces()` + `MetricType::Histogram` path in `export_prometheus()` |
| `test_gauge_and_summary_metric_types` | `MetricType::Gauge` and `MetricType::Summary` in `export_prometheus()` |
| `test_telemetry_config_default` | `TelemetryConfig::default()` |

### `harness/src/observability.rs` — 5 new tests

| Test | Covers |
|------|--------|
| `test_with_alert_policy_builder` | `ObservabilitySystem::with_alert_policy()` |
| `test_with_health_thresholds_builder` | `ObservabilitySystem::with_health_thresholds()` |
| `test_observability_system_default` | `ObservabilitySystem::default()` / `Default` impl |
| `test_trend_direction_variants` | `TrendDirection::Improving` and `TrendDirection::Unknown` variants; `PerformanceTrends` struct construction |
| `test_start_stop_monitoring` | `start_monitoring()` and `stop_monitoring()` lifecycle |

## Testing strategy

All tests follow the existing `#[tokio::test]` pattern used throughout the harness. The tracing subscriber double-init error (expected in parallel test runs) is already handled by existing tests; new tests avoid calling `telemetry.initialize()` where not needed. The `start_monitoring` test uses a 1-hour interval so the background task never actually fires during the test.

---
_Generated by [Claude Code](https://claude.ai/code/session_019T93vHqfbkr8WNBYvSsMth)_